### PR TITLE
[3.x] Add method to run a callback on the central application

### DIFF
--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -85,6 +85,27 @@ class Tenancy
         return array_map('app', $resolve($this->tenant));
     }
 
+    /**
+     * @param callable $callback
+     * @return mixed
+     */
+    public function runGlobal(callable $callback)
+    {
+        $oldTenant = $this->tenant;
+
+        if ($this->initialized) {
+            $this->end();
+        }
+
+        $result = $callback();
+
+        if ($oldTenant) {
+            $this->initialize($oldTenant);
+        }
+
+        return $result;
+    }
+
     public function query(): Builder
     {
         return $this->model()->query();

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -86,7 +86,7 @@ class Tenancy
     }
 
     /**
-     * Run a callback using the central environment.
+     * Run a callback inside the central environment.
      *
      * @param callable $callback
      * @return mixed

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -86,6 +86,8 @@ class Tenancy
     }
 
     /**
+     * Run a callback using the central environment.
+     *
      * @param callable $callback
      * @return mixed
      */

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -89,7 +89,7 @@ class Tenancy
      * @param callable $callback
      * @return mixed
      */
-    public function runGlobal(callable $callback)
+    public function central(callable $callback)
     {
         $oldTenant = $this->tenant;
 

--- a/tests/AutomaticModeTest.php
+++ b/tests/AutomaticModeTest.php
@@ -73,7 +73,7 @@ class AutomaticModeTest extends TestCase
     }
 
     /** @test */
-    public function running_the_global_tenancy_helper_with_tenant_already_initialized()
+    public function running_the_central_tenancy_helper_with_tenant_already_initialized()
     {
         MyBootstrapper::$revertedCallCount = 0;
         GlobalRun::$count = 0;
@@ -90,7 +90,7 @@ class AutomaticModeTest extends TestCase
 
         $this->assertSame('acme', app('tenancy_initialized_for_tenant'));
 
-        tenancy()->runGlobal(function () {
+        tenancy()->central(function () {
             GlobalRun::$count = 1;
         });
 
@@ -100,7 +100,7 @@ class AutomaticModeTest extends TestCase
     }
 
     /** @test */
-    public function running_the_global_tenancy_helper_with_tenant_not_already_initialized()
+    public function running_the_central_tenancy_helper_with_tenant_not_already_initialized()
     {
         MyBootstrapper::$revertedCallCount = 0;
         GlobalRun::$count = 0;
@@ -109,7 +109,7 @@ class AutomaticModeTest extends TestCase
             MyBootstrapper::class,
         ]]);
 
-        tenancy()->runGlobal(function () {
+        tenancy()->central(function () {
             GlobalRun::$count = 1;
         });
 


### PR DESCRIPTION
Closes: https://github.com/stancl/tenancy/issues/487

I found some free time to create a helper for when a tenant has been identified and you want to run a callback on the central application.

I'm not quite sure about the naming tho: 

Other naming possiblities considered: 
- runAsCentral($callback)
- onCentral($callback)
- runCentral($callback) 