### PR TITLE
[1.8.0] Allow conflicting routes

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -34,11 +34,18 @@ class Install extends Command
             ]);
         $this->info('✔️  Created config/tenancy.php');
 
-        \file_put_contents(app_path('Http/Kernel.php'), \str_replace(
+        $newKernel = \str_replace(
             'protected $middlewarePriority = [',
-            "protected \$middlewarePriority = [\n        \Stancl\Tenancy\Middleware\InitializeTenancy::class,",
+            "protected \$middlewarePriority = [
+        \Stancl\Tenancy\Middleware\InitializeTenancy::class,
+        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class",
             \file_get_contents(app_path('Http/Kernel.php'))
-        ));
+        );
+
+        $newKernel = \str_replace("'web' => [", "'web' => [
+            \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
+
+        \file_put_contents(app_path('Http/Kernel.php'), $newKernel);
         $this->info('✔️  Set middleware priority');
 
         \file_put_contents(

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -37,8 +37,8 @@ class Install extends Command
         $newKernel = \str_replace(
             'protected $middlewarePriority = [',
             "protected \$middlewarePriority = [
-        \Stancl\Tenancy\Middleware\InitializeTenancy::class,
-        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class",
+        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,
+        \Stancl\Tenancy\Middleware\InitializeTenancy::class,",
             \file_get_contents(app_path('Http/Kernel.php'))
         );
 

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -42,7 +42,7 @@ class Install extends Command
             \file_get_contents(app_path('Http/Kernel.php'))
         );
 
-        $newKernel = \str_replace("'web' => [", "'web' => [
+        $newKernel = \str_replace("protected \$middleware = [", "protected \$middleware = [
             \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
 
         \file_put_contents(app_path('Http/Kernel.php'), $newKernel);

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -43,7 +43,7 @@ class Install extends Command
         );
 
         $newKernel = \str_replace("protected \$middleware = [", "protected \$middleware = [
-            \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
+        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
 
         \file_put_contents(app_path('Http/Kernel.php'), $newKernel);
         $this->info('✔️  Set middleware priority');

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -42,7 +42,7 @@ class Install extends Command
             \file_get_contents(app_path('Http/Kernel.php'))
         );
 
-        $newKernel = \str_replace("protected \$middleware = [", "protected \$middleware = [
+        $newKernel = \str_replace('protected $middleware = [', "protected \$middleware = [
             \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
 
         \file_put_contents(app_path('Http/Kernel.php'), $newKernel);

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -42,8 +42,8 @@ class Install extends Command
             \file_get_contents(app_path('Http/Kernel.php'))
         );
 
-        $newKernel = \str_replace('protected $middleware = [', "protected \$middleware = [
-        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
+        $newKernel = \str_replace("'web' => [", "'web' => [
+            \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,", $newKernel);
 
         \file_put_contents(app_path('Http/Kernel.php'), $newKernel);
         $this->info('✔️  Set middleware priority');
@@ -63,7 +63,7 @@ class Install extends Command
 |
 */
 
-Route::get('/your/application/homepage', function () {
+Route::get('/', function () {
     return 'This is your multi-tenant application. The uuid of the current tenant is ' . tenant('uuid');
 });
 "

--- a/src/Middleware/PreventAccessFromTenantDomains.php
+++ b/src/Middleware/PreventAccessFromTenantDomains.php
@@ -17,9 +17,9 @@ class PreventAccessFromTenantDomains
     {
         // If the domain is not in exempt domains, it's a tenant domain.
         // Tenant domains can't have routes without tenancy middleware.
-        if (! in_array(request()->getHost(), config('tenancy.exempt_domains')) &&
-            ! in_array('tenancy', request()->route()->middleware())) {
-                abort(404);
+        if (! \in_array(request()->getHost(), config('tenancy.exempt_domains')) &&
+            ! \in_array('tenancy', request()->route()->middleware())) {
+            abort(404);
         }
 
         return $next($request);

--- a/src/Middleware/PreventAccessFromTenantDomains.php
+++ b/src/Middleware/PreventAccessFromTenantDomains.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Stancl\Tenancy\Middleware;
+
+use Closure;
+
+class PreventAccessFromTenantDomains
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+        // If the domain is not in exempt domains, it's a tenant domain.
+        // Tenant domains can't have routes without tenancy middleware.
+        if (! in_array(request()->getHost(), config('tenancy.exempt_domains')) &&
+            ! in_array('tenancy', request()->route()->middleware())) {
+                abort(404);
+        }
+
+        return $next($request);
+    }
+}

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -286,6 +286,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected \$middlewarePriority = [
+        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,
         \Stancl\Tenancy\Middleware\InitializeTenancy::class,
         \Illuminate\Session\Middleware\StartSession::class,
         \Illuminate\View\Middleware\ShareErrorsFromSession::class,

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -230,6 +230,7 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected \$middleware = [
+        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -230,7 +230,6 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected \$middleware = [
-        \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,
         \App\Http\Middleware\TrustProxies::class,
         \App\Http\Middleware\CheckForMaintenanceMode::class,
         \Illuminate\Foundation\Http\Middleware\ValidatePostSize::class,
@@ -245,6 +244,7 @@ class Kernel extends HttpKernel
      */
     protected \$middlewareGroups = [
         'web' => [
+            \Stancl\Tenancy\Middleware\PreventAccessFromTenantDomains::class,
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,


### PR DESCRIPTION
Resolves #102 

This adds a global middleware preventing non-tenant routes from being accessible on tenant domains. This also lets you have conflicting routes (e.g. `/`) for the tenant and the non-tenant part of the application.

This middleware is high-priority to avoid other middleware being executed and the request getting discarded anyway.

**TODO:**

- [x] What about API routes?  ~https://github.com/stancl/tenancy/pull/114/commits/965f67c747d907fa449180df06748a51444d5d19~ addressed in docs
- [ ] Write tests
- [x] Test branch, including `tenancy:install` and conflicting routes on a fresh install
- [x] Update default tenant.php routes file