### PR TITLE
[2.x] Allow automatic seeding after automatic migrations

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -92,7 +92,9 @@ return [
     'queue_database_creation' => false,
     'migrate_after_creation' => false, // run migrations after creating a tenant
     'seed_after_migration' => false, // should the seeder run after automatic migration
-    'seeder_class' => 'DatabaseSeeder', // root seeder class to run after automatic migrations, eg: 'DatabaseSeeder'
+    'seeder_parameters' => [
+        '--class' => 'DatabaseSeeder', // root seeder class to run after automatic migrations, eg: 'DatabaseSeeder'
+    ],
     'queue_database_deletion' => false,
     'delete_database_after_tenant_deletion' => false, // delete the tenant's database after deleting the tenant
     'unique_id_generator' => Stancl\Tenancy\UniqueIDGenerators\UUIDGenerator::class,

--- a/assets/config.php
+++ b/assets/config.php
@@ -91,6 +91,8 @@ return [
     'home_url' => '/app',
     'queue_database_creation' => false,
     'migrate_after_creation' => false, // run migrations after creating a tenant
+    'seed_after_migration' => false, // should the seeder run after automatic migration
+    'seeder_class' => 'DatabaseSeeder', // root seeder class to run after automatic migrations, eg: 'DatabaseSeeder'
     'queue_database_deletion' => false,
     'delete_database_after_tenant_deletion' => false, // delete the tenant's database after deleting the tenant
     'unique_id_generator' => Stancl\Tenancy\UniqueIDGenerators\UUIDGenerator::class,

--- a/src/Jobs/QueuedTenantDatabaseSeeder.php
+++ b/src/Jobs/QueuedTenantDatabaseSeeder.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Artisan;
+use Stancl\Tenancy\Tenant;
+
+class QueuedTenantDatabaseSeeder implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var string */
+    protected $tenantId;
+
+    /** @var array */
+    protected $seederClassParameter = [];
+
+    public function __construct(Tenant $tenant, $seederClassName = '')
+    {
+        $this->tenantId = $tenant->id;
+        $this->seederClassParameter = ! empty($seederClassName) ? ['--class' => $seederClassName] : [];
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        Artisan::call('tenants:seed', [
+            '--tenants' => [$this->tenantId],
+        ] + $this->seederClassParameter);
+    }
+}

--- a/src/Jobs/QueuedTenantDatabaseSeeder.php
+++ b/src/Jobs/QueuedTenantDatabaseSeeder.php
@@ -22,7 +22,7 @@ class QueuedTenantDatabaseSeeder implements ShouldQueue
     /** @var array */
     protected $seederClassParameter = [];
 
-    public function __construct(Tenant $tenant, $seederClassName = '')
+    public function __construct(Tenant $tenant, string $seederClassName)
     {
         $this->tenantId = $tenant->id;
         $this->seederClassParameter = ! empty($seederClassName) ? ['--class' => $seederClassName] : [];

--- a/src/Jobs/QueuedTenantDatabaseSeeder.php
+++ b/src/Jobs/QueuedTenantDatabaseSeeder.php
@@ -20,12 +20,12 @@ class QueuedTenantDatabaseSeeder implements ShouldQueue
     protected $tenantId;
 
     /** @var array */
-    protected $seederClassParameter = [];
+    protected $seederParameters = [];
 
-    public function __construct(Tenant $tenant, string $seederClassName)
+    public function __construct(Tenant $tenant, $seederParameters = [])
     {
         $this->tenantId = $tenant->id;
-        $this->seederClassParameter = ! empty($seederClassName) ? ['--class' => $seederClassName] : [];
+        $this->seederParameters = $seederParameters;
     }
 
     /**
@@ -37,6 +37,6 @@ class QueuedTenantDatabaseSeeder implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenantId],
-        ] + $this->seederClassParameter);
+        ] + $this->seederParameters);
     }
 }

--- a/tests/TenantManagerTest.php
+++ b/tests/TenantManagerTest.php
@@ -237,7 +237,6 @@ class TenantManagerTest extends TestCase
         $tenant2 = Tenant::create(['bar.localhost']);
         tenancy()->initialize($tenant2);
         $this->assertTrue(\Schema::hasTable('users'));
-        $this->assertCount(0, \DB::select('select * from users'));
     }
 
     /** @test */


### PR DESCRIPTION
Fixes #158

If `config('tenancy.seeder_class')` is null or a blank string, the seeder-class parameter is not passed, and therefore Laravel's default option of calling 'DatabaseSeeder' will occur.

As with Laravel's normal seeding process, the class is treated as the "root" seeder class, which can call other seeder classes in turn.