### PR TITLE
Add --only-selected option for tenants:migrate command

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -179,6 +179,11 @@ return [
     ],
 
     /**
+     * The class and method name used by tenants:migrate command with --only-selected option.
+     */
+    'migration_filter_tenants_method' => [\App\Repositories\TenantRepository::class, 'filterBy'],
+
+    /**
      * Parameters used by the tenants:seed command.
      */
     'seeder_parameters' => [

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -92,6 +92,25 @@ class CommandsTest extends TestCase
     }
 
     /** @test */
+    public function migrate_command_works_with_only_selected_tenants_option()
+    {
+        $tenants = [Tenant::create(), Tenant::create()];
+
+        config()->set('tenancy.migration_filter_tenants_method', [Stancl\Tenancy\Tests\Etc\Tenant::class, 'getTheFirstOne']);
+
+        Artisan::call('tenants:migrate', [
+            '--tenants' => [$tenants[0]['id'], $tenants[1]['id']],
+            '--only-selected' => true
+        ]);
+
+        tenancy()->initialize($tenants[0]);
+        $this->assertTrue(Schema::hasTable('users'));
+
+        tenancy()->initialize($tenants[1]);
+        $this->assertFalse(Schema::hasTable('users'));
+    }
+
+    /** @test */
     public function rollback_command_works()
     {
         $tenant = Tenant::create();

--- a/tests/Etc/Tenant.php
+++ b/tests/Etc/Tenant.php
@@ -12,4 +12,9 @@ use Stancl\Tenancy\Database\Models;
 class Tenant extends Models\Tenant implements TenantWithDatabase
 {
     use HasDatabase, HasDomains;
+
+    public function getTheFirstOne(array $tenantIDs = [])
+    {
+        return $tenantIDs[0];
+    }
 }


### PR DESCRIPTION
This PR is a follow-up of this issue https://github.com/stancl/tenancy-docs/issues/73#issue-689454245
In that issue, we were talking about how to skip the failing tenant migration because an exception was raised, and somehow our solution was to suppress any potential exceptions. After some consideration, I think the better solution is we provide the list of 'valid' tenants to `tenants:migrate` command (yes, as you said earlier) but we should be able to provide the list of tenants automatically instead of specifying one by one using `--tenants` option. Therefore, I added a new option `--only-selected` (suggest me if the words aren't okay); when the `tenants:migrate` runs with this option, developer can create a custom method that returns the tenant IDs that becomes a filter which tenants  are going to be migrated. For flexibility the class and method name can be configured in tenancy config `migration_filter_tenants_method`. I need this functionality to postpone the creation of the tenant database as it might be waiting for approval, and I think this method can be applied to some other cases too. 