### PR TITLE
[2.x] Remove request helper from TenantManager

### DIFF
--- a/src/Middleware/InitializeTenancy.php
+++ b/src/Middleware/InitializeTenancy.php
@@ -29,7 +29,7 @@ class InitializeTenancy
     public function handle($request, Closure $next)
     {
         try {
-            tenancy()->init();
+            tenancy()->init($request->getHost());
         } catch (TenantCouldNotBeIdentifiedException $e) {
             ($this->onFail)($e);
         }

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -133,9 +133,8 @@ class TenantManager
      * @param string $domain
      * @return self
      */
-    public function init(string $domain = null): self
+    public function init(string $domain): self
     {
-        $domain = $domain ?? request()->getHost();
         $this->initializeTenancy($this->findByDomain($domain));
 
         return $this;

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -130,11 +130,12 @@ class TenantManager
     /**
      * Find tenant by domain & initialize tenancy.
      *
-     * @param string $domain
+     * @param string|null $domain
      * @return self
      */
-    public function init(string $domain): self
+    public function init(string $domain = null): self
     {
+        $domain = $domain ?? request()->getHost();
         $this->initializeTenancy($this->findByDomain($domain));
 
         return $this;


### PR DESCRIPTION
I've removed `request()` helper from TenantManager's `init` method because it's called only from single place (from middleware) and there we have $request already.