### PR TITLE
Migration paths

### DIFF
--- a/src/Traits/DealsWithMigrations.php
+++ b/src/Traits/DealsWithMigrations.php
@@ -12,6 +12,6 @@ trait DealsWithMigrations
             return parent::getMigrationPaths();
         }
 
-        return config('tenancy.migrations_paths', [config('tenancy.migrations_directory') ?? database_path('migrations/tenant')]);
+        return config('tenancy.migration_paths', [config('tenancy.migrations_directory') ?? database_path('migrations/tenant')]);
     }
 }

--- a/src/Traits/DealsWithMigrations.php
+++ b/src/Traits/DealsWithMigrations.php
@@ -12,6 +12,6 @@ trait DealsWithMigrations
             return parent::getMigrationPaths();
         }
 
-        return [config('tenancy.migrations_directory', database_path('migrations/tenant'))];
+        return config('tenancy.migrations_paths', [database_path('migrations/tenant')]);
     }
 }

--- a/src/Traits/DealsWithMigrations.php
+++ b/src/Traits/DealsWithMigrations.php
@@ -12,6 +12,6 @@ trait DealsWithMigrations
             return parent::getMigrationPaths();
         }
 
-        return config('tenancy.migrations_paths', [database_path('migrations/tenant')]);
+        return config('tenancy.migrations_paths', [config('tenancy.migrations_directory') ?? database_path('migrations/tenant')]);
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -18,7 +18,7 @@ class CommandsTest extends TestCase
     {
         parent::setUp();
 
-        config('tenancy.migrations_paths', [database_path('../migrations')]);
+        config(['tenancy.migration_paths', [database_path('../migrations')]]);
     }
 
     /** @test */

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -18,7 +18,7 @@ class CommandsTest extends TestCase
     {
         parent::setUp();
 
-        config(['tenancy.migrations_directory' => database_path('../migrations')]);
+        config('tenancy.migrations_paths', [database_path('migrations/tenant')]);
     }
 
     /** @test */

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -18,7 +18,7 @@ class CommandsTest extends TestCase
     {
         parent::setUp();
 
-        config('tenancy.migrations_paths', [database_path('migrations/tenant')]);
+        config('tenancy.migrations_paths', [database_path('../migrations')]);
     }
 
     /** @test */

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -96,7 +96,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'tenancy.redis.tenancy' => env('TENANCY_TEST_REDIS_TENANCY', true),
             'database.redis.client' => env('TENANCY_TEST_REDIS_CLIENT', 'phpredis'),
             'tenancy.redis.prefixed_connections' => ['default'],
-            'tenancy.migrations_directory' => database_path('../migrations'),
+            'tenancy.migrations_paths' => [database_path('../migrations')],
             'tenancy.storage_drivers.db.connection' => 'central',
             'tenancy.bootstrappers.redis' => \Stancl\Tenancy\TenancyBootstrappers\RedisTenancyBootstrapper::class,
             'queue.connections.central' => [

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -96,7 +96,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             'tenancy.redis.tenancy' => env('TENANCY_TEST_REDIS_TENANCY', true),
             'database.redis.client' => env('TENANCY_TEST_REDIS_CLIENT', 'phpredis'),
             'tenancy.redis.prefixed_connections' => ['default'],
-            'tenancy.migrations_paths' => [database_path('../migrations')],
+            'tenancy.migration_paths' => [database_path('../migrations')],
             'tenancy.storage_drivers.db.connection' => 'central',
             'tenancy.bootstrappers.redis' => \Stancl\Tenancy\TenancyBootstrappers\RedisTenancyBootstrapper::class,
             'queue.connections.central' => [


### PR DESCRIPTION
Allow to pass multiple paths to where tenant migrations are stored. This way if the project have many migrations and they are separated into modules we can include them through config, e.g. `config(['tenancy.migrations_paths' => ['/path/one', '/path/two']]);`