### PR TITLE
Add static variable for MiddlewareUniversalName.

### DIFF
--- a/src/Features/UniversalRoutes.php
+++ b/src/Features/UniversalRoutes.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Stancl\Tenancy\Features;
 
@@ -13,6 +13,8 @@ use Stancl\Tenancy\Tenancy;
 
 class UniversalRoutes implements Feature
 {
+    public static $middlewareUniversalName = 'universal';
+
     public static $identificationMiddlewares = [
         Middleware\InitializeTenancyByDomain::class,
         Middleware\InitializeTenancyBySubdomain::class,
@@ -22,7 +24,7 @@ class UniversalRoutes implements Feature
     {
         foreach (static::$identificationMiddlewares as $middleware) {
             $middleware::$onFail = function ($exception, $request, $next) {
-                if (static::routeHasMiddleware($request->route(), 'universal')) {
+                if (static::routeHasMiddleware($request->route(), static::$middlewareUniversalName)) {
                     return $next($request);
                 }
 
@@ -41,7 +43,7 @@ class UniversalRoutes implements Feature
         // groups have the searhced middleware group inside them
         $middlewareGroups = Router::getMiddlewareGroups();
         foreach ($route->gatherMiddleware() as $inner) {
-            if (! $inner instanceof Closure && isset($middlewareGroups[$inner]) && in_array($middleware, $middlewareGroups[$inner], true)) {
+            if (!$inner instanceof Closure && isset($middlewareGroups[$inner]) && in_array($middleware, $middlewareGroups[$inner], true)) {
                 return true;
             }
         }

--- a/src/Features/UniversalRoutes.php
+++ b/src/Features/UniversalRoutes.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Stancl\Tenancy\Features;
 
@@ -13,7 +13,7 @@ use Stancl\Tenancy\Tenancy;
 
 class UniversalRoutes implements Feature
 {
-    public static $middlewareUniversalName = 'universal';
+    public static $middlewareGroup = 'universal';
 
     public static $identificationMiddlewares = [
         Middleware\InitializeTenancyByDomain::class,
@@ -24,7 +24,7 @@ class UniversalRoutes implements Feature
     {
         foreach (static::$identificationMiddlewares as $middleware) {
             $middleware::$onFail = function ($exception, $request, $next) {
-                if (static::routeHasMiddleware($request->route(), static::$middlewareUniversalName)) {
+                if (static::routeHasMiddleware($request->route(), static::$middlewareGroup)) {
                     return $next($request);
                 }
 
@@ -43,7 +43,7 @@ class UniversalRoutes implements Feature
         // groups have the searhced middleware group inside them
         $middlewareGroups = Router::getMiddlewareGroups();
         foreach ($route->gatherMiddleware() as $inner) {
-            if (!$inner instanceof Closure && isset($middlewareGroups[$inner]) && in_array($middleware, $middlewareGroups[$inner], true)) {
+            if (! $inner instanceof Closure && isset($middlewareGroups[$inner]) && in_array($middleware, $middlewareGroups[$inner], true)) {
                 return true;
             }
         }


### PR DESCRIPTION
Hi,

I am working on a project that uses [sharp](https://github.com/code16/sharp) as the dashboard.

I need to use it both to login to the 'central' and 'tenants', and when I found the solution (use the Feature UniversalRoutes), I noticed that Sharp does not publish its route, so I found another way to solve the problem, which would be to extend the UniversalRoutes class and then change `universal` to `sharp_web` (middleware that sharp uses on all of its dashboard routes), so that I don't have to add the 'universal' class to the routes (changing something in the vendor dir or copying all the sharp routes to laravel app).

Thinking about it, I found it interesting to do this PR by creating a `public static` variable, making it possible to extend the class and then just change the middleware name to something specific (in case you happen to fall into the same problem with someone).

Sorry about my english, isn't my first language.