### PR TITLE
Feature: New PreventAccessFromTenants Middleware

### DIFF
--- a/src/Middleware/PreventAccessFromTenants.php
+++ b/src/Middleware/PreventAccessFromTenants.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class PreventAccessFromTenants
+{
+    /**
+     * Set this property if you want to customize the on-fail behavior.
+     *
+     * @var callable|null
+     */
+    public static $abortRequest;
+
+    public function handle(Request $request, Closure $next)
+    {
+        if (! in_array($request->getHost(), config('tenancy.central_domains'))) {
+            $abortRequest = static::$abortRequest ?? function () {
+                abort(404);
+            };
+
+            return $abortRequest($request, $next);
+        }
+
+        return $next($request);
+    }
+}


### PR DESCRIPTION
As discussed in #help you were looking for an additional solution to the ``domain`` functionality in routes, with this middleware which is the inverse of ``PreventAccessFromCentralDomains`` should suffice. Let me know your thoughts.