### PR TITLE
Add missing json extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
         }
     ],
     "require": {
+        "ext-json": "*",
         "illuminate/support": "^6.0",
         "ramsey/uuid": "^3.7"
     },


### PR DESCRIPTION
As we use json_encode, JSON_PRETTY_PRINT etc we need to define the json extension. 