### PR TITLE
[1.7.0] Fix Events system

### DIFF
--- a/src/Traits/BootstrapsTenancy.php
+++ b/src/Traits/BootstrapsTenancy.php
@@ -23,7 +23,7 @@ trait BootstrapsTenancy
     {
         array_map(function ($listener) {
             $listener($this);
-        }, $this->listeners['boostrapping']);
+        }, $this->listeners['bootstrapping']);
 
         $this->initialized = true;
 
@@ -36,7 +36,7 @@ trait BootstrapsTenancy
 
         array_map(function ($listener) {
             $listener($this);
-        }, $this->listeners['boostrapped']);
+        }, $this->listeners['bootstrapped']);
     }
 
     public function end()

--- a/src/Traits/BootstrapsTenancy.php
+++ b/src/Traits/BootstrapsTenancy.php
@@ -41,9 +41,9 @@ trait BootstrapsTenancy
 
     public function end()
     {
-        // array_map(function ($listener) {
-        //     $listener($this);
-        // }, $this->listeners['ending']);
+        array_map(function ($listener) {
+            $listener($this);
+        }, $this->listeners['ending']);
 
         $this->initialized = false;
 

--- a/src/Traits/BootstrapsTenancy.php
+++ b/src/Traits/BootstrapsTenancy.php
@@ -41,6 +41,10 @@ trait BootstrapsTenancy
 
     public function end()
     {
+        // array_map(function ($listener) {
+        //     $listener($this);
+        // }, $this->listeners['ending']);
+
         $this->initialized = false;
 
         $this->disconnectDatabase();
@@ -49,6 +53,10 @@ trait BootstrapsTenancy
         }
         $this->untagCache();
         $this->resetFileSystemRootPaths();
+
+        array_map(function ($listener) {
+            $listener($this);
+        }, $this->listeners['ended']);
     }
 
     public function switchDatabaseConnection()

--- a/src/Traits/BootstrapsTenancy.php
+++ b/src/Traits/BootstrapsTenancy.php
@@ -9,6 +9,8 @@ use Stancl\Tenancy\Exceptions\PhpRedisNotInstalledException;
 
 trait BootstrapsTenancy
 {
+    use TenantManagerEvents;
+
     public $originalSettings = [];
     /**
      * Was tenancy initialized/bootstrapped?
@@ -19,6 +21,10 @@ trait BootstrapsTenancy
 
     public function bootstrap()
     {
+        array_map(function ($listener) {
+            $listener($this);
+        }, $this->listeners['boostrapping']);
+
         $this->initialized = true;
 
         $this->switchDatabaseConnection();
@@ -27,6 +33,10 @@ trait BootstrapsTenancy
         }
         $this->tagCache();
         $this->suffixFilesystemRootPaths();
+
+        array_map(function ($listener) {
+            $listener($this);
+        }, $this->listeners['boostrapped']);
     }
 
     public function end()

--- a/src/Traits/TenantManagerEvents.php
+++ b/src/Traits/TenantManagerEvents.php
@@ -10,8 +10,8 @@ trait TenantManagerEvents
      * @var callable[][]
      */
     protected $listeners = [
-        'boostrapping' => [],
-        'boostrapped' => [],
+        'bootstrapping' => [],
+        'bootstrapped' => [],
         'ending' => [],
         'ended' => [],
     ];
@@ -35,7 +35,7 @@ trait TenantManagerEvents
      * @param callable $callback
      * @return self
      */
-    public function boostrapped(callable $callback)
+    public function bootstrapped(callable $callback)
     {
         $this->listeners['bootstrapped'][] = $callback;
 

--- a/src/Traits/TenantManagerEvents.php
+++ b/src/Traits/TenantManagerEvents.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Stancl\Tenancy\Traits;
+
+trait TenantManagerEvents
+{
+    /**
+     * Event listeners
+     *
+     * @var callable[][]
+     */
+    protected $listeners = [
+        'boostrapping' => [],
+        'boostrapped' => [],
+        'ending' => [],
+        'ended' => [],
+    ];
+
+    /**
+     * Register a listener that will be executed before tenancy is bootstrapped.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function bootstrapping(callable $callback)
+    {
+        $this->listeners['bootstrapping'][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a listener that will be executed after tenancy is bootstrapped.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function boostrapped(callable $callback)
+    {
+        $this->listeners['bootstrapped'][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a listener that will be executed before tenancy is ended.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function ending(callable $callback)
+    {
+        $this->listeners['ending'][] = $callback;
+
+        return $this;
+    }
+
+    /**
+     * Register a listener that will be executed after tenancy is ended.
+     *
+     * @param callable $callback
+     * @return self
+     */
+    public function ended(callable $callback)
+    {
+        $this->listeners['ended'][] = $callback;
+
+        return $this;
+    }
+}

--- a/src/Traits/TenantManagerEvents.php
+++ b/src/Traits/TenantManagerEvents.php
@@ -5,7 +5,7 @@ namespace Stancl\Tenancy\Traits;
 trait TenantManagerEvents
 {
     /**
-     * Event listeners
+     * Event listeners.
      *
      * @var callable[][]
      */

--- a/test
+++ b/test
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # for development
 docker-compose up -d

--- a/tests/TenantManagerTest.php
+++ b/tests/TenantManagerTest.php
@@ -254,6 +254,7 @@ class TenantManagerTest extends TestCase
             }
         });
 
+        $this->assertSame(null, config('tenancy.foo'));
         tenancy()->init('foo.localhost');
         $this->assertSame('bar', config('tenancy.foo'));
     }
@@ -269,7 +270,44 @@ class TenantManagerTest extends TestCase
             }
         });
 
+        $this->assertSame(null, config('tenancy.foo'));
         tenancy()->init('foo.localhost');
+        $this->assertSame('bar', config('tenancy.foo'));
+    }
+
+    /** @test */
+    public function ending_event_works()
+    {
+        $uuid = tenant()->create('foo.localhost')['uuid'];
+
+        Tenancy::ending(function ($tenantManager) use ($uuid) {
+            if ($tenantManager->tenant['uuid'] === $uuid) {
+                config(['tenancy.foo' => 'bar']);
+            }
+        });
+
+        $this->assertSame(null, config('tenancy.foo'));
+        tenancy()->init('foo.localhost');
+        $this->assertSame(null, config('tenancy.foo'));
+        tenancy()->end();
+        $this->assertSame('bar', config('tenancy.foo'));
+    }
+
+    /** @test */
+    public function ended_event_works()
+    {
+        $uuid = tenant()->create('foo.localhost')['uuid'];
+
+        Tenancy::ended(function ($tenantManager) use ($uuid) {
+            if ($tenantManager->tenant['uuid'] === $uuid) {
+                config(['tenancy.foo' => 'bar']);
+            }
+        });
+
+        $this->assertSame(null, config('tenancy.foo'));
+        tenancy()->init('foo.localhost');
+        $this->assertSame(null, config('tenancy.foo'));
+        tenancy()->end();
         $this->assertSame('bar', config('tenancy.foo'));
     }
 }


### PR DESCRIPTION
This makes `./test` fail on error and verifies that the tests would have failed if this had been configured correctly before.