### PR TITLE
Check cache store support for tags

### DIFF
--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -18,6 +18,7 @@ class CacheManager extends BaseCacheManager
     public function __call($method, $parameters)
     {
         $tags = [config('tenancy.cache.tag_base') . tenant()->getTenantKey()];
+        $supportTags = $this->store()->getStore() instanceof \Illuminate\Cache\TaggableStore;
 
         if ($method === 'tags') {
             if (count($parameters) !== 1) {
@@ -30,6 +31,8 @@ class CacheManager extends BaseCacheManager
             return $this->store()->tags(array_merge($tags, $names));
         }
 
-        return $this->store()->tags($tags)->$method(...$parameters);
+        return $supportTags
+            ? $this->store()->tags($tags)->$method(...$parameters)
+            : $this->store()->$method(...$parameters);
     }
 }


### PR DESCRIPTION
The issue arises when using a cache driver which doesn't support cache tags, therefore if the `tags` method wasn't explicitly called and the current cache driver doesn't support tags it shouldn't be invoked by default on all calls to mitigate any unwanted "This cache store does not support tagging." exception. 

This solves the issue for cache drivers which doesn't support tags such as the "file" driver.