### PR TITLE
[2.3.1] Fix exit codes in TenantAwareCommand

### DIFF
--- a/src/Traits/TenantAwareCommand.php
+++ b/src/Traits/TenantAwareCommand.php
@@ -10,7 +10,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 trait TenantAwareCommand
 {
-    /** @return mixed|void */
+    /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $tenants = $this->getTenants();
@@ -21,13 +21,18 @@ trait TenantAwareCommand
             });
         }
 
+        $exitCode = 0;
         foreach ($tenants as $tenant) {
-            $tenant->run(function () {
-                $this->laravel->call([$this, 'handle']);
+            $result = $tenant->run(function () {
+                return $this->laravel->call([$this, 'handle']);
             });
+
+            if ($result !== 0) {
+                $exitCode = $result;
+            }
         }
 
-        return 1;
+        return $exitCode;
     }
 
     /**

--- a/src/Traits/TenantAwareCommand.php
+++ b/src/Traits/TenantAwareCommand.php
@@ -23,7 +23,7 @@ trait TenantAwareCommand
 
         $exitCode = 0;
         foreach ($tenants as $tenant) {
-            $result = $tenant->run(function () {
+            $result = (int) $tenant->run(function () {
                 return $this->laravel->call([$this, 'handle']);
             });
 

--- a/tests/Traits/TenantAwareCommandTest.php
+++ b/tests/Traits/TenantAwareCommandTest.php
@@ -22,7 +22,7 @@ class TenantAwareCommandTest extends TestCase
         ]);
 
         $this->artisan('user:add')
-            ->assertExitCode(1);
+            ->assertExitCode(0);
 
         tenancy()->initializeTenancy($tenant1);
         $this->assertNotEmpty(\DB::table('users')->get());


### PR DESCRIPTION
Follow-up to #333

@devonmather Please review.

If there is only one tenant, we return the command's exit code. If there are multiple tenants, we return the latest non-0 exit code.