### PR TITLE
[2.2.0] Optional storage path suffixing

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -42,6 +42,7 @@ return [
     ],
     'filesystem' => [ // https://tenancy.samuelstancl.me/docs/v2/filesystem-tenancy/
         'suffix_base' => 'tenant',
+        'suffix_storage_path' => true, // Note: Disabling this will likely break local disk tenancy. Only disable this if you're using an external file storage service like S3.
         // Disks which should be suffixed with the suffix_base + tenant id.
         'disks' => [
             'local',

--- a/src/TenancyBootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/TenancyBootstrappers/FilesystemTenancyBootstrapper.php
@@ -38,7 +38,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenant->id;
 
         // storage_path()
-        if ($this->app['config']['tenancy.filesystem.suffix_storage_path'] ?? false) {
+        if ($this->app['config']['tenancy.filesystem.suffix_storage_path'] ?? true) {
             $this->app->useStoragePath($this->originalPaths['storage'] . "/{$suffix}");
         }
 

--- a/src/TenancyBootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/TenancyBootstrappers/FilesystemTenancyBootstrapper.php
@@ -38,7 +38,9 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenant->id;
 
         // storage_path()
-        $this->app->useStoragePath($this->originalPaths['storage'] . "/{$suffix}");
+        if ($this->app['config']['tenancy.filesystem.suffix_storage_path'] ?? false) {
+            $this->app->useStoragePath($this->originalPaths['storage'] . "/{$suffix}");
+        }
 
         // asset()
         if ($this->originalPaths['asset_url']) {


### PR DESCRIPTION
Resolves #196 

Sometimes you may want to disable storage_path() suffixing, such as when using Vapor with Passport.

This adds a new config key.