### PR TITLE
Add --tenant option to the make:migration command

### DIFF
--- a/src/Commands/MigrateMake
+++ b/src/Commands/MigrateMake
@@ -1,0 +1,39 @@
+<?php
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Migrations\MigrationCreator;
+use Illuminate\Support\Composer;
+
+class MigrateMake extends MigrateMakeCommand
+{
+    public function __construct(MigrationCreator $creator, Composer $composer)
+    {
+        $this->signature .= '
+                {--tenant : Create migration file in the tenant migrations directory.}
+        ';
+
+        parent::__construct($creator, $composer);
+    }
+
+    /**
+     * Get migration path (either specified by '--path' option or default location).
+     *
+     * @return string
+     */
+    protected function getMigrationPath(): string
+    {
+        if (! is_null($targetPath = $this->input->getOption('path'))) {
+            return ! $this->usingRealPath()
+                ? $this->laravel->basePath().'/'.$targetPath
+                : $targetPath;
+        }
+
+        if ($this->hasOption('tenant') && $this->option('tenant')) {
+            return parent::getMigrationPath().DIRECTORY_SEPARATOR.'tenant';
+        }
+
+        return parent::getMigrationPath();
+    }
+}

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -72,6 +72,8 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->bind('globalCache', function ($app) {
             return new CacheManager($app);
         });
+        
+        $this->registerMigrateMakeCommand();
     }
 
     /**
@@ -124,6 +126,18 @@ class TenancyServiceProvider extends ServiceProvider
             }
 
             return $instance;
+        });
+    }
+    
+    
+    protected function registerMigrateMakeCommand(): void
+    {
+        $this->app->when(MigrationCreator::class)
+            ->needs('$customStubPath')
+            ->give(fn ($app) => $app->basePath('stubs'));
+
+        $this->app->singleton('command.migrate.make', function ($app) {
+            return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
         });
     }
 }

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -6,6 +6,8 @@ namespace Stancl\Tenancy;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Database\Console\Migrations\MigrateMakeCommand;
+use Illuminate\Database\Migrations\MigrationCreator;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;


### PR DESCRIPTION
Add `--tenant` option to the default MigrateMake command provided by Laravel. This option will create the migration file inside of the tenant migrations directory