### PR TITLE
Check DB existsance  as config

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -39,6 +39,7 @@ return [
      * Database tenancy config. Used by DatabaseTenancyBootstrapper.
      */
     'database' => [
+        'check_db_exists' => true,
         'central_connection' => env('DB_CONNECTION', 'central'),
 
         /**

--- a/src/TenantDatabaseManagers/MySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/MySQLDatabaseManager.php
@@ -45,7 +45,11 @@ class MySQLDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return  config('tenancy.database.check_db_exists') ? (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'") : true;
+        if(config('tenancy.database.check_db_exists')) {
+            return (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'");
+        } else  {
+            return true;
+        }
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/MySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/MySQLDatabaseManager.php
@@ -45,7 +45,7 @@ class MySQLDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'");
+        return  config('tenancy.database.check_db_exists') ? (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'") : true;
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/MySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/MySQLDatabaseManager.php
@@ -45,9 +45,9 @@ class MySQLDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        if(config('tenancy.database.check_db_exists')) {
+        if (config('tenancy.database.check_db_exists')) {
             return (bool) $this->database()->select("SELECT SCHEMA_NAME FROM INFORMATION_SCHEMA.SCHEMATA WHERE SCHEMA_NAME = '$name'");
-        } else  {
+        } else {
             return true;
         }
     }

--- a/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -41,7 +41,11 @@ class PostgreSQLDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return  config('tenancy.database.check_db_exists') ? (bool)$this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'") : true;
+        if (config('tenancy.database.check_db_exists')) {
+            return (bool)$this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'");
+        } else {
+            return true;
+        }
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -42,7 +42,7 @@ class PostgreSQLDatabaseManager implements TenantDatabaseManager
     public function databaseExists(string $name): bool
     {
         if (config('tenancy.database.check_db_exists')) {
-            return (bool)$this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'");
+            return (bool) $this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'");
         } else {
             return true;
         }

--- a/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -41,7 +41,7 @@ class PostgreSQLDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return (bool) $this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'");
+        return  config('tenancy.database.check_db_exists') ? (bool)$this->database()->select("SELECT datname FROM pg_database WHERE datname = '$name'") : true;
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -41,7 +41,7 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return (bool) $this->database()->select("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$name'");
+        return  config('tenancy.database.check_db_exists') ? (bool) $this->database()->select("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$name'") : true;
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -41,7 +41,12 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return  config('tenancy.database.check_db_exists') ? (bool) $this->database()->select("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$name'") : true;
+        if(config('tenancy.database.check_db_exists')) {
+            return (bool) $this->database()->select("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$name'");
+        } else {
+            return true;
+        }
+
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -41,7 +41,7 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        if(config('tenancy.database.check_db_exists')) {
+        if (config('tenancy.database.check_db_exists')) {
             return (bool) $this->database()->select("SELECT schema_name FROM information_schema.schemata WHERE schema_name = '$name'");
         } else {
             return true;

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -46,7 +46,6 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
         } else {
             return true;
         }
-
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
+++ b/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
@@ -29,7 +29,7 @@ class SQLiteDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        if(config('tenancy.database.check_db_exists')) {
+        if (config('tenancy.database.check_db_exists')) {
             return file_exists(database_path($name));
         } else {
             return true;

--- a/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
+++ b/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
@@ -29,7 +29,7 @@ class SQLiteDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return file_exists(database_path($name));
+        return  config('tenancy.database.check_db_exists') ? file_exists(database_path($name)) : true;
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array

--- a/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
+++ b/src/TenantDatabaseManagers/SQLiteDatabaseManager.php
@@ -29,7 +29,11 @@ class SQLiteDatabaseManager implements TenantDatabaseManager
 
     public function databaseExists(string $name): bool
     {
-        return  config('tenancy.database.check_db_exists') ? file_exists(database_path($name)) : true;
+        if(config('tenancy.database.check_db_exists')) {
+            return file_exists(database_path($name));
+        } else {
+            return true;
+        }
     }
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array


### PR DESCRIPTION
I have a project with an high I/O (20/30 API requests per second) and using all the caches remains a query to the DB: the one  that check DB existence.
I would like to make optional that query since I'm the admin of the DB and I know when a DB exists or not.

I hope that it's a good feature :)