### PR TITLE
[2.2.0] Make tenancy initialization in global MW stack optional

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -98,5 +98,5 @@ return [
     'queue_database_deletion' => false,
     'delete_database_after_tenant_deletion' => false, // delete the tenant's database after deleting the tenant
     'unique_id_generator' => Stancl\Tenancy\UniqueIDGenerators\UUIDGenerator::class,
-    'push_middleware_to_global_stack' => true,
+    'push_initialization_middleware_to_global_stack' => true,
 ];

--- a/assets/config.php
+++ b/assets/config.php
@@ -98,4 +98,5 @@ return [
     'queue_database_deletion' => false,
     'delete_database_after_tenant_deletion' => false, // delete the tenant's database after deleting the tenant
     'unique_id_generator' => Stancl\Tenancy\UniqueIDGenerators\UUIDGenerator::class,
+    'push_middleware_to_global_stack' => true,
 ];

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -78,7 +78,9 @@ class TenancyServiceProvider extends ServiceProvider
             __DIR__ . '/../assets/migrations/' => database_path('migrations'),
         ], 'migrations');
 
-        $this->app->make(Kernel::class)->prependMiddleware(Middleware\InitializeTenancy::class);
+        if ($this->app['config']['tenancy.push_initialization_middleware_to_global_stack'] ?? true) {
+            $this->app->make(Kernel::class)->prependMiddleware(Middleware\InitializeTenancy::class);
+        }
 
         /*
          * Since tenancy is initialized in the global middleware stack, this


### PR DESCRIPTION
When using custom tenancy initialization mechanism, this middleware needs to be disabled.