### PR TITLE
Added support for migration parameters

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -93,9 +93,13 @@ return [
     'home_url' => '/app',
     'queue_database_creation' => false,
     'migrate_after_creation' => false, // run migrations after creating a tenant
+    'migration_parameters' => [
+        // '--force' => true, // force database migrations
+    ],
     'seed_after_migration' => false, // should the seeder run after automatic migration
     'seeder_parameters' => [
         '--class' => 'DatabaseSeeder', // root seeder class to run after automatic migrations, e.g.: 'DatabaseSeeder'
+        // '--force' => true, // force database seeder
     ],
     'queue_database_deletion' => false,
     'delete_database_after_tenant_deletion' => false, // delete the tenant's database after deleting the tenant

--- a/src/Jobs/QueuedTenantDatabaseMigrator.php
+++ b/src/Jobs/QueuedTenantDatabaseMigrator.php
@@ -19,9 +19,13 @@ class QueuedTenantDatabaseMigrator implements ShouldQueue
     /** @var string */
     protected $tenantId;
 
-    public function __construct(Tenant $tenant)
+    /** @var array */
+    protected $migrationParameters = [];
+
+    public function __construct(Tenant $tenant, $migrationParameters = [])
     {
         $this->tenantId = $tenant->id;
+        $this->migrationParameters = $migrationParameters;
     }
 
     /**
@@ -33,6 +37,6 @@ class QueuedTenantDatabaseMigrator implements ShouldQueue
     {
         Artisan::call('tenants:migrate', [
             '--tenants' => [$this->tenantId],
-        ]);
+        ] + $this->migrationParameters);
     }
 }

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -78,11 +78,11 @@ class TenantManager
 
         if ($this->shouldMigrateAfterCreation()) {
             $afterCreating[] = $this->databaseCreationQueued()
-                ? new QueuedTenantDatabaseMigrator($tenant)
+                ? new QueuedTenantDatabaseMigrator($tenant, $this->getMigrationParameters())
                 : function () use ($tenant) {
                     $this->artisan->call('tenants:migrate', [
                         '--tenants' => [$tenant['id']],
-                    ]);
+                    ] + $this->getMigrationParameters());
                 };
         }
 
@@ -399,6 +399,11 @@ class TenantManager
     public function getSeederParameters()
     {
         return $this->app['config']['tenancy.seeder_parameters'] ?? [];
+    }
+
+    public function getMigrationParameters()
+    {
+        return $this->app['config']['tenancy.migration_parameters'] ?? [];
     }
 
     /**


### PR DESCRIPTION
I added the support for migration parameters because I was facing an issue with running the migrations in production. In order to add the "--force" flag, I had to implement the same logic as for seeders.