### PR TITLE
Improved query for resolving domain

### DIFF
--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -29,7 +29,7 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
     public function resolveWithoutCache(...$args): Tenant
     {
         /** @var Domain $domain */
-        $domain = config('tenancy.domain_model')::where('domain', $args[0])->first();
+        $domain = config('tenancy.domain_model')::with('tenant')->where('domain', $args[0])->first();
 
         if ($domain) {
             static::$currentDomain = $domain;


### PR DESCRIPTION
The tenant relation is instantly called 100% of the times this method is called.
Including the tenant relation, we are saving an additional database query.