### PR TITLE
[1.7.0] Install command

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -35,8 +35,8 @@ class Install extends Command
         $this->info('✔️  Created config/tenancy.php');
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
-            'protected $middlewarePriority = [',
-            'protected $middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class',
+            "protected \$middlewarePriority = [",
+            "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class",
             file_get_contents(app_path('Http/Kernel.php'))
         ));
         $this->info('✔️  Set middleware priority');

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -36,7 +36,7 @@ class Install extends Command
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
             "protected \$middlewarePriority = [",
-            "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class",
+            "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class,",
             file_get_contents(app_path('Http/Kernel.php'))
         ));
         $this->info('✔️  Set middleware priority');
@@ -46,25 +46,24 @@ class Install extends Command
 
 /*
 |--------------------------------------------------------------------------
-| Web Routes
+| Tenant Routes
 |--------------------------------------------------------------------------
 |
-| Here is where you can register tenat routes for your application. These
+| Here is where you can register tenant routes for your application. These
 | routes are loaded by the TenantRouteServiceProvider within a group
 | which contains the \"InitializeTenancy\" middleware. Good luck!
 |
+*/
 
 Route::get('/your/application/homepage', function () {
     return 'This is your multi-tenant application. The uuid of the current tenant is ' . tenant('uuid');
 });
-*/
 ");
         $this->info('✔️  Created routes/tenant.php');
 
         $this->line('');
