### PR TITLE
[2.x] Don't purge central connections

### DIFF
--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -57,6 +57,17 @@ class DatabaseManager
     }
 
     /**
+     * Change the default database connection config.
+     *
+     * @param string $connection
+     * @return void
+     */
+    public function setDefaultConnection(string $connection)
+    {
+        $this->app['config']['database.default'] = $connection;
+    }
+
+    /**
      * Create the tenant database connection.
      *
      * @param string $databaseName
@@ -106,7 +117,6 @@ class DatabaseManager
      */
     public function switchConnection(string $connection)
     {
-        $this->app['config']['database.default'] = $connection;
         $this->database->purge();
         $this->database->reconnect($connection);
         $this->database->setDefaultConnection($connection);

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -39,6 +39,7 @@ class DatabaseManager
     public function connect(Tenant $tenant)
     {
         $this->createTenantConnection($tenant->getDatabaseName(), $tenant->getConnectionName());
+        $this->setDefaultConnection($tenant->getConnectionName());
         $this->switchConnection($tenant->getConnectionName());
     }
 
@@ -49,7 +50,10 @@ class DatabaseManager
      */
     public function reconnect()
     {
+        // Opposite order to connect() because we don't
+        // want to ever purge the central connection
         $this->switchConnection($this->originalDefaultConnectionName);
+        $this->setDefaultConnection($this->originalDefaultConnectionName);
     }
 
     /**

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -52,8 +52,8 @@ class DatabaseManager
     {
         // Opposite order to connect() because we don't
         // want to ever purge the central connection
-        $this->switchConnection($this->originalDefaultConnectionName);
         $this->setDefaultConnection($this->originalDefaultConnectionName);
+        $this->switchConnection($this->originalDefaultConnectionName);
     }
 
     /**

--- a/tests/DatabaseManagerTest.php
+++ b/tests/DatabaseManagerTest.php
@@ -45,4 +45,21 @@ class DatabaseManagerTest extends TestCase
         $this->assertSame('tenant', config('database.default'));
         $this->assertSame('bar', config('database.connections.' . config('database.default') . '.foo'));
     }
+
+    /** @test */
+    public function ending_tenancy_doesnt_purge_the_central_connection()
+    {
+        $this->markTestIncomplete('Seems like this only happens on MySQL?');
+        
+        // regression test for https://github.com/stancl/tenancy/pull/189
+        // config(['tenancy.migrate_after_creation' => true]);
+
+        tenancy()->create(['foo.localhost']);
+        tenancy()->init('foo.localhost');
+        tenancy()->end();
+
+        $this->assertNotEmpty(tenancy()->all());
+
+        tenancy()->all()->each->delete();
+    }
 }

--- a/tests/DatabaseManagerTest.php
+++ b/tests/DatabaseManagerTest.php
@@ -50,7 +50,7 @@ class DatabaseManagerTest extends TestCase
     public function ending_tenancy_doesnt_purge_the_central_connection()
     {
         $this->markTestIncomplete('Seems like this only happens on MySQL?');
-        
+
         // regression test for https://github.com/stancl/tenancy/pull/189
         // config(['tenancy.migrate_after_creation' => true]);
 


### PR DESCRIPTION
Fixes #176 

The `endTenancy()` method (indirectly) calls `DatabaseManager::reconnect()` which reconnects the default database back to the central database. That method purges the connection that we are switching to - this makes sense in case of switching tenants, to purge the 'tenant' connection, but in case of ending tenancy, this purges the central connection, resulting in `DatabaseStorageDriver::$centralDatabase->getPdo()` returning null, making it unable to delete tenants after tenancy was ended (such as in tests' `tearDown()`).

TODO:
- [ ] Regression test