### PR TITLE
Add return value to execute method

### DIFF
--- a/src/Traits/TenantAwareCommand.php
+++ b/src/Traits/TenantAwareCommand.php
@@ -26,6 +26,8 @@ trait TenantAwareCommand
                 $this->laravel->call([$this, 'handle']);
             });
         }
+
+        return 1;
     }
 
     /**

--- a/tests/Etc/AddUserCommand.php
+++ b/tests/Etc/AddUserCommand.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests\Etc;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Stancl\Tenancy\Traits\HasATenantsOption;
+use Stancl\Tenancy\Traits\TenantAwareCommand;
+
+class AddUserCommand extends Command
+{
+    use TenantAwareCommand, HasATenantsOption;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:add';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        User::create([
+            'name' => Str::random(10),
+            'email' => Str::random(10) . '@gmail.com',
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+    }
+}

--- a/tests/Etc/ConsoleKernel.php
+++ b/tests/Etc/ConsoleKernel.php
@@ -15,5 +15,6 @@ class ConsoleKernel extends Kernel
      */
     protected $commands = [
         ExampleCommand::class,
+        AddUserCommand::class,
     ];
 }

--- a/tests/Traits/TenantAwareCommandTest.php
+++ b/tests/Traits/TenantAwareCommandTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests\Traits;
+
+use Stancl\Tenancy\Tenant;
+use Stancl\Tenancy\Tests\TestCase;
+
+class TenantAwareCommandTest extends TestCase
+{
+    public $autoCreateTenant = false;
+    public $autoInitTenancy = false;
+
+    /** @test */
+    public function commands_run_globally_are_tenant_aware_and_return_valid_exit_code()
+    {
+        $tenant1 = Tenant::new()->save();
+        $tenant2 = Tenant::new()->save();
+        \Artisan::call('tenants:migrate', [
+            '--tenants' => [$tenant1['id'], $tenant2['id']],
+        ]);
+
+        $this->artisan('user:add')
+            ->assertExitCode(1);
+
+        tenancy()->initializeTenancy($tenant1);
+        $this->assertNotEmpty(\DB::table('users')->get());
+        tenancy()->end();
+
+        tenancy()->initializeTenancy($tenant2);
+        $this->assertNotEmpty(\DB::table('users')->get());
+        tenancy()->end();
+    }
+}


### PR DESCRIPTION
Fixes the following error as demonstrated with test in PR and error below. Occurs after updating to Laravel 7.x and Tenancy 2.3

```
TypeError: Return value of "Stancl\Tenancy\Tests\Etc\AddUserCommand::execute()" must be of the type int, NULL returned.
```

Let me know if further changes are needed ✌🏻