### PR TITLE
[2.x] Add missing parent::__construct call in exceptions

### DIFF
--- a/src/Exceptions/DatabaseManagerNotRegisteredException.php
+++ b/src/Exceptions/DatabaseManagerNotRegisteredException.php
@@ -8,6 +8,6 @@ class DatabaseManagerNotRegisteredException extends \Exception
 {
     public function __construct($driver)
     {
-        $this->message = "Database manager for driver $driver is not registered.";
+        parent::__construct("Database manager for driver $driver is not registered.");
     }
 }

--- a/src/Exceptions/TenantCouldNotBeIdentifiedException.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedException.php
@@ -12,7 +12,7 @@ class TenantCouldNotBeIdentifiedException extends \Exception implements Provides
 {
     public function __construct($domain)
     {
-        $this->message = "Tenant could not be identified on domain $domain";
+        parent::__construct("Tenant could not be identified on domain $domain");
     }
 
     public function getSolution(): Solution


### PR DESCRIPTION
Some of the exceptions missing `parent::__construct()` call.