### PR TITLE
Add schema dump command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG=en_GB.UTF-8
 
 # install some OS packages we need
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git
+RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git default-mysql-client
     # install php extensions
 RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     # && if [ "${PHP_VERSION}" = "7.4" ]; then docker-php-ext-configure gd --with-freetype --with-jpeg; else docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; fi \

--- a/assets/config.php
+++ b/assets/config.php
@@ -42,7 +42,8 @@ return [
         'central_connection' => env('DB_CONNECTION', 'central'),
 
         /**
-         * Connection used as a "template" for the tenant database connection.
+         * Connection used as a "template" for the dynamically created tenant database connection.
+         * Note: don't name your template connection tenant. That name is reserved by package.
          */
         'template_tenant_connection' => null,
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
         build:
             context: .
             args:
-              PHP_VERSION: ${PHP_VERSION}
+              PHP_VERSION: ${PHP_VERSION:-8.1}
         depends_on:
             mysql:
                 condition: service_healthy

--- a/src/Bootstrappers/DatabaseTenancyBootstrapper.php
+++ b/src/Bootstrappers/DatabaseTenancyBootstrapper.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy\Bootstrappers;
 
 use Stancl\Tenancy\Contracts\TenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Tenant;
+use Stancl\Tenancy\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Database\DatabaseManager;
 use Stancl\Tenancy\Exceptions\TenantDatabaseDoesNotExistException;
 

--- a/src/Bootstrappers/QueueTenancyBootstrapper.php
+++ b/src/Bootstrappers/QueueTenancyBootstrapper.php
@@ -7,7 +7,10 @@ namespace Stancl\Tenancy\Bootstrappers;
 use Illuminate\Config\Repository;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Queue\Events\JobFailed;
+use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\Events\JobRetryRequested;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Testing\Fakes\QueueFake;
 use Stancl\Tenancy\Contracts\TenancyBootstrapper;
@@ -28,7 +31,7 @@ class QueueTenancyBootstrapper implements TenancyBootstrapper
      */
     public static function __constructStatic(Application $app)
     {
-        static::setUpJobListener($app->make(Dispatcher::class));
+        static::setUpJobListener($app->make(Dispatcher::class), $app->runningUnitTests());
     }
 
     public function __construct(Repository $config, QueueManager $queue)
@@ -39,25 +42,70 @@ class QueueTenancyBootstrapper implements TenancyBootstrapper
         $this->setUpPayloadGenerator();
     }
 
