### PR TITLE
Remove redundant initialization

### DIFF
--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -34,7 +34,6 @@ class Run extends Command
     {
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
             $this->line("Tenant: {$tenant->getTenantKey()}");
-            tenancy()->initialize($tenant);
 
             $callback = function ($prefix = '') {
                 return function ($arguments, $argument) use ($prefix) {


### PR DESCRIPTION
I noticed the run command initializes the tenant, but the `runForMultiple` function already takes care of that which means when running `tenants:run` each tenant is initialized twice.

Please double check that I'm not changing something else by removing this.