### PR TITLE
Fix tenants:list when not using multi-domain tenancy

### DIFF
--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -35,7 +35,10 @@ class TenantList extends Command
             ->query()
             ->cursor()
             ->each(function (Tenant $tenant) {
-                $this->line("[Tenant] id: {$tenant['id']} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
+                $this->line(
+                    "[Tenant] id: {$tenant['id']}" .
+                    ($tenant->domains ? " @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []) : "")
+                );
             });
     }
 }

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -37,7 +37,7 @@ class TenantList extends Command
             ->each(function (Tenant $tenant) {
                 $this->line(
                     "[Tenant] id: {$tenant['id']}" .
-                    ($tenant->domains ? " @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []) : "")
+                    ($tenant->domains ? ' @ ' . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []) : '')
                 );
             });
     }

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -35,10 +35,11 @@ class TenantList extends Command
             ->query()
             ->cursor()
             ->each(function (Tenant $tenant) {
-                $this->line(
-                    "[Tenant] id: {$tenant['id']}" .
-                    ($tenant->domains ? ' @ ' . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []) : '')
-                );
+                if ($tenant->domains) {
+                    $this->line("[Tenant] id: {$tenant['id']} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
+                } else {
+                    $this->line("[Tenant] id: {$tenant['id']}");
+                }
             });
     }
 }


### PR DESCRIPTION
This is to fix the below when not using the `HasDomains` trait.

```
tenants:list
Listing all tenants.

   Error

  Call to a member function pluck() on null

  at vendor/stancl/tenancy/src/Commands/TenantList.php:38
     34▕         tenancy()
     35▕             ->query()
     36▕             ->cursor()
     37▕             ->each(function (Tenant $tenant) {
  ➜  38▕                 $this->line("[Tenant] id: {$tenant['id']} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
     39▕             });
     40▕     }
     41▕ }
     42▕
```