### PR TITLE
reverse middlewares order before prepend

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -136,7 +136,7 @@ class TenancyServiceProvider extends ServiceProvider
             Middleware\InitializeTenancyByRequestData::class,
         ];
 
-        foreach ($tenancyMiddleware as $middleware) {
+        foreach (array_reverse($tenancyMiddleware) as $middleware) {
             $this->app[\Illuminate\Contracts\Http\Kernel::class]->prependToMiddlewarePriority($middleware);
         }
     }


### PR DESCRIPTION
`prependToMiddlewarePriority` will add the middleware to first one. If it just iterates the `$tenancyMiddleware` array. The final middleware order will be incorrect.