### PR TITLE
[2.x] Add missing field in InitializeTenancy middleware

### DIFF
--- a/src/Middleware/InitializeTenancy.php
+++ b/src/Middleware/InitializeTenancy.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Middleware;
 
 use Closure;
+use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedException;
 
 class InitializeTenancy
 {
@@ -31,7 +32,7 @@ class InitializeTenancy
     {
         try {
             tenancy()->init();
-        } catch (\Exception $e) {
+        } catch (TenantCouldNotBeIdentifiedException $e) {
             ($this->onFail)($e);
         }
 

--- a/src/Middleware/InitializeTenancy.php
+++ b/src/Middleware/InitializeTenancy.php
@@ -11,7 +11,7 @@ class InitializeTenancy
     /**
      * @var \Closure
      */
-    private $onFail;
+    protected $onFail;
 
     public function __construct(Closure $onFail = null)
     {

--- a/src/Middleware/InitializeTenancy.php
+++ b/src/Middleware/InitializeTenancy.php
@@ -9,12 +9,10 @@ use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedException;
 
 class InitializeTenancy
 {
-    /**
-     * @var \Closure
-     */
+    /** @var callable */
     protected $onFail;
 
-    public function __construct(Closure $onFail = null)
+    public function __construct(callable $onFail = null)
     {
         $this->onFail = $onFail ?? function ($e) {
             throw $e;

--- a/src/Middleware/InitializeTenancy.php
+++ b/src/Middleware/InitializeTenancy.php
@@ -8,6 +8,11 @@ use Closure;
 
 class InitializeTenancy
 {
+    /**
+     * @var \Closure
+     */
+    private $onFail;
+
     public function __construct(Closure $onFail = null)
     {
         $this->onFail = $onFail ?? function ($e) {


### PR DESCRIPTION
`onFail` field was declared dynamically.

And one more question accordingly this middleware: if `$onFail` is null - from where `$e` will be taken for the fallback closure?