### PR TITLE
Fix issue 521: Array input for `--tenants`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,6 @@ StyleCI will flag code style violations in your pull requests.
 
 ## Running tests
 
-Run `docker-compose up-d` to start the containers. Then run `./test` to run the tests.
+Run `docker-compose up -d` to start the containers. Then run `./test` to run the tests.
 
 When you're done testing, run `docker-compose down` to shut down the containers.

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -21,7 +21,7 @@ class Run extends Command
      * @var string
      */
     protected $signature = "tenants:run {commandname : The command's name.}
-                            {--tenants= : The tenant(s) to run the command for. Default: all}
+                            {--tenants=* : The tenant(s) to run the command for. Default: all}
                             {--argument=* : The arguments to pass to the command. Default: none}
                             {--option=* : The options to pass to the command. Default: none}";
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -195,12 +195,11 @@ class CommandsTest extends TestCase
     public function run_command_with_array_of_tenants_works()
     {
         $tenantId1 = Tenant::create()->getTenantKey();
-        $tenantId2= Tenant::create()->getTenantKey();
+        $tenantId2 = Tenant::create()->getTenantKey();
         Artisan::call('tenants:migrate-fresh');
 
         $this->artisan("tenants:run foo --tenants=$tenantId1 --tenants=$tenantId2 --argument='a=foo' --option='b=bar' --option='c=xyz'")
-            ->expectsOutput("Tenant: " . $tenantId1)
-            ->expectsOutput("Tenant: " . $tenantId2);
+            ->expectsOutput('Tenant: ' . $tenantId1)
+            ->expectsOutput('Tenant: ' . $tenantId2);
     }
-
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -190,4 +190,17 @@ class CommandsTest extends TestCase
         Artisan::call('tenants:migrate-fresh');
         $this->assertFalse(DB::table('users')->exists());
     }
+
+    /** @test */
+    public function run_command_with_array_of_tenants_works()
+    {
+        $tenantId1 = Tenant::create()->getTenantKey();
+        $tenantId2= Tenant::create()->getTenantKey();
+        Artisan::call('tenants:migrate-fresh');
+
+        $this->artisan("tenants:run foo --tenants=$tenantId1 --tenants=$tenantId2 --argument='a=foo' --option='b=bar' --option='c=xyz'")
+            ->expectsOutput("Tenant: " . $tenantId1)
+            ->expectsOutput("Tenant: " . $tenantId2);
+    }
+
 }


### PR DESCRIPTION
Tenancy for Laravel docs refer to using multiple `--tenants=<...> ` options when running a command for multiple tenants explicitly: https://tenancyforlaravel.com/docs/v3/console-commands

However, the command input is not defined correctly to receive arrays.
https://laravel.com/docs/7.x/artisan#input-arrays

This PR adds a failing test, fixes the issue and corrects a typo in the contributing readme.