### PR TITLE
Adds ability to disable tenant asset routes

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -135,6 +135,13 @@ return [
          * where you want to use tenant-specific assets (product images, avatars, etc).
          */
         'asset_helper_tenancy' => true,
+        
+        /**
+         * Should the tenant asset route be registered. This route enables you to access files
+         * in the tenant-specific storage. By default, this route is enabled. But it may
+         * be useful to disable if you use external storage (e.g. S3 or Dropbox).
+         */
+        'serve_tenant_assets' => true,
     ],
 
     /**

--- a/assets/config.php
+++ b/assets/config.php
@@ -135,13 +135,6 @@ return [
          * where you want to use tenant-specific assets (product images, avatars, etc).
          */
         'asset_helper_tenancy' => true,
-        
-        /**
-         * Should the tenant asset route be registered. This route enables you to access files
-         * in the tenant-specific storage. By default, this route is enabled. But it may
-         * be useful to disable if you use external storage (e.g. S3 or Dropbox).
-         */
-        'serve_tenant_assets' => true,
     ],
 
     /**
@@ -175,6 +168,15 @@ return [
         // Stancl\Tenancy\Features\TenantConfig::class, // https://tenancyforlaravel.com/docs/v3/features/tenant-config
         // Stancl\Tenancy\Features\CrossDomainRedirect::class, // https://tenancyforlaravel.com/docs/v3/features/cross-domain-redirect
     ],
+    
+    /**
+     * Should tenancy routes be registered. 
+     * 
+     * Tenancy routes include tenant asset routes. By default, this route is 
+     * enabled. But it may be useful to disable them if you use external 
+     * storage (e.g. S3 / Dropbox) or have a custom asset controller.
+     */
+    'routes' => true,
 
     /**
      * Parameters used by the tenants:migrate command.

--- a/assets/routes.php
+++ b/assets/routes.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 
-if (config('tenancy.filesystem.serve_tenant_assets', true)) {
-
-    Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
-        ->where('path', '(.*)')
-        ->name('stancl.tenancy.asset');
-}
+Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
+    ->where('path', '(.*)')
+    ->name('stancl.tenancy.asset');

--- a/assets/routes.php
+++ b/assets/routes.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 
-Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
-    ->where('path', '(.*)')
-    ->name('stancl.tenancy.asset');
+if (config('tenancy.serve_tenant_assets', true)) {
+
+    Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
+        ->where('path', '(.*)')
+        ->name('stancl.tenancy.asset');
+}

--- a/assets/routes.php
+++ b/assets/routes.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Route;
 
-if (config('tenancy.serve_tenant_assets', true)) {
+if (config('tenancy.filesystem.serve_tenant_assets', true)) {
 
     Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
         ->where('path', '(.*)')

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -110,7 +110,9 @@ class TenancyServiceProvider extends ServiceProvider
             __DIR__ . '/../assets/TenancyServiceProvider.stub.php' => app_path('Providers/TenancyServiceProvider.php'),
         ], 'providers');
 
-        $this->loadRoutesFrom(__DIR__ . '/../assets/routes.php');
+        if (config('tenancy.routes', true)) {
+            $this->loadRoutesFrom(__DIR__ . '/../assets/routes.php');
+        }
 
         $this->app->singleton('globalUrl', function ($app) {
             if ($app->bound(FilesystemTenancyBootstrapper::class)) {


### PR DESCRIPTION
In some cases, it may not be necessary to have a tenant asset route exposed. In such cases, it would be nice to disable the default `/tenancy/asset/{file}` route that is generated. 

This is not a breaking change as the config defaults to "true" -- as in the route is registered by default. 

```php
config('tenancy.filesystem.serve_tenant_assets', true)
```

I do not believe this needs additional testing. If it does, happy to write a test.