### PR TITLE
[2.x] Change Tenant id string column type to UUID

### DIFF
--- a/assets/migrations/2019_09_15_000010_create_tenants_table.php
+++ b/assets/migrations/2019_09_15_000010_create_tenants_table.php
@@ -13,10 +13,10 @@ class CreateTenantsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('tenants', function (Blueprint $table) {
-            $table->string('id', 36)->primary(); // 36 characters is the default uuid length
+            $table->uuid('id')->primary();
             // (optional) your custom, indexed columns can go here
 
             $table->json('data');
@@ -28,8 +28,8 @@ class CreateTenantsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
-        Schema::drop('tenants');
+        Schema::dropIfExists('tenants');
     }
 }

--- a/assets/migrations/2019_09_15_000020_create_domains_table.php
+++ b/assets/migrations/2019_09_15_000020_create_domains_table.php
@@ -13,11 +13,11 @@ class CreateDomainsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('domains', function (Blueprint $table) {
             $table->string('domain', 255)->primary();
-            $table->string('tenant_id', 36);
+            $table->uuid('tenant_id');
 
             $table->foreign('tenant_id')->references('id')->on('tenants')->onUpdate('cascade')->onDelete('cascade');
         });
@@ -28,8 +28,8 @@ class CreateDomainsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
-        Schema::drop('domains');
+        Schema::dropIfExists('domains');
     }
 }


### PR DESCRIPTION
Laravel has special `uuid` type in migrations which stores IDs in `UUID` if available in driver, otherwise fallback to `CHAR` or `VARCHAR`.

Additionally added `void` return type to follow same code style and replaced strict `drop` method to `dropIfExists` for cases with corrupted databases.