### PR TITLE
Fix issue 632: cached lookup

### DIFF
--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -38,7 +38,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
         if ($this->cache->has($key)) {
             $tenant = $this->cache->get($key);
-            $this->tenantIdentifiedFromCache($tenant, ...$args);
+            $this->tenantIdentified($tenant, ...$args);
 
             return $tenant;
         }
@@ -67,7 +67,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
     abstract public function resolveWithoutCache(...$args): Tenant;
 
-    public function tenantIdentifiedFromCache(Tenant $tenant, ...$args): void
+    public function tenantIdentified(Tenant $tenant, ...$args): void
     {
     }
 

--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -37,7 +37,10 @@ abstract class CachedTenantResolver implements TenantResolver
         $key = $this->getCacheKey(...$args);
 
         if ($this->cache->has($key)) {
-            return $this->cache->get($key);
+            $tenant = $this->cache->get($key);
+            $this->tenantIdentifiedFromCache($tenant, ...$args);
+
+            return $tenant;
         }
 
         $tenant = $this->resolveWithoutCache(...$args);
@@ -63,6 +66,10 @@ abstract class CachedTenantResolver implements TenantResolver
     }
 
     abstract public function resolveWithoutCache(...$args): Tenant;
+
+    public function tenantIdentifiedFromCache(Tenant $tenant, ...$args): void
+    {
+    }
 
     /**
      * Get all the arg combinations for resolve() that can be used to find this tenant.

--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -38,7 +38,8 @@ abstract class CachedTenantResolver implements TenantResolver
 
         if ($this->cache->has($key)) {
             $tenant = $this->cache->get($key);
-            $this->tenantIdentified($tenant, ...$args);
+
+            $this->resolved($tenant, ...$args);
 
             return $tenant;
         }
@@ -67,7 +68,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
     abstract public function resolveWithoutCache(...$args): Tenant;
 
-    public function tenantIdentified(Tenant $tenant, ...$args): void
+    public function resolved(Tenant $tenant, ...$args): void
     {
     }
 

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -43,7 +43,7 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
             ->first();
 
         /** @var Domain|null $domain */
-        $domain = $tenant?->domains->first();
+        $domain = $tenant ? $tenant->domains->first() : null;
 
         if ($domain) {
             static::$currentDomain = $domain;

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -35,15 +35,11 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
             ->whereHas('domains', function ($query) use ($domain) {
                 $query->select(['tenant_id', 'domain'])->where('domain', $domain);
             })
-            ->with([
-                'domains' => function ($query) use ($domain) {
-                    $query->where('domain', $domain);
-                },
-            ])
+            ->with('domains')
             ->first();
 
         if ($tenant) {
-            static::$currentDomain = $tenant->domains->first();
+            $this->tenantIdentified($tenant, ...$args);
 
             return $tenant;
         }
@@ -51,9 +47,9 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
         throw new TenantCouldNotBeIdentifiedOnDomainException($args[0]);
     }
 
-    public function tenantIdentifiedFromCache(Tenant $tenant, ...$args): void
+    public function tenantIdentified(Tenant $tenant, ...$args): void
     {
-        static::$currentDomain = $tenant->domains->first();
+        static::$currentDomain = $tenant->domains->where('domain', $args[0])->first();
     }
 
     public function getArgsForTenant(Tenant $tenant): array

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -33,13 +33,13 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
         /** @var Tenant|null $tenant */
         $tenant = config('tenancy.tenant_model')::query()
             ->whereHas('domains', function ($query) use ($domain) {
-                $query->select(['tenant_id', 'domain'])->where('domain', $domain);
+                $query->where('domain', $domain);
             })
             ->with('domains')
             ->first();
 
         if ($tenant) {
-            $this->tenantIdentified($tenant, ...$args);
+            $this->setCurrentDomain($tenant, ...$args);
 
             return $tenant;
         }
@@ -48,6 +48,11 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
     }
 
     public function tenantIdentified(Tenant $tenant, ...$args): void
+    {
+        $this->setCurrentDomain($tenant, ...$args);
+    }
+
+    protected function setCurrentDomain(Tenant $tenant, ...$args): void
     {
         static::$currentDomain = $tenant->domains->where('domain', $args[0])->first();
     }

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -42,11 +42,8 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
             ])
             ->first();
 
-        /** @var Domain|null $domain */
-        $domain = $tenant ? $tenant->domains->first() : null;
-
-        if ($domain) {
-            static::$currentDomain = $domain;
+        if ($tenant) {
+            static::$currentDomain = $tenant->domains->first();
 
             return $tenant;
         }

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Resolvers;
 
+use Illuminate\Database\Eloquent\Builder;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedOnDomainException;
-use Illuminate\Database\Eloquent\Builder;
 
 class DomainTenantResolver extends Contracts\CachedTenantResolver
 {


### PR DESCRIPTION
Fixes #632 

#### What I changed
https://github.com/stancl/tenancy/blob/27e9fb4a692a15ca2fd320799d97fc657cb14b68/src/Resolvers/DomainTenantResolver.php#L31-L38

Instead of querying Domain model, find Tenant and eager load its domains via Tenant model. This way, you get `$tenant`, which already has loaded `domains` relationship ~~, **with only the current domain** (Tenant can have many domains, but `$tenant->domains` will have **only the identified domain!**)~~. This reduces SQL queries and memory usage - when using cache, Domain models are loaded from cache, not from the central database. Now there is no need to access central database, if you need to get current Domain or Tenant models, or any of Tenant's domains.

~~Added a new method to `CachedTenantResolver` - `tenantIdentifiedFromCache(Tenant $tenant, ...$args)`, which is called everytime, when Tenant is identified from cache. Then it's used in resolver, to set the current domain.~~

Added a new method to `CachedTenantResolver` - `tenantIdentified(Tenant $tenant, ...$args)`, which is used to set `$currentDomain` in `DomainTenantResolver`.