### PR TITLE
[2.3.0] Make DB creation optional

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -91,6 +91,7 @@ return [
         // 'paypal_api_key' => 'services.paypal.api_key',
     ],
     'home_url' => '/app',
+    'create_database' => true,
     'queue_database_creation' => false,
     'migrate_after_creation' => false, // run migrations after creating a tenant
     'migration_parameters' => [

--- a/src/TenantManager.php
+++ b/src/TenantManager.php
@@ -98,7 +98,9 @@ class TenantManager
                 };
         }
 
-        $this->database->createDatabase($tenant, $afterCreating);
+        if ($this->shouldCreateDatabase($tenant)) {
+            $this->database->createDatabase($tenant, $afterCreating);
+        }
 
         $this->event('tenant.created', $tenant);
 
@@ -376,6 +378,15 @@ class TenantManager
     public function tenancyBootstrappers($except = []): array
     {
         return array_diff_key($this->app['config']['tenancy.bootstrappers'], array_flip($except));
+    }
+
+    public function shouldCreateDatabase(Tenant $tenant): bool
+    {
+        if (array_key_exists('_tenancy_create_database', $tenant->data)) {
+            return $tenant->data['_tenancy_create_database'];
+        }
+
+        return $this->app['config']['tenancy.create_database'] ?? true;
     }
 
     public function shouldMigrateAfterCreation(): bool

--- a/tests/TenantManagerTest.php
+++ b/tests/TenantManagerTest.php
@@ -345,4 +345,38 @@ class TenantManagerTest extends TestCase
         $this->assertArrayHasKey('foo', $tenant->data);
         $this->assertArrayHasKey('abc123', $tenant->data);
     }
+
+    /** @test */
+    public function database_creation_can_be_disabled()
+    {
+        config(['tenancy.create_database' => false]);
+
+        tenancy()->hook('database.creating', function () {
+            $this->fail();
+        });
+
+        $tenant = Tenant::new()->save();
+
+        $this->assertTrue(true);
+    }
+
+    /** @test */
+    public function database_creation_can_be_disabled_for_specific_tenants()
+    {
+        config(['tenancy.create_database' => true]);
+
+        tenancy()->hook('database.creating', function () {
+            $this->assertTrue(true);
+        });
+
+        $tenant = Tenant::new()->save();
+
+        tenancy()->hook('database.creating', function () {
+            $this->fail();
+        });
+
+        $tenant2 = Tenant::new()->withData([
+            '_tenancy_create_database' => false,
+        ])->save();
+    }
 }


### PR DESCRIPTION
Resolves #296 

DB creation can be disabled for all tenants (`tenancy.create_database` config), or for individual tenants during tenant creation:

```php
Tenant::new()->withData([
    '_tenancy_create_database' => false,
])->save();
```