### PR TITLE
Add --force option to tenants:seed Artisan call

### DIFF
--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -33,6 +33,7 @@ class SeedDatabase implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--force' => true,
         ]);
     }
 }


### PR DESCRIPTION
When creating a tenant using the SeedDatabase job in production I've been getting a `Undefined constant "STDIN"` error. Adding the --force flag to the tenants:seed resolves the issue of artisan trying to interact with the CLI when running in production (as per [Mohamed Said](https://divinglaravel.com/the-problem-behind-undefined-constant-stdin-when-running-laravel-artisan-command-programmatically)).