### PR TITLE
Change tenant connection name in DatabaseManager

### DIFF
--- a/src/Database/DatabaseManager.php
+++ b/src/Database/DatabaseManager.php
@@ -38,9 +38,9 @@ class DatabaseManager
      */
     public function connectToTenant(TenantWithDatabase $tenant)
     {
-        $this->database->purge('tenant');
+        $this->database->purge($tenant->database()->getTemplateConnectionName());
         $this->createTenantConnection($tenant);
-        $this->setDefaultConnection('tenant');
+        $this->setDefaultConnection($tenant->database()->getTemplateConnectionName());
     }
 
     /**
@@ -49,7 +49,7 @@ class DatabaseManager
     public function reconnectToCentral()
     {
         if (tenancy()->initialized) {
-            $this->database->purge('tenant');
+            $this->database->purge($tenant->database()->getTemplateConnectionName());
         }
 
         $this->setDefaultConnection($this->config->get('tenancy.database.central_connection'));
@@ -69,7 +69,7 @@ class DatabaseManager
      */
     public function createTenantConnection(TenantWithDatabase $tenant)
     {
-        $this->app['config']['database.connections.tenant'] = $tenant->database()->connection();
+        $this->app['config']['database.connections.'.$tenant->database()->getTemplateConnectionName()] = $tenant->database()->connection();
     }
 
     /**


### PR DESCRIPTION
I'm integrating with an existing project that requires the tenant connection to be called something else. I can get this working in most parts of the code, including by changing the `tenancy.database.template_tenant_connection` config value.

However the `Stancl\Tenancy\Database\DatabaseManager` class seems to hard-code the connection name, causing `SQLSTATE[3D000]: Invalid catalog name: 1046 No database selected exceptions on migration, etc.

This PR replaces the hard-coded tenant connection name with `$tenant->database()->getTemplateConnectionName()`. 

Hope that is acceptable :)