### PR TITLE
[3.x] - Add a hook to console commands that should run before trying to fetch/initialize tenants

### DIFF
--- a/src/Traits/TenantAwareCommand.php
+++ b/src/Traits/TenantAwareCommand.php
@@ -13,6 +13,12 @@ trait TenantAwareCommand
     /** @return int */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        $callback = $this->runBeforeRunningTenantsHook();
+
+        if ($callback !== 0) {
+            return $callback;
+        }
+
         $tenants = $this->getTenants();
         $exitCode = 0;
 
@@ -35,4 +41,13 @@ trait TenantAwareCommand
      * @return Tenant[]
      */
     abstract protected function getTenants(): array;
+
+    private function runBeforeRunningTenantsHook()
+    {
+        if (! method_exists($this, 'beforeRunningTenants')) {
+            return;
+        }
+
+        return (int) $this->laravel->call([$this, 'beforeRunningTenants']);
+    }
 }

--- a/tests/Etc/AddUserConditionally.php
+++ b/tests/Etc/AddUserConditionally.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Stancl\Tenancy\Tests\Etc;
+
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Str;
+use Stancl\Tenancy\Traits\HasATenantsOption;
+use Stancl\Tenancy\Traits\TenantAwareCommand;
+
+class AddUserConditionally extends Command
+{
+    use TenantAwareCommand, HasATenantsOption;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'user:add_conditionally {--stop}';
+
+    public function beforeRunningTenants()
+    {
+        if ($this->option('stop')) {
+            $this->error('You stopped the command conditionally');
+            return 1;
+        }
+
+        return 0;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        User::create([
+            'name' => Str::random(10),
+            'email' => Str::random(10) . '@gmail.com',
+            'email_verified_at' => now(),
+            'password' => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token' => Str::random(10),
+        ]);
+    }
+}

--- a/tests/Etc/ConsoleKernel.php
+++ b/tests/Etc/ConsoleKernel.php
@@ -16,5 +16,6 @@ class ConsoleKernel extends Kernel
     protected $commands = [
         ExampleCommand::class,
         AddUserCommand::class,
+        AddUserConditionally::class
     ];
 }


### PR DESCRIPTION
# Introduction
This pull request adds the ability to run arbitary code before any tenants have been located and initialized. 

## Why
Imagine you have to create a confirmation dialog/ or some other condition which states if the command should run. Given the current implementation of `TenantAwareCommand` trait. If you implement that logic with the `handle` method inside the command that condition would previously run for every single tenant. 
This can in some situations be the desired behaviour and in other cases it's a termination of the command entirely.

I hope the point of this is getting across, if not i'll be happy to provide extra any extra information needed. 