### PR TITLE
[1.8.0] Add Queue support

### DIFF
--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -73,7 +73,7 @@ class TenancyServiceProvider extends ServiceProvider
         });
 
         $this->app['events']->listen(\Illuminate\Queue\Events\JobProcessing::class, function ($event) {
-            if (array_key_exists('tenant_uuid', $event->job->payload())) {
+            if (\array_key_exists('tenant_uuid', $event->job->payload())) {
                 tenancy()->initById($event->job->payload()['tenant_uuid']);
             }
         });

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -70,7 +70,7 @@ class TenancyServiceProvider extends ServiceProvider
     {
         $this->app['queue']->createPayloadUsing(function () {
             if (tenancy()->initialized) {
-                [$uuid, $domain] = tenant()->get('uuid', 'domain');
+                [$uuid, $domain] = tenant()->get(['uuid', 'domain']);
 
                 return [
                     'tenant_uuid' => $uuid,

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -70,10 +70,13 @@ class TenancyServiceProvider extends ServiceProvider
     {
         $this->app['queue']->createPayloadUsing(function () {
             if (tenancy()->initialized) {
-                $uuid = tenant('uuid');
+                [$uuid, $domain] = tenant()->get('uuid', 'domain');
                 return [
                     'tenant_uuid' => $uuid,
-                    'tags' => ["tenant:$uuid"],
+                    'tags' => [
+                        "tenant:$uuid",
+                        "domain:$domain"
+                    ],
                 ];
             }
 

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -69,7 +69,15 @@ class TenancyServiceProvider extends ServiceProvider
     public function makeQueuesTenantAware()
     {
         $this->app['queue']->createPayloadUsing(function () {
-            return tenancy()->initialized ? ['tenant_uuid' => tenant('uuid')] : [];
+            if (tenancy()->initialized) {
+                $uuid = tenant('uuid');
+                return [
+                    'tenant_uuid' => $uuid,
+                    'tags' => ["tenant:$uuid"],
+                ];
+            }
+
+            return [];
         });
 
         $this->app['events']->listen(\Illuminate\Queue\Events\JobProcessing::class, function ($event) {

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -50,6 +50,7 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->register(TenantRouteServiceProvider::class);
 
         $this->registerTenantRedirectMacro();
+        $this->makeQueuesTenantAware();
     }
 
     public function registerTenantRedirectMacro()
@@ -62,6 +63,19 @@ class TenancyServiceProvider extends ServiceProvider
             $this->setTargetUrl(\substr_replace($url, $domain, $position, \strlen($hostname)));
 
             return $this;
+        });
+    }
+
+    public function makeQueuesTenantAware()
+    {
+        $this->app['queue']->createPayloadUsing(function () {
+            return tenancy()->initialized ? ['tenant_uuid' => tenant('uuid')] : [];
+        });
+
+        $this->app['events']->listen(\Illuminate\Queue\Events\JobProcessing::class, function ($event) {
+            if (array_key_exists('tenant_uuid', $event->job->payload())) {
+                tenancy()->initById($event->job->payload()['tenant_uuid']);
+            }
         });
     }
 

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -71,11 +71,12 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app['queue']->createPayloadUsing(function () {
             if (tenancy()->initialized) {
                 [$uuid, $domain] = tenant()->get('uuid', 'domain');
+
                 return [
                     'tenant_uuid' => $uuid,
                     'tags' => [
                         "tenant:$uuid",
-                        "domain:$domain"
+                        "domain:$domain",
                     ],
                 ];
             }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -3,14 +3,13 @@
 namespace Stancl\Tenancy\Tests;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
-use Illuminate\Queue\Events\JobProcessed;
-use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Support\Facades\Event;
 
 class QueueTest extends TestCase
 {
@@ -56,6 +55,6 @@ class TestJob implements ShouldQueue
      */
     public function handle()
     {
-        logger(json_encode(\DB::table('users')->get()));
+        logger(\json_encode(\DB::table('users')->get()));
     }
 }

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -4,7 +4,6 @@ namespace Stancl\Tenancy\Tests;
 
 use Illuminate\Bus\Queueable;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Queue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\Events\JobProcessing;

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Stancl\Tenancy\Tests;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Events\JobProcessed;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Support\Facades\Event;
+
+class QueueTest extends TestCase
+{
+    /** @test */
+    public function queues_use_non_tenant_db_connection()
+    {
+        $this->markTestIncomplete();
+    }
+
+    /** @test */
+    public function tenancy_is_initialized_inside_queues()
+    {
+        // Queue::fake();
+        $this->loadLaravelMigrations(['--database' => 'tenant']);
+        Event::fake();
+
+        dispatch(new TestJob());
+        // Queue::assertPushed(TestJob::class);
+        Event::assertDispatched(JobProcessing::class, function ($event) {
+            return $event->job->payload()['tenant_uuid'] === tenant('uuid');
+        });
+    }
+}
+
+class TestJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        logger(json_encode(\DB::table('users')->get()));
+    }
+}

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -17,18 +17,18 @@ class QueueTest extends TestCase
     /** @test */
     public function queues_use_non_tenant_db_connection()
     {
+        // todo finish this test. requires using the db driver
         $this->markTestIncomplete();
     }
 
     /** @test */
     public function tenancy_is_initialized_inside_queues()
     {
-        // Queue::fake();
         $this->loadLaravelMigrations(['--database' => 'tenant']);
         Event::fake();
 
         dispatch(new TestJob());
-        // Queue::assertPushed(TestJob::class);
+
         Event::assertDispatched(JobProcessing::class, function ($event) {
             return $event->job->payload()['tenant_uuid'] === tenant('uuid');
         });


### PR DESCRIPTION
- If using DB driver, `connection` has to be specified in the queue connection. A non-tenant DB connection must be used.
- Same with Redis, presumably. A non-prefixed connection must be used.

**TODO:** Write tests, ~test sync driver.~

Images: https://imgur.com/a/hAWQud5