### PR TITLE
Fix arguments being initialized twice for tenants:seed command

### DIFF
--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -21,6 +21,8 @@ class Seed extends SeedCommand
      */
     protected $description = 'Seed tenant database(s).';
 
+    protected $name = 'tenants:seed';
+
     /**
      * Create a new command instance.
      *
@@ -29,9 +31,6 @@ class Seed extends SeedCommand
     public function __construct(ConnectionResolverInterface $resolver)
     {
         parent::__construct($resolver);
-
-        $this->setName('tenants:seed');
-        $this->specifyParameters();
     }
 
     /**


### PR DESCRIPTION
Laravel >= 8.32 introduced a new argument to the seed command see https://github.com/laravel/framework/pull/36513.

This is causing our extended tenants:seed command to initialize the options and arguments twice which throws an exception because at the point we call the `specifyParameters` method in the constructor it has already instanciated the arguments once so the new `class` argument is already present.

This pr fixes that by removing our call to the `specifyParameters` method on the constructor sense it's already being called in the parent constructor anyway and the only thing we are really doing is specifying one additional option to the command anyway.