-    protected static function setUpJobListener($dispatcher)
+    protected static function setUpJobListener($dispatcher, $runningTests)
     {
-        $dispatcher->listen(JobProcessing::class, function ($event) {
-            $tenantId = $event->job->payload()['tenant_id'] ?? null;
+        $previousTenant = null;
 
-            // The job is not tenant-aware
-            if (! $tenantId) {
-                return;
-            }
+        $dispatcher->listen(JobProcessing::class, function ($event) use (&$previousTenant) {
+            $previousTenant = tenant();
 
-            // Tenancy is already initialized for the tenant (e.g. dispatchNow was used)
-            if (tenancy()->initialized && tenant()->getTenantKey() === $tenantId) {
-                return;
-            }
-
-            // Tenancy was either not initialized, or initialized for a different tenant.
-            // Therefore, we initialize it for the correct tenant.
-            tenancy()->initialize(tenancy()->find($tenantId));
+            static::initializeTenancyForQueue($event->job->payload()['tenant_id'] ?? null);
         });
+
+        $dispatcher->listen(JobRetryRequested::class, function ($event) use (&$previousTenant) {
+            $previousTenant = tenant();
+
+            static::initializeTenancyForQueue($event->payload()['tenant_id'] ?? null);
+        });
+
+        // If we're running tests, we make sure to clean up after any artisan('queue:work') calls
+        $revertToPreviousState = function ($event) use (&$previousTenant, $runningTests) {
+            if ($runningTests) {
+                static::revertToPreviousState($event, $previousTenant);
+            }
+        };
+
+        $dispatcher->listen(JobProcessed::class, $revertToPreviousState); // artisan('queue:work') which succeeds
+        $dispatcher->listen(JobFailed::class, $revertToPreviousState); // artisan('queue:work') which fails
+    }
+
+    protected static function initializeTenancyForQueue($tenantId)
+    {
+        // The job is not tenant-aware
+        if (! $tenantId) {
+            return;
+        }
+
+        if (tenancy()->initialized) {
+            if (tenant()->getTenantKey() === $tenantId) {
+                // Tenancy is already initialized for the tenant (e.g. dispatchNow was used)
+                return;
+            }
+        }
+
+        // Tenancy was either not initialized, or initialized for a different tenant.
+        // Therefore, we initialize it for the correct tenant.
+        tenancy()->initialize(tenancy()->find($tenantId));
+    }
+
+    protected static function revertToPreviousState($event, &$previousTenant)
+    {
+        $tenantId = $event->job->payload()['tenant_id'] ?? null;
+
+        // The job was not tenant-aware
+        if (! $tenantId) {
+            return;
+        }
+
+        // Revert back to the previous tenant
+        if (tenant() && $previousTenant && $previousTenant->isNot(tenant())) {
+            tenancy()->initialize($previousTenant);
+        }
+
+        // End tenancy
+        if (tenant() && (! $previousTenant)) {
+            tenancy()->end();
+        }
     }
 
     protected function setUpPayloadGenerator()

--- a/src/Bootstrappers/QueueTenancyBootstrapper.php
+++ b/src/Bootstrappers/QueueTenancyBootstrapper.php
@@ -54,7 +54,7 @@ class QueueTenancyBootstrapper implements TenancyBootstrapper
         });
 
         if (Str::startsWith(app()->version(), '8')) {
-            // queue:retry tenancy is only supported in Laravel 8
+            // JobRetryRequested only exists since Laravel 8
             $dispatcher->listen(JobRetryRequested::class, function ($event) use (&$previousTenant) {
                 $previousTenant = tenant();
 

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -20,8 +20,10 @@ class CacheManager extends BaseCacheManager
         $tags = [config('tenancy.cache.tag_base') . tenant()->getTenantKey()];
 
         if ($method === 'tags') {
-            if (count($parameters) !== 1) {
-                throw new \Exception("Method tags() takes exactly 1 argument. {count($parameters)} passed.");
+            $count = count($parameters);
+            
+            if ($count !== 1) {
+                throw new \Exception("Method tags() takes exactly 1 argument. $count passed.");
             }
 
             $names = $parameters[0];

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -34,7 +34,6 @@ class Run extends Command
     {
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
             $this->line("Tenant: {$tenant->getTenantKey()}");
-            tenancy()->initialize($tenant);
 
             $callback = function ($prefix = '') {
                 return function ($arguments, $argument) use ($prefix) {

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\DumpCommand;
+use Stancl\Tenancy\Contracts\Tenant;
+use Symfony\Component\Console\Input\InputOption;
+
+class TenantDump extends DumpCommand
+{
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setName('tenants:dump');
+        $this->specifyParameters();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $connections
+     * @param \Illuminate\Contracts\Events\Dispatcher $dispatcher
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
+    {
+        $this->tenant()->run(fn() => parent::handle($connections, $dispatcher));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Get tenant to use as a template for the schema dump.
+     *
+     * @return \Stancl\Tenancy\Contracts\Tenant
+     *
+     * @throws \Throwable
+     */
+    public function tenant(): Tenant
+    {
+        $tenant = $this->option('tenant')
+            ?? tenant()
+            ?? tenancy()->query()->first()
+            ?? $this->ask('What tenant do you want to dump the schema for?');
+
+        if (! $tenant instanceof Tenant) {
+            $tenant = tenancy()->find($tenant);
+        }
+
+        throw_if(! $tenant, 'Could not identify the tenant to use for dumping the schema.');
+
+        return $tenant;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions(): array
+    {
+        return array_merge([
+            ['tenant', null, InputOption::VALUE_OPTIONAL, '', null],
+        ], parent::getOptions());
+    }
+}

--- a/src/Database/DatabaseManager.php
+++ b/src/Database/DatabaseManager.php
@@ -38,7 +38,7 @@ class DatabaseManager
      */
     public function connectToTenant(TenantWithDatabase $tenant)
     {
-        $this->database->purge('tenant');
+        $this->purgeTenantConnection();
         $this->createTenantConnection($tenant);
         $this->setDefaultConnection('tenant');
     }
@@ -48,10 +48,7 @@ class DatabaseManager
      */
     public function reconnectToCentral()
     {
-        if (tenancy()->initialized) {
-            $this->database->purge('tenant');
-        }
-
+        $this->purgeTenantConnection();
         $this->setDefaultConnection($this->config->get('tenancy.database.central_connection'));
     }
 
@@ -60,7 +57,7 @@ class DatabaseManager
      */
     public function setDefaultConnection(string $connection)
     {
-        $this->app['config']['database.default'] = $connection;
+        $this->config['database.default'] = $connection;
         $this->database->setDefaultConnection($connection);
     }
 
@@ -69,7 +66,19 @@ class DatabaseManager
      */
     public function createTenantConnection(TenantWithDatabase $tenant)
     {
-        $this->app['config']['database.connections.tenant'] = $tenant->database()->connection();
+        $this->config['database.connections.tenant'] = $tenant->database()->connection();
+    }
+
+    /**
+     * Purge the tenant database connection.
+     */
+    public function purgeTenantConnection()
+    {
+        if (array_key_exists('tenant', $this->database->getConnections())) {
+            $this->database->purge('tenant');
+        }
+
+        unset($this->config['database.connections.tenant']);
     }
 
     /**

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -66,9 +66,9 @@ class Tenancy
             return;
         }
 
-        $this->initialized = false;
-
         event(new Events\TenancyEnded($this));
+
+        $this->initialized = false;
 
         $this->tenant = null;
     }

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -87,6 +87,7 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Install::class,
             Commands\Migrate::class,
             Commands\Rollback::class,
+            Commands\TenantDump::class,
             Commands\TenantList::class,
             Commands\MigrateFresh::class,
         ]);

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -87,6 +87,7 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Seed::class,
             Commands\Install::class,
             Commands\Migrate::class,
+            Commands\Rollback::class,
             Commands\TenantList::class,
             Commands\TenantDump::class,
             Commands\MigrateFresh::class,

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy;
 
 use Illuminate\Cache\CacheManager;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;
@@ -86,11 +87,13 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Seed::class,
             Commands\Install::class,
             Commands\Migrate::class,
-            Commands\Rollback::class,
-            Commands\TenantDump::class,
             Commands\TenantList::class,
             Commands\MigrateFresh::class,
         ]);
+
+        if ((int) Str::before($this->app->version(), '.') >= 8) {
+            $this->commands([Commands\TenantDump::class]);
+        }
 
         $this->publishes([
             __DIR__ . '/../assets/config.php' => config_path('tenancy.php'),

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -88,12 +88,9 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Install::class,
             Commands\Migrate::class,
             Commands\TenantList::class,
+            Commands\TenantDump::class,
             Commands\MigrateFresh::class,
         ]);
-
-        if ((int) Str::before($this->app->version(), '.') >= 8) {
-            $this->commands([Commands\TenantDump::class]);
-        }
 
         $this->publishes([
             __DIR__ . '/../assets/config.php' => config_path('tenancy.php'),

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
 use Stancl\JobPipeline\JobPipeline;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 use Stancl\Tenancy\Events\TenancyEnded;
@@ -94,6 +95,10 @@ class CommandsTest extends TestCase
     /** @test */
     public function migrate_command_loads_schema_state()
     {
+        if ((int) Str::before($this->app->version(), '.') < 8) {
+            $this->markTestSkipped("'Laravel version doesn't support schema dumps.'");
+        }
+
         $tenant = Tenant::create();
 
         $this->assertFalse(Schema::hasTable('schema_users'));
@@ -114,6 +119,10 @@ class CommandsTest extends TestCase
     /** @test */
     public function dump_command_works()
     {
+        if ((int) Str::before($this->app->version(), '.') < 9) {
+            $this->markTestSkipped("'Laravel version doesn't support schema dumps.'");
+        }
+
         $tenant = Tenant::create();
         Artisan::call('tenants:migrate');
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -8,7 +8,6 @@ use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
 use Stancl\JobPipeline\JobPipeline;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 use Stancl\Tenancy\Events\TenancyEnded;
@@ -95,10 +94,6 @@ class CommandsTest extends TestCase
     /** @test */
     public function migrate_command_loads_schema_state()
     {
-        if ((int) Str::before($this->app->version(), '.') < 8) {
-            $this->markTestSkipped("'Laravel version doesn't support schema dumps.'");
-        }
-
         $tenant = Tenant::create();
 
         $this->assertFalse(Schema::hasTable('schema_users'));
@@ -119,10 +114,6 @@ class CommandsTest extends TestCase
     /** @test */
     public function dump_command_works()
     {
-        if ((int) Str::before($this->app->version(), '.') < 9) {
-            $this->markTestSkipped("'Laravel version doesn't support schema dumps.'");
-        }
-
         $tenant = Tenant::create();
         Artisan::call('tenants:migrate');
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -92,6 +92,38 @@ class CommandsTest extends TestCase
     }
 
     /** @test */
+    public function migrate_command_loads_schema_state()
+    {
+        $tenant = Tenant::create();
+
+        $this->assertFalse(Schema::hasTable('schema_users'));
+        $this->assertFalse(Schema::hasTable('users'));
+
+        Artisan::call('tenants:migrate --schema-path="tests/Etc/tenant-schema.dump"');
+
+        $this->assertFalse(Schema::hasTable('schema_users'));
+        $this->assertFalse(Schema::hasTable('users'));
+
+        tenancy()->initialize($tenant);
+
+        // Check for both tables to see if missing migrations also get executed.
+        $this->assertTrue(Schema::hasTable('schema_users'));
+        $this->assertTrue(Schema::hasTable('users'));
+    }
+
+    /** @test */
+    public function dump_command_works()
+    {
+        $tenant = Tenant::create();
+        Artisan::call('tenants:migrate');
+
+        tenancy()->initialize($tenant);
+
+        Artisan::call('tenants:dump --path="tests/Etc/tenant-schema-test.dump"');
+        $this->assertFileExists('tests/Etc/tenant-schema-test.dump');
+    }
+
+    /** @test */
     public function rollback_command_works()
     {
         $tenant = Tenant::create();

--- a/tests/Etc/tenant-schema.dump
+++ b/tests/Etc/tenant-schema.dump
@@ -1,0 +1,66 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `failed_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `failed_jobs` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `connection` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `queue` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` longtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `exception` longtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `failed_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `failed_jobs_uuid_unique` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `migrations` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `migration` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `batch` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `password_resets`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `password_resets` (
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  KEY `password_resets_email_index` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email_verified_at` timestamp NULL DEFAULT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `remember_token` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_email_unique` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+INSERT INTO `migrations` VALUES (2,'2014_10_12_100000_testbench_create_password_resets_table',1);
+INSERT INTO `migrations` VALUES (3,'2019_08_19_000000_testbench_create_failed_jobs_table',1);

--- a/tests/Etc/tmp/queuetest.json
+++ b/tests/Etc/tmp/queuetest.json
@@ -1,1 +1,1 @@
-{"tenant_id":"The current tenant id is: acme"}
+{"userName":"Bar","shouldFail":false,"tenant_id":"The current tenant id is: a7f73c10-9879-40ae-b7b0-1ded7c1f7b1b"}

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -5,29 +5,30 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Tests;
 
 use Exception;
+use Illuminate\Support\Str;
 use Illuminate\Bus\Queueable;
-use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\Valuestore\Valuestore;
+use Illuminate\Support\Facades\DB;
+use Stancl\Tenancy\Tests\Etc\User;
+use Stancl\JobPipeline\JobPipeline;
+use Stancl\Tenancy\Tests\Etc\Tenant;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Schema;
+use Stancl\Tenancy\Events\TenancyEnded;
+use Stancl\Tenancy\Jobs\CreateDatabase;
+use Illuminate\Queue\InteractsWithQueue;
+use Stancl\Tenancy\Events\TenantCreated;
 use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
-use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Event;
-use Illuminate\Support\Facades\Schema;
-use Spatie\Valuestore\Valuestore;
-use Stancl\JobPipeline\JobPipeline;
-use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
-use Stancl\Tenancy\Bootstrappers\QueueTenancyBootstrapper;
-use Stancl\Tenancy\Events\TenancyEnded;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Stancl\Tenancy\Events\TenancyInitialized;
-use Stancl\Tenancy\Events\TenantCreated;
-use Stancl\Tenancy\Jobs\CreateDatabase;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
 use Stancl\Tenancy\Listeners\RevertToCentralContext;
-use Stancl\Tenancy\Tests\Etc\Tenant;
-use Stancl\Tenancy\Tests\Etc\User;
+use Stancl\Tenancy\Bootstrappers\QueueTenancyBootstrapper;
+use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 
 class QueueTest extends TestCase
 {
@@ -173,6 +174,10 @@ class QueueTest extends TestCase
      */
     public function tenancy_is_initialized_when_retrying_jobs(bool $shouldEndTenancy)
     {
+        if (! Str::startsWith(app()->version(), '8')) {
+            $this->markTestSkipped('queue:retry tenancy is only supported in Laravel 8');
+        }
+
         $this->withFailedJobs();
         $this->withTenantDatabases();
 

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -57,7 +57,7 @@ class QueueTest extends TestCase
     protected function withFailedJobs()
     {
         Schema::connection('central')->create('failed_jobs', function (Blueprint $table) {
-            $table->id();
+            $table->increments('id');
             $table->string('uuid')->unique();
             $table->text('connection');
             $table->text('queue');

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -4,18 +4,30 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 
+use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Queue\Events\JobProcessing;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Spatie\Valuestore\Valuestore;
+use Stancl\JobPipeline\JobPipeline;
+use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 use Stancl\Tenancy\Bootstrappers\QueueTenancyBootstrapper;
+use Stancl\Tenancy\Events\TenancyEnded;
 use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Events\TenantCreated;
+use Stancl\Tenancy\Jobs\CreateDatabase;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
+use Stancl\Tenancy\Listeners\RevertToCentralContext;
 use Stancl\Tenancy\Tests\Etc\Tenant;
+use Stancl\Tenancy\Tests\Etc\User;
 
 class QueueTest extends TestCase
 {
@@ -31,13 +43,47 @@ class QueueTest extends TestCase
         config([
             'tenancy.bootstrappers' => [
                 QueueTenancyBootstrapper::class,
+                DatabaseTenancyBootstrapper::class,
             ],
             'queue.default' => 'redis',
         ]);
 
         Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
+        Event::listen(TenancyEnded::class, RevertToCentralContext::class);
 
         $this->valuestore = Valuestore::make(__DIR__ . '/Etc/tmp/queuetest.json')->flush();
+    }
+
+    protected function withFailedJobs()
+    {
+        Schema::connection('central')->create('failed_jobs', function (Blueprint $table) {
+            $table->id();
+            $table->string('uuid')->unique();
+            $table->text('connection');
+            $table->text('queue');
+            $table->longText('payload');
+            $table->longText('exception');
+            $table->timestamp('failed_at')->useCurrent();
+        });
+    }
+
+    protected function withUsers()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    protected function withTenantDatabases()
+    {
+        Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
+            return $event->tenant;
+        })->toListener());
     }
 
     /** @test */
@@ -49,7 +95,7 @@ class QueueTest extends TestCase
 
         tenancy()->initialize($tenant);
 
-        Event::fake([JobProcessing::class]);
+        Event::fake([JobProcessing::class, JobProcessed::class]);
 
         dispatch(new TestJob($this->valuestore));
 
@@ -79,21 +125,91 @@ class QueueTest extends TestCase
         });
     }
 
-    /** @test */
-    public function tenancy_is_initialized_inside_queues()
+    /**
+     * @test
+     *
+     * @testWith [true]
+     *           [false]
+     */
+    public function tenancy_is_initialized_inside_queues(bool $shouldEndTenancy)
     {
-        $tenant = Tenant::create([
-            'id' => 'acme',
-        ]);
+        $this->withTenantDatabases();
+        $this->withFailedJobs();
+
+        $tenant = Tenant::create();
 
         tenancy()->initialize($tenant);
 
-        dispatch(new TestJob($this->valuestore));
+        $this->withUsers();
+
+        $user = User::create(['name' => 'Foo', 'email' => 'foo@bar.com', 'password' => 'secret']);
+
+        $this->valuestore->put('userName', 'Bar');
+
+        dispatch(new TestJob($this->valuestore, $user));
 
         $this->assertFalse($this->valuestore->has('tenant_id'));
+
+        if ($shouldEndTenancy) {
+            tenancy()->end();
+        }
+
         $this->artisan('queue:work --once');
 
-        $this->assertSame('The current tenant id is: acme', $this->valuestore->get('tenant_id'));
+        $this->assertSame(0, DB::connection('central')->table('failed_jobs')->count());
+
+        $this->assertSame('The current tenant id is: ' . $tenant->id, $this->valuestore->get('tenant_id'));
+
+        $tenant->run(function () use ($user) {
+            $this->assertSame('Bar', $user->fresh()->name);
+        });
+    }
+
+    /**
+     * @test
+     *
+     * @testWith [true]
+     *           [false]
+     */
+    public function tenancy_is_initialized_when_retrying_jobs(bool $shouldEndTenancy)
+    {
+        $this->withFailedJobs();
+        $this->withTenantDatabases();
+
+        $tenant = Tenant::create();
+
+        tenancy()->initialize($tenant);
+
+        $this->withUsers();
+
+        $user = User::create(['name' => 'Foo', 'email' => 'foo@bar.com', 'password' => 'secret']);
+
+        $this->valuestore->put('userName', 'Bar');
+        $this->valuestore->put('shouldFail', true);
+
+        dispatch(new TestJob($this->valuestore, $user));
+
+        $this->assertFalse($this->valuestore->has('tenant_id'));
+
+        if ($shouldEndTenancy) {
+            tenancy()->end();
+        }
+
+        $this->artisan('queue:work --once');
+
+        $this->assertSame(1, DB::connection('central')->table('failed_jobs')->count());
+        $this->assertNull($this->valuestore->get('tenant_id')); // job failed
+
+        $this->artisan('queue:retry all');
+        $this->artisan('queue:work --once');
+
+        $this->assertSame(0, DB::connection('central')->table('failed_jobs')->count());
+
+        $this->assertSame('The current tenant id is: ' . $tenant->id, $this->valuestore->get('tenant_id')); // job succeeded
+
+        $tenant->run(function () use ($user) {
+            $this->assertSame('Bar', $user->fresh()->name);
+        });
     }
 
     /** @test */
@@ -127,13 +243,31 @@ class TestJob implements ShouldQueue
     /** @var Valuestore */
     protected $valuestore;
 
-    public function __construct(Valuestore $valuestore)
+    /** @var User|null */
+    protected $user;
+
+    public function __construct(Valuestore $valuestore, User $user = null)
     {
         $this->valuestore = $valuestore;
+        $this->user = $user;
     }
 
     public function handle()
     {
+        if ($this->valuestore->get('shouldFail')) {
+            $this->valuestore->put('shouldFail', false);
+
+            throw new Exception('failing');
+        }
+
+        if ($this->user) {
+            assert($this->user->getConnectionName() === 'tenant');
+        }
+
         $this->valuestore->put('tenant_id', 'The current tenant id is: ' . tenant('id'));
+
+        if ($userName = $this->valuestore->get('userName')) {
+            $this->user->update(['name' => $userName]);
+        }
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,11 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         if (file_exists(__DIR__ . '/../.env')) {
-            \Dotenv\Dotenv::create(__DIR__ . '/..')->load();
+            if (method_exists(\Dotenv\Dotenv::class, 'createImmutable')) {
+                \Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->load();
+            } else {
+                \Dotenv\Dotenv::create(__DIR__ . '/..')->load();
+            }
         }
 
         $app['config']->set([


### PR DESCRIPTION
Add schema dump command for the tenant context.

It accepts a tenant identifier as `tenant` option. If the option is not provided, it prompt the user for it or if there is no input, it will try to get the first tenant from the database.

Schema file will be created inside of the `database/schema` folder with the default name of `tenant-schema.sql`