### PR TITLE
[2.x] Migrate fresh

### DIFF
--- a/src/Commands/Migrate.php
+++ b/src/Commands/Migrate.php
@@ -53,8 +53,6 @@ class Migrate extends MigrateCommand
         tenancy()->all($this->option('tenants'))->each(function ($tenant) {
             $this->line("Tenant: {$tenant['id']}");
 
-            // See Illuminate\Database\Migrations\DatabaseMigrationRepository::getConnection.
-            // Database connections are cached by Illuminate\Database\ConnectionResolver.
             $this->input->setOption('database', 'tenant');
             tenancy()->initialize($tenant);
 

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Console\Command;
+use Stancl\Tenancy\Traits\DealsWithMigrations;
+use Stancl\Tenancy\Traits\HasATenantsOption;
+
+class MigrateFresh extends Command
+{
+    use HasATenantsOption, DealsWithMigrations;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'tenants:migrate-fresh';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Drop all tables and re-run all migrations for tenant(s)';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $originalTenant = tenancy()->getTenant();
+        $this->info('Dropping tables.');
+
+        tenancy()->all($this->option('tenants'))->each(function ($tenant) {
+            $this->line("Tenant: {$tenant->id}");
+
+            tenancy()->initialize($tenant);
+
+            $this->call('db:wipe', [
+                '--database' => $tenant->getDatabaseName(),
+                '--force' => true,
+            ]);
+
+            $this->call('tenants:migrate', [
+                '--tenants' => [$tenant->id],
+            ]);
+
+            tenancy()->end();
+        });
+
+        $this->info('Done.');
+
+        if ($originalTenant) {
+            tenancy()->initialize($originalTenant);
+        }
+    }
+}

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 use Stancl\Tenancy\Traits\DealsWithMigrations;
 use Stancl\Tenancy\Traits\HasATenantsOption;
 
-class MigrateFresh extends Command
+final class MigrateFresh extends Command
 {
     use HasATenantsOption, DealsWithMigrations;
 

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -42,7 +42,7 @@ final class MigrateFresh extends Command
             tenancy()->initialize($tenant);
 
             $this->call('db:wipe', [
-                '--database' => $tenant->getDatabaseName(),
+                '--database' => $tenant->getDatabaseConnection(),
                 '--force' => true,
             ]);
 

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -13,18 +13,18 @@ final class MigrateFresh extends Command
     use HasATenantsOption, DealsWithMigrations;
 
     /**
-     * The name and signature of the console command.
-     *
-     * @var string
-     */
-    protected $signature = 'tenants:migrate-fresh';
-
-    /**
      * The console command description.
      *
      * @var string
      */
     protected $description = 'Drop all tables and re-run all migrations for tenant(s)';
+
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setName('tenants:migrate-fresh');
+    }
 
     /**
      * Execute the console command.
@@ -42,7 +42,7 @@ final class MigrateFresh extends Command
             tenancy()->initialize($tenant);
 
             $this->call('db:wipe', [
-                '--database' => $tenant->getDatabaseConnection(),
+                '--database' => $tenant->getConnectionName(),
                 '--force' => true,
             ]);
 

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -41,10 +41,10 @@ final class MigrateFresh extends Command
 
             tenancy()->initialize($tenant);
 
-            $this->call('db:wipe', [
+            $this->call('db:wipe', array_filter([
                 '--database' => $tenant->getDatabaseConnection(),
                 '--force' => true,
-            ]);
+            ]));
 
             $this->call('tenants:migrate', [
                 '--tenants' => [$tenant->id],

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -65,6 +65,7 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Migrate::class,
             Commands\Rollback::class,
             Commands\TenantList::class,
+            Commands\MigrateFresh::class,
         ]);
 
         $this->publishes([

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -138,4 +138,22 @@ class CommandsTest extends TestCase
         $this->assertDirectoryExists(database_path('migrations/tenant'));
         $this->assertSame(file_get_contents(__DIR__ . '/Etc/modifiedHttpKernel.stub'), file_get_contents(app_path('Http/Kernel.php')));
     }
+
+    /** @test */
+    public function migrate_fresh_command_works()
+    {
+        $this->assertFalse(Schema::hasTable('users'));
+        Artisan::call('tenants:migrate-fresh');
+        $this->assertFalse(Schema::hasTable('users'));
+        tenancy()->init('test.localhost');
+        $this->assertTrue(Schema::hasTable('users'));
+
+        $this->assertFalse(DB::table('users')->exists());
+        DB::table('users')->insert(['name' => 'xxx', 'password' => bcrypt('password'), 'email' => 'foo@bar.xxx']);
+        $this->assertTrue(DB::table('users')->exists());
+       
+        // test that db is wiped
+        Artisan::call('tenants:migrate-fresh');
+        $this->assertFalse(DB::table('users')->exists());
+    }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -151,7 +151,7 @@ class CommandsTest extends TestCase
         $this->assertFalse(DB::table('users')->exists());
         DB::table('users')->insert(['name' => 'xxx', 'password' => bcrypt('password'), 'email' => 'foo@bar.xxx']);
         $this->assertTrue(DB::table('users')->exists());
-       
+
         // test that db is wiped
         Artisan::call('tenants:migrate-fresh');
         $this->assertFalse(DB::table('users')->exists());


### PR DESCRIPTION
Alternative implementation of #128

I think delegating the migration logic to `tenants:migrate` is better than extending the MigrateCommand, when it's not really a migrate command. Kind of a composition over inheritance thing. Also this means that we don't have to register the command in the service provider, as it does not depend on `Migrator`.

Also used `$tenant->getDatabaseConnection()` instead of hard-coded `'tenant'`, since tenants can use a different DB connection. And used the `tenants` namespace instead of `tenancy`.

ping @drbyte

TODO:
- [x] Tests
- [x] Documentation https://github.com/stancl/tenancy/pull/148