### PR TITLE
Use tenant key on console commands instead of id

### DIFF
--- a/src/Commands/Migrate.php
+++ b/src/Commands/Migrate.php
@@ -55,7 +55,7 @@ class Migrate extends MigrateCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->line("Tenant: {$tenant->getTenantKey()}");
 
             event(new MigratingDatabase($tenant));
 

--- a/src/Commands/Rollback.php
+++ b/src/Commands/Rollback.php
@@ -53,7 +53,7 @@ class Rollback extends RollbackCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->line("Tenant: {$tenant->getTenantKey()}");
 
             event(new RollingBackDatabase($tenant));
 

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -33,7 +33,7 @@ class Run extends Command
     public function handle()
     {
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->line("Tenant: {$tenant->getTenantKey()}");
             tenancy()->initialize($tenant);
 
             $callback = function ($prefix = '') {

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -51,7 +51,7 @@ class Seed extends SeedCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->line("Tenant: {$tenant->getTenantKey()}");
 
             event(new SeedingDatabase($tenant));
 

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -36,9 +36,9 @@ class TenantList extends Command
             ->cursor()
             ->each(function (Tenant $tenant) {
                 if ($tenant->domains) {
-                    $this->line("[Tenant] id: {$tenant['id']} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
+                    $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
                 } else {
-                    $this->line("[Tenant] id: {$tenant['id']}");
+                    $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}");
                 }
             });
     }


### PR DESCRIPTION
In some cases 'id' would not be used (For example, assume one has a key named slug and deleted id column, commands would not recognize tenant on console comment, this simple PR fixes that).