### PR TITLE
prevent sync of non-existent column and primary key collisions

### DIFF
--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -59,7 +59,7 @@ class UpdateSyncedResource extends QueueableListener
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             } else {
                 // If the resource doesn't exist at all in the central DB,we create
-                // the record with all attributes, not just the synced ones.
+                // the record with only synced ones.
                 $centralModel = $event->model->getCentralModelName()::create($syncedAttributes);
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             }

--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -60,7 +60,7 @@ class UpdateSyncedResource extends QueueableListener
             } else {
                 // If the resource doesn't exist at all in the central DB,we create
                 // the record with all attributes, not just the synced ones.
-                $centralModel = $event->model->getCentralModelName()::create($event->model->getAttributes());
+                $centralModel = $event->model->getCentralModelName()::create($syncedAttributes);
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             }
         });


### PR DESCRIPTION
When syncing resources, this line $centralModel = $event->model->getCentralModelName()::create($event->model->getAttributes()); fails in two situations:

1. when there are column(s) in tenant table that are not in central table.
2. when there is already a row in central table with same id as the id generated while creating the model on tenant table(With ID i mean primary key which my differ from Global ID column).

With this change, only syncedAttributes will be used while creating the model on central table. unfortunatelly, with this we lose the hability to populate the row with default values and all required columns must be on $syncedAttributes, but is the only way I could get it to work.