### PR TITLE
Support Laravel 7.x

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,27 +4,30 @@ LABEL maintainer="Samuel Štancl"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+RUN apt-get update && apt-get install -y software-properties-common
+
+RUN add-apt-repository -y ppa:ondrej/php
+
 RUN apt-get update \
     && apt-get install -y curl zip unzip git sqlite3 \
-    php7.2-fpm php7.2-cli \
-    php7.2-pgsql php7.2-sqlite3 php7.2-gd \
-    php7.2-curl php7.2-memcached \
-    php7.2-imap php7.2-mysql php7.2-mbstring \
-    php7.2-xml php7.2-zip php7.2-bcmath php7.2-soap \
-    php7.2-intl php7.2-readline php7.2-xdebug \
+    php7.3-fpm php7.3-cli \
+    php7.3-pgsql php7.3-sqlite3 php7.3-gd \
+    php7.3-curl php7.3-memcached \
+    php7.3-imap php7.3-mysql php7.3-mbstring \
+    php7.3-xml php7.3-zip php7.3-bcmath php7.3-soap \
+    php7.3-intl php7.3-readline php7.3-xdebug \
     php-msgpack php-igbinary \
     && php -r "readfile('http://getcomposer.org/installer');" | php -- --install-dir=/usr/bin/ --filename=composer \
     && mkdir /run/php
 
-RUN apt-get install -y php7.2-redis
+RUN apt-get install -y php7.3-redis
 
 RUN apt-get install -y python3
 
-RUN apt-get install -y php7.2-dev php-pear
-RUN pecl install xdebug
-# RUN echo '' > /etc/php/7.2/cli/conf.d/20-xdebug.ini
-# RUN echo 'zend_extension=/usr/lib/php/20170718/xdebug.so' >> /etc/php/7.2/cli/php.ini
-RUN echo 'zend_extension=/usr/lib/php/20170718/xdebug.so' > /etc/php/7.2/cli/conf.d/20-xdebug.ini
+RUN apt-get install -y php7.3-dev php-pear php-xdebug
+# RUN echo '' > /etc/php/7.3/cli/conf.d/30-xdebug.ini
+# RUN echo 'zend_extension=/usr/lib/php/30170718/xdebug.so' >> /etc/php/7.3/cli/php.ini
+
 
 RUN apt-get -y autoremove \
     && apt-get clean \

--- a/composer.json
+++ b/composer.json
@@ -11,15 +11,15 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/support": "^7.0",
+        "illuminate/support": "^6.0|^7.0",
         "facade/ignition-contracts": "^1.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {
-        "vlucas/phpdotenv": "^4.0",
-        "laravel/telescope": "^3.0",
-        "laravel/framework": "^7.0",
-        "orchestra/testbench-browser-kit": "^5.0",
+        "vlucas/phpdotenv": "^3.3|^4.0",
+        "laravel/telescope": "^2.0|^3.0",
+        "laravel/framework": "^6.0|^7.0",
+        "orchestra/testbench-browser-kit": "^4.0|^5.0",
         "league/flysystem-aws-s3-v3": "~1.0",
         "phpunit/phpcov": "dev-master"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/support": "^6.0",
+        "illuminate/support": "^7.0",
         "facade/ignition-contracts": "^1.0",
         "ramsey/uuid": "^3.7"
     },
     "require-dev": {
-        "vlucas/phpdotenv": "^3.3",
-        "laravel/telescope": "^2.0",
-        "laravel/framework": "^6.0",
-        "orchestra/testbench-browser-kit": "^4.0",
+        "vlucas/phpdotenv": "^4.0",
+        "laravel/telescope": "^3.0",
+        "laravel/framework": "^7.0",
+        "orchestra/testbench-browser-kit": "^5.0",
         "league/flysystem-aws-s3-v3": "~1.0",
-        "phpunit/phpcov": "^6.0"
+        "phpunit/phpcov": "dev-master"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Did initial work to get this package to run on laravel 7.x, e.g updated dependencies etc. 

~This is set as a draft because the package `phpunit/phpcov` (used in require-dev) depends on `symfony/console` and there is not yet a released package with "5.x" support yet.~

I have also only bumped the dependencies to laravel 7.x no actual code changes have been done sense i don't believe such changes is needed for this update. 

Because of the use of `phpunit/phpunit` "^9.0" i had to change our docker image to PHP 7.3 instead of 7.2

Edit: Added support for laravel 6.x back in.  