### PR TITLE
[2.x] Fix default tenant route

### DIFF
--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -65,7 +65,7 @@ class Install extends Command
 |
 */
 
-Route::get('/', function () {
+Route::get('/app', function () {
     return 'This is your multi-tenant application. The id of the current tenant is ' . tenant('id');
 });
 "


### PR DESCRIPTION
In config file route defined as `/app`:

https://github.com/stancl/tenancy/blob/a166de2ef63de0a56b42a14cf33bce717bb659ec/assets/config.php#L85

But `tenancy:install` commands creates `/` route only. So it's not working out of the box.