### PR TITLE
Add missing import for Domain model

### DIFF
--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -7,6 +7,7 @@ namespace Stancl\Tenancy;
 use Illuminate\Cache\CacheManager;
 use Illuminate\Support\ServiceProvider;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
+use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Resolvers\DomainTenantResolver;
 


### PR DESCRIPTION
I noticed there's a binding in the container for the current domain, but it's not working because the Domain class import is missing.