### PR TITLE
[2.x] Replace drop with dropIfExists in migrations

### DIFF
--- a/assets/migrations/2019_09_15_000010_create_tenants_table.php
+++ b/assets/migrations/2019_09_15_000010_create_tenants_table.php
@@ -13,7 +13,7 @@ class CreateTenantsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('tenants', function (Blueprint $table) {
             $table->string('id', 36)->primary(); // 36 characters is the default uuid length
@@ -28,8 +28,8 @@ class CreateTenantsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
-        Schema::drop('tenants');
+        Schema::dropIfExists('tenants');
     }
 }

--- a/assets/migrations/2019_09_15_000020_create_domains_table.php
+++ b/assets/migrations/2019_09_15_000020_create_domains_table.php
@@ -13,7 +13,7 @@ class CreateDomainsTable extends Migration
      *
      * @return void
      */
-    public function up()
+    public function up(): void
     {
         Schema::create('domains', function (Blueprint $table) {
             $table->string('domain', 255)->primary();
@@ -28,8 +28,8 @@ class CreateDomainsTable extends Migration
      *
      * @return void
      */
-    public function down()
+    public function down(): void
     {
-        Schema::drop('domains');
+        Schema::dropIfExists('domains');
     }
 }


### PR DESCRIPTION
Followup #142 

Replaced strict drop method to dropIfExists for cases with corrupted databases.

Additionally added void return type to follow same code style.