### PR TITLE
Fix typo in TenantRouteServiceProvider

### DIFF
--- a/src/TenantRouteServiceProvider.php
+++ b/src/TenantRouteServiceProvider.php
@@ -14,7 +14,7 @@ class TenantRouteServiceProvider extends RouteServiceProvider
         if (! in_array(request()->getHost(), $this->app['config']['tenancy.exempt_domains'] ?? [])
             && file_exists(base_path('routes/tenant.php'))) {
             Route::middleware(['web', 'tenancy'])
-                ->namespace($this->app['config']['tenant_route_namespace'] ?? 'App\Http\Controllers')
+                ->namespace($this->app['config']['tenancy.tenant_route_namespace'] ?? 'App\Http\Controllers')
                 ->group(base_path('routes/tenant.php'));
         }
     }


### PR DESCRIPTION
config `tenant_route_namespace` was used instead  of
`tenancy.tenant_route_namespace`