### PR TITLE
Reinitialize tenancy for queued jobs if tenant id has changed

### DIFF
--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -109,10 +109,12 @@ class TenancyServiceProvider extends ServiceProvider
 
         // Queue tenancy
         $this->app['events']->listen(\Illuminate\Queue\Events\JobProcessing::class, function ($event) {
-            if (array_key_exists('tenant_id', $event->job->payload())) {
-                if (! tenancy()->initialized) { // dispatchNow
-                    tenancy()->initialize(tenancy()->find($event->job->payload()['tenant_id']));
-                }
+            $tenantId = $event->job->payload()['tenant_id'] ?? null;
+            if (
+                $tenantId !== null &&
+                (! tenancy()->initialized || tenancy('id') !== $tenantId)
+            ) {
+                tenancy()->initById($tenantId);
             }
         });
     }


### PR DESCRIPTION
Hi

I have put in the fix as mentioned in #274.

Previously the code would only initialise tenancy when processing a queued job if tenancy wasn't already initialised. 

This will now initialise the tenancy if the previously initialised tenant id is different to the `tenant_id` in the job payload.

--- 

Fixes #274 

