### PR TITLE
Adds a new tenant resolver using request origin

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -132,6 +132,7 @@ class TenancyServiceProvider extends ServiceProvider
             // Even higher priority than the initialization middleware
             Middleware\PreventAccessFromCentralDomains::class,
 
+	        Middleware\InitializeTenancyByRequestOrigin::class,
             Middleware\InitializeTenancyByDomain::class,
             Middleware\InitializeTenancyBySubdomain::class,
             Middleware\InitializeTenancyByDomainOrSubdomain::class,

--- a/src/Database/Concerns/InvalidatesResolverCache.php
+++ b/src/Database/Concerns/InvalidatesResolverCache.php
@@ -14,6 +14,7 @@ trait InvalidatesResolverCache
         Resolvers\DomainTenantResolver::class,
         Resolvers\PathTenantResolver::class,
         Resolvers\RequestDataTenantResolver::class,
+	    Resolvers\RequestOriginTenantResolver::class
     ];
 
     public static function bootInvalidatesResolverCache()

--- a/src/Database/Concerns/InvalidatesTenantsResolverCache.php
+++ b/src/Database/Concerns/InvalidatesTenantsResolverCache.php
@@ -17,6 +17,7 @@ trait InvalidatesTenantsResolverCache
         Resolvers\DomainTenantResolver::class,
         Resolvers\PathTenantResolver::class,
         Resolvers\RequestDataTenantResolver::class,
+	    Resolvers\RequestOriginTenantResolver::class
     ];
 
     public static function bootInvalidatesTenantsResolverCache()

--- a/src/Exceptions/TenantCouldNotBeIdentifiedByRequestOriginException.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedByRequestOriginException.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Exceptions;
+
+use Facade\IgnitionContracts\BaseSolution;
+use Facade\IgnitionContracts\ProvidesSolution;
+use Facade\IgnitionContracts\Solution;
+use Stancl\Tenancy\Contracts\TenantCouldNotBeIdentifiedException;
+
+class TenantCouldNotBeIdentifiedByRequestOriginException extends TenantCouldNotBeIdentifiedException implements ProvidesSolution
+{
+    public function __construct($tenant_id)
+    {
+        parent::__construct("Tenant could not be identified by request origin with payload: $tenant_id");
+    }
+
+    public function getSolution(): Solution
+    {
+        return BaseSolution::create('Tenant could not be identified with this request origin')
+            ->setSolutionDescription('The request needs to originate from the same domain as the tenant.');
+    }
+}

--- a/src/Middleware/InitializeTenancyByRequestOrigin.php
+++ b/src/Middleware/InitializeTenancyByRequestOrigin.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Stancl\Tenancy\Tenancy;
+use Stancl\Tenancy\Resolvers\RequestOriginTenantResolver;
+
+class InitializeTenancyByRequestOrigin extends IdentificationMiddleware
+{
+	/** @var callable|null */
+    public static $onFail;
+
+    /** @var Tenancy */
+    protected $tenancy;
+
+    /** @var TenantResolver */
+    protected $resolver;
+
+    public function __construct(Tenancy $tenancy, RequestOriginTenantResolver $resolver)
+    {
+        $this->tenancy = $tenancy;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @return mixed
+     */
+    public function handle($request, Closure $next)
+    {
+	    return $this->initializeTenancy($request, $next, $this->getPayload($request));
+    }
+
+	protected function getPayload(Request $request): ?string
+	{
+		$tenant = null;
+		if ($request->hasHeader('origin')) {
+			$tenant = optional(parse_url($request->headers->get('origin')))['host'];
+		}
+
+		return $tenant;
+	}
+}

--- a/src/Middleware/InitializeTenancyByRequestOrigin.php
+++ b/src/Middleware/InitializeTenancyByRequestOrigin.php
@@ -42,7 +42,11 @@ class InitializeTenancyByRequestOrigin extends IdentificationMiddleware
 	{
 		$tenant = null;
 		if ($request->hasHeader('origin')) {
-			$tenant = optional(parse_url($request->headers->get('origin')))['host'];
+			$parts = parse_url($request->headers->get('origin'));
+			$tenant = optional($parts)['host'];
+			if (array_key_exists('port', $parts) && $tenant) {
+				$tenant .= ":{$parts['port']}";
+			}
 		}
 
 		return $tenant;

--- a/src/Resolvers/RequestOriginTenantResolver.php
+++ b/src/Resolvers/RequestOriginTenantResolver.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Resolvers;
+
+use Stancl\Tenancy\Contracts\Tenant;
+use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedByRequestOriginException;
+
+class RequestOriginTenantResolver extends Contracts\CachedTenantResolver
+{
+    /** @var bool */
+    public static $shouldCache = false;
+
+    /** @var int */
+    public static $cacheTTL = 3600; // seconds
+
+    /** @var string|null */
+    public static $cacheStore = null; // default
+
+    public function resolveWithoutCache(...$args): Tenant
+    {
+        $payload = $args[0];
+
+	    $domain = config('tenancy.domain_model')::where('domain', $payload)->first();
+
+	    if ($domain) {
+            return $domain->tenant;
+        }
+
+        throw new TenantCouldNotBeIdentifiedByRequestOriginException($payload);
+    }
+
+    public function getArgsForTenant(Tenant $tenant): array
+    {
+        return [
+            [$tenant->id],
+        ];
+    }
+}

--- a/tests/RequestOriginIdentificationTest.php
+++ b/tests/RequestOriginIdentificationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests;
+
+use Illuminate\Support\Facades\Route;
+use Stancl\Tenancy\Middleware\InitializeTenancyByRequestOrigin;
+use Stancl\Tenancy\Tests\Etc\Tenant;
+
+class RequestOriginIdentificationTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'tenancy.central_domains' => [
+                'localhost',
+            ],
+        ]);
+
+        Route::middleware(InitializeTenancyByRequestOrigin::class)->get('/test', function () {
+            return 'Tenant id: ' . tenant('id');
+        });
+    }
+
+    /** @test */
+    public function origin_identification_works()
+    {
+        $tenant = Tenant::create();
+	    $tenant->domains()->create([
+		    'domain' => 'localhost'
+	    ]);
+
+        $this
+            ->withoutExceptionHandling()
+            ->get('test', [
+                'Origin' => 'http://localhost',
+            ])
+            ->assertSee($tenant->id);
+    }
+}


### PR DESCRIPTION
Introduces a new tenant resolver using the request origin. This tenant resolver is lightweight and the perfect addition for an SPA that uses AJAX requests to a Laravel backend. By using the request origin for resolving, requests can be made without additional config on the frontend to include paths or extra request data. 