### PR TITLE
[2.3.0] tenant_route() helper

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Stancl\Tenancy\Tenant;
 use Stancl\Tenancy\TenantManager;
 
-if (! \function_exists('tenancy')) {
+if (! function_exists('tenancy')) {
     /** @return TenantManager|mixed */
     function tenancy($key = null)
     {
@@ -17,7 +17,7 @@ if (! \function_exists('tenancy')) {
     }
 }
 
-if (! \function_exists('tenant')) {
+if (! function_exists('tenant')) {
     /** @return Tenant|mixed */
     function tenant($key = null)
     {
@@ -29,7 +29,7 @@ if (! \function_exists('tenant')) {
     }
 }
 
-if (! \function_exists('tenant_asset')) {
+if (! function_exists('tenant_asset')) {
     /** @return string */
     function tenant_asset($asset)
     {
@@ -37,16 +37,30 @@ if (! \function_exists('tenant_asset')) {
     }
 }
 
-if (! \function_exists('global_asset')) {
+if (! function_exists('global_asset')) {
     function global_asset($asset)
     {
         return app('globalUrl')->asset($asset);
     }
 }
 
-if (! \function_exists('global_cache')) {
+if (! function_exists('global_cache')) {
     function global_cache()
     {
         return app('globalCache');
+    }
+}
+
+if (! function_exists('tenant_route')) {
+    function tenant_route(string $route, array $parameters = [], string $domain = null): string
+    {
+        $domain = $domain ?? request()->getHost();
+
+        // replace first occurance of hostname fragment with $domain
+        $url = route($route, $parameters);
+        $hostname = parse_url($url, PHP_URL_HOST);
+        $position = strpos($url, $hostname);
+
+        return substr_replace($url, $domain, $position, strlen($hostname));
     }
 }

--- a/tests/Features/TenantConfigTest.php
+++ b/tests/Features/TenantConfigTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Stancl\Tenancy\Tests\Feature;
+namespace Stancl\Tenancy\Tests\Features;
 
 use Stancl\Tenancy\Tests\TestCase;
 

--- a/tests/Features/TimestampTest.php
+++ b/tests/Features/TimestampTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Stancl\Tenancy\Tests\Feature;
+namespace Stancl\Tenancy\Tests\Features;
 
 use Stancl\Tenancy\Features\Timestamps;
 use Stancl\Tenancy\Tenant;

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -6,7 +6,6 @@ namespace Stancl\Tenancy\Tests;
 
 use Route;
 use Stancl\Tenancy\Tenant;
-use Stancl\Tenancy\Tests\TestCase;
 
 class RedirectTest extends TestCase
 {

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Stancl\Tenancy\Tests\Feature;
+namespace Stancl\Tenancy\Tests;
 
 use Route;
 use Stancl\Tenancy\Tenant;

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -8,10 +8,15 @@ use Route;
 use Stancl\Tenancy\Tenant;
 use Stancl\Tenancy\Tests\TestCase;
 
-class TenantRedirectMacroTest extends TestCase
+class RedirectTest extends TestCase
 {
     public $autoCreateTenant = false;
     public $autoInitTenancy = false;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+    }
 
     /** @test */
     public function tenant_redirect_macro_replaces_only_the_hostname()
@@ -33,5 +38,18 @@ class TenantRedirectMacroTest extends TestCase
 
         $this->get('/redirect')
             ->assertRedirect('http://abcd/foobar');
+    }
+
+    /** @test */
+    public function tenant_route_helper_generates_correct_url()
+    {
+        Route::get('/abcdef/{a?}/{b?}', function () {
+            return 'Foo';
+        })->name('foo');
+
+        $this->assertSame('http://foo.localhost/abcdef/as/df', tenant_route('foo', ['a' => 'as', 'b' => 'df'], 'foo.localhost'));
+        $this->assertSame('http://foo.localhost/abcdef', tenant_route('foo', [], 'foo.localhost'));
+
+        $this->assertSame('http://' . request()->getHost() . '/abcdef/x/y', tenant_route('foo', ['a' => 'x', 'b' => 'y']));
     }
 }

--- a/tests/RedirectTest.php
+++ b/tests/RedirectTest.php
@@ -13,11 +13,6 @@ class RedirectTest extends TestCase
     public $autoCreateTenant = false;
     public $autoInitTenancy = false;
 
-    public function setUp(): void
-    {
-        parent::setUp();
-    }
-
     /** @test */
     public function tenant_redirect_macro_replaces_only_the_hostname()
     {


### PR DESCRIPTION
```php
tenant_route('foo'); // current hostname
tenant_route('bar', ['a' => 'b']); // current hostname
tenant_route('abc', [], 'anotherdomain.com');
```