### PR TITLE
Only bind UUID generator if one is specified in config

### DIFF
--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -54,7 +54,9 @@ class TenancyServiceProvider extends ServiceProvider
         }
 
         // Bind the class in the tenancy.id_generator config to the UniqueIdentifierGenerator abstract.
-        $this->app->bind(Contracts\UniqueIdentifierGenerator::class, $this->app['config']['tenancy.id_generator']);
+        if (! is_null($this->app['config']['tenancy.id_generator'])) {
+            $this->app->bind(Contracts\UniqueIdentifierGenerator::class, $this->app['config']['tenancy.id_generator']);
+        }
 
         $this->app->singleton(Commands\Migrate::class, function ($app) {
             return new Commands\Migrate($app['migrator'], $app['events']);


### PR DESCRIPTION
I would using autoincrement IDs for tenants. I changed the migration and set the `tenancy.id_generator` config to `null`. But when I tried to create a new tenant I got the error message:

`Illuminate/Contracts/Container/BindingResolutionException with message 'Target [Stancl/Tenancy/Contracts/UniqueIdentifierGenerator] is not instantiable.'`

This is because the `GeneratesIds` trait checks if an UUID generator is bound to determine if autoincrement should be used. But even if you bind a class with null Laravel interprets this as 'bound'.

This PR only binds the generator class if a generator is specified in the config.