### PR TITLE
Register tenant routes after other SPs are executed

### DIFF
--- a/src/TenantRouteServiceProvider.php
+++ b/src/TenantRouteServiceProvider.php
@@ -11,10 +11,12 @@ class TenantRouteServiceProvider extends RouteServiceProvider
 {
     public function map()
     {
-        if (file_exists(base_path('routes/tenant.php'))) {
-            Route::middleware(['web', 'tenancy'])
-                ->namespace($this->app['config']['tenancy.tenant_route_namespace'] ?? 'App\Http\Controllers')
-                ->group(base_path('routes/tenant.php'));
-        }
+        $this->app->booted(function () {
+            if (file_exists(base_path('routes/tenant.php'))) {
+                Route::middleware(['web', 'tenancy'])
+                    ->namespace($this->app['config']['tenancy.tenant_route_namespace'] ?? 'App\Http\Controllers')
+                    ->group(base_path('routes/tenant.php'));
+            }
+        });
     }
 }


### PR DESCRIPTION
Resolves #182 

This makes it possible to have conflicting route URLs by registering the web/api routes only for exempt_domains. The tenant routes will be registered after the web routes.