### PR TITLE
Fix .env loading in development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
         "stancl/virtualcolumn": "^1.0"
     },
     "require-dev": {
-        "vlucas/phpdotenv": "^5.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
         "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0",
         "league/flysystem-aws-s3-v3": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "stancl/virtualcolumn": "^1.0"
     },
     "require-dev": {
-        "vlucas/phpdotenv": "^3.3|^4.0|^5.0",
+        "vlucas/phpdotenv": "^5.0",
         "laravel/framework": "^6.0|^7.0|^8.0",
         "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0",
         "league/flysystem-aws-s3-v3": "~1.0",

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         if (file_exists(__DIR__ . '/../.env')) {
-            \Dotenv\Dotenv::create(__DIR__ . '/..')->load();
+            \Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->load();
         }
 
         $app['config']->set([

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,11 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     protected function getEnvironmentSetUp($app)
     {
         if (file_exists(__DIR__ . '/../.env')) {
-            \Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->load();
+            if (method_exists(\Dotenv\Dotenv::class, 'createImmutable')) {
+                \Dotenv\Dotenv::createImmutable(__DIR__ . '/..')->load();
+            } else {
+                \Dotenv\Dotenv::create(__DIR__ . '/..')->load();
+            }
         }
 
         $app['config']->set([


### PR DESCRIPTION
`Dotenv::create($paths)` was the syntax for releases before v4. As it's a dev dependency, I think it's reasonable to require the latest major version at minimum.
