### PR TITLE
Extend GlobalCache facade from the original facade

### DIFF
--- a/src/Facades/GlobalCache.php
+++ b/src/Facades/GlobalCache.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Facades;
 
-use Illuminate\Support\Facades\Facade;
+use Illuminate\Support\Facades\Cache;
 
-class GlobalCache extends Facade
+class GlobalCache extends Cache
 {
     protected static function getFacadeAccessor()
     {


### PR DESCRIPTION
I want to use the GlobalCache facade but I noticed that my IDE (PhpStorm) doesn't recognize any functions in the autocomplete.

This PR simply extends the GlobalCache facade from the original Cache facade. Thus the IDE can use the "@method"s in the PHPdoc of the original facade.

I don't know if it's a good idea to extend the facade. Another idea would be to copy the PHPdoc from the original facade. But the extend works fine and we don't have to worry when a new cache function should be implemented in the Laravel framework.