### PR TITLE
Fix: The database name is displayed when the TenantDatabaseAlreadyExistsException exception is thrown.

### DIFF
--- a/src/Exceptions/TenantDatabaseAlreadyExistsException.php
+++ b/src/Exceptions/TenantDatabaseAlreadyExistsException.php
@@ -18,8 +18,8 @@ class TenantDatabaseAlreadyExistsException extends TenantCannotBeCreatedExceptio
 
     public function __construct(string $database)
     {
-		$this->database = $database;
-		
+        $this->database = $database;
+
         parent::__construct();
     }
 }

--- a/src/Exceptions/TenantDatabaseAlreadyExistsException.php
+++ b/src/Exceptions/TenantDatabaseAlreadyExistsException.php
@@ -18,8 +18,8 @@ class TenantDatabaseAlreadyExistsException extends TenantCannotBeCreatedExceptio
 
     public function __construct(string $database)
     {
+		$this->database = $database;
+		
         parent::__construct();
-
-        $this->database = $database;
     }
 }


### PR DESCRIPTION
When TenantDatabaseAlreadyExistsException  was thrown, the reason did not display the concerned database name. This PR fixes that behavior.