### PR TITLE
Set keyType to String for Tenant

### DIFF
--- a/src/Database/Models/Tenant.php
+++ b/src/Database/Models/Tenant.php
@@ -30,6 +30,7 @@ class Tenant extends Model implements Contracts\Tenant
 
     protected $table = 'tenants';
     protected $primaryKey = 'id';
+    protected $keyType = 'string';
     protected $guarded = [];
 
     public function getTenantKeyName(): string

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types = 1);
 
 namespace Stancl\Tenancy\Tests;
 
@@ -76,8 +76,8 @@ class TenantModelTest extends TestCase
         $tenant1 = Tenant::create();
         $tenant2 = Tenant::create();
 
-        $this->assertSame(1, $tenant1->id);
-        $this->assertSame(2, $tenant2->id);
+        $this->assertSame((string) 1, $tenant1->id);
+        $this->assertSame((string) 2, $tenant2->id);
     }
 
     /** @test */

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-declare (strict_types = 1);
+declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 


### PR DESCRIPTION
Got issues since last composer update with PostgreSQL and the Tenant model:

` LINE 1: select * from "domains" where "domains"."tenant_id" in (0) ^ HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts. (SQL: select * from "domains" where "domains"."tenant_id" in (0)) {"exception":"[object] (Illuminate\\Database\\QueryException(code: 42883): SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: character varying = integer LINE 1: select * from \"domains\" where \"domains\".\"tenant_id\" in (0) ^ HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts. (SQL: select * from \"domains\" where \"domains\".\"tenant_id\" in (0)) at `

Solved by setting the `keyType` to `string`.