### PR TITLE
Creates route helper method on tenant

### DIFF
--- a/src/Tenant.php
+++ b/src/Tenant.php
@@ -385,14 +385,14 @@ class Tenant implements ArrayAccess
     }
     
      /**
-     * Get a route specific to this tenant.
+     * Generate a route specific to this tenant with the given path.
      *
      * @param String $path
      * @return string
      */
-    public function route($path)
+    public function route($path): string
     {
-        $path = $path[0] !== '/' ? '/'.$path : $path;
+        $path = $path[0] === '/' ?: sprintf('/%s', $path);
 
         $url = $this->app->config->get('app.url');
         $subdomain = $this->domains[0];

--- a/src/Tenant.php
+++ b/src/Tenant.php
@@ -383,6 +383,23 @@ class Tenant implements ArrayAccess
 
         return $result;
     }
+    
+     /**
+     * Get a route specific to this tenant.
+     *
+     * @param String $path
+     * @return string
+     */
+    public function route($path)
+    {
+        $path = $path[0] !== '/' ? '/'.$path : $path;
+
+        $url = $this->app->config->get('app.url');
+        $subdomain = $this->domains[0];
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+
+        return sprintf('%s://%s%s', $scheme, $subdomain, $path);
+    }
 
     public function __get($key)
     {


### PR DESCRIPTION
# What does this do?
This PR is helpful while testing your application. It is often useful to assert where a specific action redirects, and it was becoming cumbersome to try to create tenant routes each time.

# How is it used?
Imagine a test that is testing a tenant create route.
```
$response = $this->post(route('register'), $data);
// some assertions about the created user and tenant

// Assert that the controller redirected where it was supposed to
$response->assertRedirect(tenant()->route('/dashboard'));
```

## Quesions
- Is there already a way to do this that I'm missing?
- Is this even something you would want in the codebase?
- Since there can be more than 1 domain per tenant, is there a way the rest of the package decides which domain to use? Currently this code just grabs the first from the tenant's domains array.
- Is there another place this code would be more appropriate?


