### PR TITLE
[2.1.0] Tenant Run

### DIFF
--- a/src/Tenant.php
+++ b/src/Tenant.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy;
 
 use ArrayAccess;
+use Closure;
 use Illuminate\Foundation\Application;
 use Illuminate\Support\Str;
 use Illuminate\Support\Traits\ForwardsCalls;
@@ -360,6 +361,27 @@ class Tenant implements ArrayAccess
         $this->data[$key] = $value;
 
         return $this;
+    }
+
+    /**
+     * Run a closure inside the tenant's environment.
+     *
+     * @param Closure $closure
+     * @return mixed
+     */
+    public function run(Closure $closure)
+    {
+        $originalTenant = $this->manager->getTenant();
+
+        $this->manager->initializeTenancy($this);
+        $result = $closure($this);
+        $this->manager->endTenancy($this);
+
+        if ($originalTenant) {
+            $this->manager->initializeTenancy($originalTenant);
+        }
+
+        return $result;
     }
 
     public function __get($key)

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -206,6 +206,10 @@ class TenantManager
      */
     public function initializeTenancy(Tenant $tenant): self
     {
+        if ($this->initialized) {
+            $this->endTenancy();
+        }
+
         $this->setTenant($tenant);
         $this->bootstrapTenancy($tenant);
         $this->initialized = true;

--- a/tests/TenantClassTest.php
+++ b/tests/TenantClassTest.php
@@ -167,5 +167,10 @@ class TenantClassTest extends TestCase
         $this->assertSame(2, $tenant->run(function () {
             return \DB::table('users')->count();
         }));
+
+        // test that the tenant variable can be accessed
+        $this->assertSame($tenant->id, $tenant->run(function ($tenant) {
+            return $tenant->id;
+        }));
     }
 }


### PR DESCRIPTION
This method lets you execute a closure inside a tenant's "environment".

A use case for this, suggested by @drbyte, is that you may want to create a superadmin user in a tenant's database after creating the tenant. With this method, you can do:
```php
$tenant->run(function () {
    User::create([...]);
});
```

You can also use this method to get some data from the tenant's environment:

```php
$userCount = $tenant->run(function () {
    return User::count();
});
```

This method also returns to the state of tenancy prior to being executed. If tenancy was not initialized, it ends it. If it was initialized, it reinitializes it for the original tenant.

TODO:
- [x] Method name: ~should it be `runAs`~?
- [x] Documentation https://github.com/stancl/tenancy-docs/issues/26