### PR TITLE
Prevent missing and duplicate field

### DIFF
--- a/src/Database/Models/Tenant.php
+++ b/src/Database/Models/Tenant.php
@@ -46,6 +46,15 @@ class Tenant extends Model implements Contracts\Tenant
     {
         return new TenantCollection($models);
     }
+    
+    public static function getCustomColumns(): array
+    {
+        return [
+            'id',
+            'created_at',
+            'updated_at',
+        ];
+    }
 
     protected $dispatchesEvents = [
         'saving' => Events\SavingTenant::class,


### PR DESCRIPTION
The documentation says a custom column needs to be declared in getCustomColumns function, that include 'id' (per default in Virtual Column package), 'created_at', 'updated_at'.

If  'created_at', 'updated_at' are not declare, that make a empty 'created_at' field and duplicate 'update_at' field, when created a tenant.