-        $this->line("The package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.");
-        $migration = $this->ask('Do you want to publish the default database migration? [yes/no]', 'yes');
-        if (\strtolower($migration) === 'yes') {
+        $this->line("This package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.");
+        if ($this->confirm('Do you want to publish the default database migration?')) {
             $this->callSilent('vendor:publish', [
             '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
             '--tag' => 'migrations',

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -35,7 +35,7 @@ class Install extends Command
         $this->info('✔️  Created config/tenancy.php');
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
-            "protected \$middlewarePriority = [",
+            'protected $middlewarePriority = [',
             "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class",
             file_get_contents(app_path('Http/Kernel.php'))
         ));

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -72,6 +72,6 @@ Route::get('/your/application/homepage', function () {
         }
 
         $this->line('');
-        $this->info('✨️  stancl/tenancy installed successfully.');
+        $this->comment('✨️ stancl/tenancy installed successfully.');
     }
 }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -35,13 +35,8 @@ class Install extends Command
         $this->info('✔️  Created config/tenancy.php');
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
-<<<<<<< HEAD
             "protected \$middlewarePriority = [",
             "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class,",
-=======
-            'protected $middlewarePriority = [',
-            "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class",
->>>>>>> 01102f481e2d4ae09c812bd93493866b72b7a1b6
             file_get_contents(app_path('Http/Kernel.php'))
         ));
         $this->info('✔️  Set middleware priority');

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -63,7 +63,7 @@ Route::get('/your/application/homepage', function () {
 
         $this->line('');
         $this->line("This package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.");
-        if ($this->confirm('Do you want to publish the default database migration?')) {
+        if ($this->confirm('Do you want to publish the default database migration?', true)) {
             $this->callSilent('vendor:publish', [
             '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
             '--tag' => 'migrations',

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -27,19 +27,19 @@ class Install extends Command
      */
     public function handle()
     {
-        $this->line('Installing stancl/tenancy... ⌛');
-        $this->call('vendor:publish', [
+        $this->comment('Installing stancl/tenancy... ⌛');
+        $this->callSilent('vendor:publish', [
             '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
             '--tag' => 'config',
             ]);
-        $this->info('✔️ Created config/tenancy.php');
+        $this->info('✔️  Created config/tenancy.php');
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
             'protected $middlewarePriority = [',
             'protected $middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class',
             file_get_contents(app_path('Http/Kernel.php'))
         ));
-        $this->info('✔️ Set middleware priority');
+        $this->info('✔️  Set middleware priority');
 
         file_put_contents(base_path('routes/tenant.php'),
 "<?php
@@ -59,18 +59,20 @@ Route::get('/your/application/homepage', function () {
 });
 */
 ");
-        $this->info('✔️ Created routes/tenant.php');
+        $this->info('✔️  Created routes/tenant.php');
 
+        $this->line('');
         $this->line("The package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.");
         $migration = $this->ask('Do you want to publish the default database migration? [yes/no]', 'yes');
         if (\strtolower($migration) === 'yes') {
-            $this->call('vendor:publish', [
+            $this->callSilent('vendor:publish', [
             '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
             '--tag' => 'migrations',
             ]);
-            $this->info('✔️ Created migration.');
+            $this->info('✔️  Created migration.');
         }
 
-        $this->info('\n✔️stancl/tenancy installed successfully ✨.');
+        $this->line('');
+        $this->info('✔️  stancl/tenancy installed successfully ✨.');
     }
 }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -27,7 +27,7 @@ class Install extends Command
      */
     public function handle()
     {
-        $this->comment('Installing stancl/tenancy... ⌛');
+        $this->comment('Installing stancl/tenancy...');
         $this->callSilent('vendor:publish', [
             '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
             '--tag' => 'config',

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Console\Command;
+
+class Install extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tenancy:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Install stancl/tenancy.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->line('Installing stancl/tenancy... ⌛');
+        $this->call('vendor:publish', [
+            '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
+            '--tag' => 'config',
+            ]);
+        $this->info('✔️ Created config/tenancy.php');
+
+        file_put_contents(app_path('Http/Kernel.php'), str_replace(
+            'protected $middlewarePriority = [',
+            'protected $middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class',
+            file_get_contents(app_path('Http/Kernel.php'))
+        ));
+        $this->info('✔️ Set middleware priority');
+
+        file_put_contents(base_path('routes/tenant.php'),
+"<?php
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes
+|--------------------------------------------------------------------------
+|
+| Here is where you can register tenat routes for your application. These
+| routes are loaded by the TenantRouteServiceProvider within a group
+| which contains the \"InitializeTenancy\" middleware. Good luck!
+|
+
+Route::get('/your/application/homepage', function () {
+    return 'This is your multi-tenant application. The uuid of the current tenant is ' . tenant('uuid');
+});
+*/
+");
+        $this->info('✔️ Created routes/tenant.php');
+
+        $this->line("The package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.");
+        $migration = $this->ask('Do you want to publish the default database migration? [yes/no]', 'yes');
+        if (\strtolower($migration) === 'yes') {
+            $this->call('vendor:publish', [
+            '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
+            '--tag' => 'migrations',
+            ]);
+            $this->info('✔️ Created migration.');
+        }
+
+        $this->info('\n✔️stancl/tenancy installed successfully ✨.');
+    }
+}

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -35,7 +35,7 @@ class Install extends Command
         $this->info('✔️  Created config/tenancy.php');
 
         file_put_contents(app_path('Http/Kernel.php'), str_replace(
-            "protected \$middlewarePriority = [",
+            'protected $middlewarePriority = [',
             "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class,",
             file_get_contents(app_path('Http/Kernel.php'))
         ));

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -72,6 +72,6 @@ Route::get('/your/application/homepage', function () {
         }
 
         $this->line('');
-        $this->info('✔️  stancl/tenancy installed successfully ✨.');
+        $this->info('✨️  stancl/tenancy installed successfully.');
     }
 }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -71,7 +71,6 @@ Route::get('/your/application/homepage', function () {
             $this->info('✔️  Created migration.');
         }
 
-        $this->line('');
         $this->comment('✨️ stancl/tenancy installed successfully.');
     }
 }

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -21,16 +21,6 @@ class TenantList extends Command
     protected $description = 'List tenants.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -5,6 +5,7 @@ namespace Stancl\Tenancy;
 use Stancl\Tenancy\Commands\Run;
 use Stancl\Tenancy\Commands\Seed;
 use Illuminate\Cache\CacheManager;
+use Stancl\Tenancy\Commands\Install;
 use Stancl\Tenancy\Commands\Migrate;
 use Illuminate\Support\Facades\Route;
 use Stancl\Tenancy\Commands\Rollback;

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -25,6 +25,7 @@ class TenancyServiceProvider extends ServiceProvider
         $this->commands([
             Run::class,
             Seed::class,
+            Install::class,
             Migrate::class,
             Rollback::class,
             TenantList::class,

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -113,4 +113,184 @@ class CommandsTest extends TestCase
             ->expectsOutput('foo')
             ->expectsOutput('xyz');
     }
+
+    /** @test */
+    public function install_command_works()
+    {
+        if (! is_dir($dir = app_path('Http'))) {
+            mkdir($dir, 0777, true);
+        }
+        if (! is_dir($dir = base_path('routes'))) {
+            mkdir($dir, 0777, true);
+        }
+
+        file_put_contents(app_path('Http/Kernel.php'), "<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array
+     */
+    protected \$middleware = [
+        \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array
+     */
+    protected \$middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            'throttle:60,1',
+            'bindings',
+        ],
+    ];
+
+    /**
+     * The application's route middleware.
+     *
+     * These middleware may be assigned to groups or used individually.
+     *
+     * @var array
+     */
+    protected \$routeMiddleware = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can' => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+    ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * This forces non-global middleware to always be in the given order.
+     *
+     * @var array
+     */
+    protected \$middlewarePriority = [
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\Authenticate::class,
+        \Illuminate\Session\Middleware\AuthenticateSession::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
+}
+");
+
+        $this->artisan('tenancy:install')
+            ->expectsQuestion('Do you want to publish the default database migration?', 'yes');
+        $this->assertFileExists(base_path('routes/tenant.php'));
+        $this->assertFileExists(base_path('config/tenancy.php'));
+        $this->assertSame("<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's global HTTP middleware stack.
+     *
+     * These middleware are run during every request to your application.
+     *
+     * @var array
+     */
+    protected \$middleware = [
+        \App\Http\Middleware\TrustProxies::class,
+        \App\Http\Middleware\CheckForMaintenanceMode::class,
+        \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
+        \App\Http\Middleware\TrimStrings::class,
+        \Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull::class,
+    ];
+
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array
+     */
+    protected \$middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            // \Illuminate\Session\Middleware\AuthenticateSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            'throttle:60,1',
+            'bindings',
+        ],
+    ];
+
+    /**
+     * The application's route middleware.
+     *
+     * These middleware may be assigned to groups or used individually.
+     *
+     * @var array
+     */
+    protected \$routeMiddleware = [
+        'auth' => \App\Http\Middleware\Authenticate::class,
+        'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
+        'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        'cache.headers' => \Illuminate\Http\Middleware\SetCacheHeaders::class,
+        'can' => \Illuminate\Auth\Middleware\Authorize::class,
+        'guest' => \App\Http\Middleware\RedirectIfAuthenticated::class,
+        'signed' => \Illuminate\Routing\Middleware\ValidateSignature::class,
+        'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'verified' => \Illuminate\Auth\Middleware\EnsureEmailIsVerified::class,
+    ];
+
+    /**
+     * The priority-sorted list of middleware.
+     *
+     * This forces non-global middleware to always be in the given order.
+     *
+     * @var array
+     */
+    protected \$middlewarePriority = [
+        \Stancl\Tenancy\Middleware\InitializeTenancy::class,
+        \Illuminate\Session\Middleware\StartSession::class,
+        \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+        \App\Http\Middleware\Authenticate::class,
+        \Illuminate\Session\Middleware\AuthenticateSession::class,
+        \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        \Illuminate\Auth\Middleware\Authorize::class,
+    ];
+}
+", \file_get_contents(app_path('Http/Kernel.php')));
+    }
 }


### PR DESCRIPTION
```
➜ php artisan tenancy:install
Installing stancl/tenancy...
✔️  Created config/tenancy.php
✔️  Set middleware priority
✔️  Created routes/tenant.php

This package lets you store data about tenants either in Redis or in a relational database like MySQL. If you're going to use the database storage, you need to create a tenants table.

 Do you want to publish the default database migration? (yes/no) [yes]:
 > 

✔️  Created migration.
✨️ stancl/tenancy installed successfully.
```