### PR TITLE
Improve PHPUnit assertions

### DIFF
--- a/tests/AutomaticModeTest.php
+++ b/tests/AutomaticModeTest.php
@@ -45,7 +45,7 @@ class AutomaticModeTest extends TestCase
 
         tenancy()->end();
 
-        $this->assertSame(true, app('tenancy_ended'));
+        $this->assertTrue(app('tenancy_ended'));
     }
 
     /** @test */
@@ -78,7 +78,7 @@ class AutomaticModeTest extends TestCase
         tenancy()->initialize($tenant = Tenant::create());
 
         tenancy()->central(function () {
-            $this->assertSame(null, tenant());
+            $this->assertNull(tenant());
         });
 
         $this->assertSame($tenant, tenant());

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -132,7 +132,7 @@ class BootstrapperTest extends TestCase
         $this->assertSame('bar', Redis::get('foo'));
 
         tenancy()->initialize($tenant2);
-        $this->assertSame(null, Redis::get('foo'));
+        $this->assertNull(Redis::get('foo'));
         Redis::set('foo', 'xyz');
         Redis::set('abc', 'def');
         $this->assertSame('xyz', Redis::get('foo'));
@@ -140,12 +140,12 @@ class BootstrapperTest extends TestCase
 
         tenancy()->initialize($tenant1);
         $this->assertSame('bar', Redis::get('foo'));
-        $this->assertSame(null, Redis::get('abc'));
+        $this->assertNull(Redis::get('abc'));
 
         $tenant3 = Tenant::create();
         tenancy()->initialize($tenant3);
-        $this->assertSame(null, Redis::get('foo'));
-        $this->assertSame(null, Redis::get('abc'));
+        $this->assertNull(Redis::get('foo'));
+        $this->assertNull(Redis::get('abc'));
     }
 
     /** @test */

--- a/tests/EventListenerTest.php
+++ b/tests/EventListenerTest.php
@@ -62,7 +62,7 @@ class EventListenerTest extends TestCase
             return false;
         });
 
-        $this->assertSame(false, Tenant::create()->exists);
+        $this->assertFalse(Tenant::create()->exists);
         $this->assertSame(0, Tenant::count());
     }
 

--- a/tests/Features/TenantConfigTest.php
+++ b/tests/Features/TenantConfigTest.php
@@ -25,7 +25,7 @@ class TenantConfigTest extends TestCase
     /** @test */
     public function config_is_merged_and_removed()
     {
-        $this->assertSame(null, config('services.paypal'));
+        $this->assertNull(config('services.paypal'));
         config([
             'tenancy.features' => [TenantConfig::class],
             'tenancy.bootstrappers' => [],
@@ -56,7 +56,7 @@ class TenantConfigTest extends TestCase
     /** @test */
     public function the_value_can_be_set_to_multiple_config_keys()
     {
-        $this->assertSame(null, config('services.paypal'));
+        $this->assertNull(config('services.paypal'));
         config([
             'tenancy.features' => [TenantConfig::class],
             'tenancy.bootstrappers' => [],

--- a/tests/GlobalCacheTest.php
+++ b/tests/GlobalCacheTest.php
@@ -30,7 +30,7 @@ class GlobalCacheTest extends TestCase
     /** @test */
     public function global_cache_manager_stores_data_in_global_cache()
     {
-        $this->assertSame(null, cache('foo'));
+        $this->assertNull(cache('foo'));
         GlobalCache::put(['foo' => 'bar'], 1);
         $this->assertSame('bar', GlobalCache::get('foo'));
 
@@ -45,13 +45,13 @@ class GlobalCacheTest extends TestCase
         tenancy()->end();
         $this->assertSame('xyz', GlobalCache::get('abc'));
         $this->assertSame('bar', GlobalCache::get('foo'));
-        $this->assertSame(null, cache('def'));
+        $this->assertNull(cache('def'));
 
         $tenant2 = Tenant::create();
         tenancy()->initialize($tenant2);
         $this->assertSame('xyz', GlobalCache::get('abc'));
         $this->assertSame('bar', GlobalCache::get('foo'));
-        $this->assertSame(null, cache('def'));
+        $this->assertNull(cache('def'));
         cache(['def' => 'xxx'], 1);
         $this->assertSame('xxx', cache('def'));
 


### PR DESCRIPTION
# Changed log

- Using the `assertTrue` to assert expected is `true`.
- Using the `assertFalse` to assert expected is `false`.
- Using the `assertNull` to assert expected is `null`.