### PR TITLE
[2.x] Reorder Service Provider methods in execution sequence

### DIFF
--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -12,11 +12,51 @@ use Stancl\Tenancy\TenancyBootstrappers\FilesystemTenancyBootstrapper;
 class TenancyServiceProvider extends ServiceProvider
 {
     /**
+     * Register services.
+     *
+     * @return void
+     */
+    public function register(): void
+    {
+        $this->mergeConfigFrom(__DIR__ . '/../assets/config.php', 'tenancy');
+
+        $this->app->bind(Contracts\StorageDriver::class, function ($app) {
+            return $app->make($app['config']['tenancy.storage_driver']);
+        });
+        $this->app->bind(Contracts\UniqueIdentifierGenerator::class, $this->app['config']['tenancy.unique_id_generator']);
+        $this->app->singleton(DatabaseManager::class);
+        $this->app->singleton(TenantManager::class);
+        $this->app->bind(Tenant::class, function ($app) {
+            return $app[TenantManager::class]->getTenant();
+        });
+
+        foreach ($this->app['config']['tenancy.bootstrappers'] as $bootstrapper) {
+            $this->app->singleton($bootstrapper);
+        }
+
+        $this->app->singleton(Commands\Migrate::class, function ($app) {
+            return new Commands\Migrate($app['migrator'], $app[DatabaseManager::class]);
+        });
+        $this->app->singleton(Commands\Rollback::class, function ($app) {
+            return new Commands\Rollback($app['migrator'], $app[DatabaseManager::class]);
+        });
+        $this->app->singleton(Commands\Seed::class, function ($app) {
+            return new Commands\Seed($app['db'], $app[DatabaseManager::class]);
+        });
+
+        $this->app->bind('globalCache', function ($app) {
+            return new CacheManager($app);
+        });
+
+        $this->app->register(TenantRouteServiceProvider::class);
+    }
+
+    /**
      * Bootstrap services.
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
         $this->commands([
             Commands\Run::class,
@@ -54,45 +94,5 @@ class TenancyServiceProvider extends ServiceProvider
                 tenancy()->initialize(tenancy()->find($event->job->payload()['tenant_id']));
             }
         });
-    }
-
-    /**
-     * Register services.
-     *
-     * @return void
-     */
-    public function register()
-    {
-        $this->mergeConfigFrom(__DIR__ . '/../assets/config.php', 'tenancy');
-
-        $this->app->bind(Contracts\StorageDriver::class, function ($app) {
-            return $app->make($app['config']['tenancy.storage_driver']);
-        });
-        $this->app->bind(Contracts\UniqueIdentifierGenerator::class, $this->app['config']['tenancy.unique_id_generator']);
-        $this->app->singleton(DatabaseManager::class);
-        $this->app->singleton(TenantManager::class);
-        $this->app->bind(Tenant::class, function ($app) {
-            return $app[TenantManager::class]->getTenant();
-        });
-
-        foreach ($this->app['config']['tenancy.bootstrappers'] as $bootstrapper) {
-            $this->app->singleton($bootstrapper);
-        }
-
-        $this->app->singleton(Commands\Migrate::class, function ($app) {
-            return new Commands\Migrate($app['migrator'], $app[DatabaseManager::class]);
-        });
-        $this->app->singleton(Commands\Rollback::class, function ($app) {
-            return new Commands\Rollback($app['migrator'], $app[DatabaseManager::class]);
-        });
-        $this->app->singleton(Commands\Seed::class, function ($app) {
-            return new Commands\Seed($app['db'], $app[DatabaseManager::class]);
-        });
-
-        $this->app->bind('globalCache', function ($app) {
-            return new CacheManager($app);
-        });
-
-        $this->app->register(TenantRouteServiceProvider::class);
     }
 }


### PR DESCRIPTION
Not so far Laravel reordered methods in the same way. Initially they were ordered alphabetically (`boot`, `register`), and now they are ordered in execution sequence (`register > boot`).