### PR TITLE
Fix PDO serialization exception

### DIFF
--- a/src/Contracts/Future/CanSetConnection.php
+++ b/src/Contracts/Future/CanSetConnection.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Contracts\Future;
 
-use Illuminate\Database\Connection;
-
 /**
  * This interface *might* be part of the TenantDatabaseManager interface in 3.x.
  */
 interface CanSetConnection
 {
-    public function setConnection(Connection $connection);
+    public function setConnection(string $connection): void;
 }

--- a/src/DatabaseManager.php
+++ b/src/DatabaseManager.php
@@ -238,7 +238,7 @@ class DatabaseManager
         $databaseManager = $this->app[$databaseManagers[$driver]];
 
         if ($connectionName !== 'tenant' && $databaseManager instanceof CanSetConnection) {
-            $databaseManager->setConnection($this->database->connection($connectionName));
+            $databaseManager->setConnection($connectionName);
         }
 
         return $databaseManager;

--- a/src/TenantDatabaseManagers/MySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/MySQLDatabaseManager.php
@@ -6,7 +6,6 @@ namespace Stancl\Tenancy\TenantDatabaseManagers;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Connection;
-use Illuminate\Database\DatabaseManager as IlluminateDatabaseManager;
 use Illuminate\Support\Facades\DB;
 use Stancl\Tenancy\Contracts\Future\CanSetConnection;
 use Stancl\Tenancy\Contracts\TenantDatabaseManager;

--- a/src/TenantDatabaseManagers/MySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/MySQLDatabaseManager.php
@@ -7,39 +7,45 @@ namespace Stancl\Tenancy\TenantDatabaseManagers;
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Connection;
 use Illuminate\Database\DatabaseManager as IlluminateDatabaseManager;
+use Illuminate\Support\Facades\DB;
 use Stancl\Tenancy\Contracts\Future\CanSetConnection;
 use Stancl\Tenancy\Contracts\TenantDatabaseManager;
 
 class MySQLDatabaseManager implements TenantDatabaseManager, CanSetConnection
 {
-    /** @var Connection */
-    protected $database;
+    /** @var string */
+    protected $connection;
 
-    public function __construct(Repository $config, IlluminateDatabaseManager $databaseManager)
+    public function __construct(Repository $config)
     {
-        $this->database = $databaseManager->connection($config['tenancy.database_manager_connections.mysql']);
+        $this->connection = $config->get('tenancy.database_manager_connections.mysql');
     }
 
-    public function setConnection(Connection $connection)
+    protected function database(): Connection
     {
-        $this->database = $connection;
+        return DB::connection($this->connection);
+    }
+
+    public function setConnection(string $connection): void
+    {
+        $this->connection = $connection;
     }
 
     public function createDatabase(string $name): bool
     {
-        $charset = $this->database->getConfig('charset');
-        $collation = $this->database->getConfig('collation');
+        $charset = $this->database()->getConfig('charset');
+        $collation = $this->database()->getConfig('collation');
 
-        return $this->database->statement("CREATE DATABASE `$name` CHARACTER SET `$charset` COLLATE `$collation`");
+        return $this->database()->statement("CREATE DATABASE `$name` CHARACTER SET `$charset` COLLATE `$collation`");
     }
 
     public function deleteDatabase(string $name): bool
     {
-        return $this->database->statement("DROP DATABASE `$name`");
+        return $this->database()->statement("DROP DATABASE `$name`");
     }
 
     public function databaseExists(string $name): bool
     {
-        return (bool) $this->database->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'");
+        return (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'");
     }
 }

--- a/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -32,16 +32,16 @@ class PostgreSQLDatabaseManager implements TenantDatabaseManager, CanSetConnecti
 
     public function createDatabase(string $name): bool
     {
-        return $this->database->statement("CREATE DATABASE \"$name\" WITH TEMPLATE=template0");
+        return $this->database()->statement("CREATE DATABASE \"$name\" WITH TEMPLATE=template0");
     }
 
     public function deleteDatabase(string $name): bool
     {
-        return $this->database->statement("DROP DATABASE \"$name\"");
+        return $this->database()->statement("DROP DATABASE \"$name\"");
     }
 
     public function databaseExists(string $name): bool
     {
-        return (bool) $this->database->select("SELECT datname FROM pg_database WHERE datname = '$name'");
+        return (bool) $this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'");
     }
 }

--- a/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -6,22 +6,28 @@ namespace Stancl\Tenancy\TenantDatabaseManagers;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Connection;
-use Illuminate\Database\DatabaseManager as IlluminateDatabaseManager;
+use Illuminate\Support\Facades\DB;
+use Stancl\Tenancy\Contracts\Future\CanSetConnection;
 use Stancl\Tenancy\Contracts\TenantDatabaseManager;
 
-class PostgreSQLDatabaseManager implements TenantDatabaseManager
+class PostgreSQLDatabaseManager implements TenantDatabaseManager, CanSetConnection
 {
-    /** @var Connection */
-    protected $database;
+    /** @var string */
+    protected $connection;
 
-    public function __construct(Repository $config, IlluminateDatabaseManager $databaseManager)
+    public function __construct(Repository $config)
     {
-        $this->database = $databaseManager->connection($config['tenancy.database_manager_connections.pgsql']);
+        $this->connection = $config->get('tenancy.database_manager_connections.pgsql');
     }
 
-    public function setConnection(Connection $connection)
+    protected function database(): Connection
     {
-        $this->database = $connection;
+        return DB::connection($this->connection);
+    }
+
+    public function setConnection(string $connection): void
+    {
+        $this->connection = $connection;
     }
 
     public function createDatabase(string $name): bool


### PR DESCRIPTION
Resolves #273 

TenantDatabaseManagers no longer store `Connection` dependencies - they store serializable strings now.

