### PR TITLE
[WIP] Laravel 9 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,15 +3,13 @@
     "description": "Automatic multi-tenancy for your Laravel application.",
     "keywords": ["laravel", "multi-tenancy", "multi-database", "tenancy"],
     "license": "MIT",
-    "authors": [
-        {
-            "name": "Samuel Štancl",
-            "email": "samuel.stancl@gmail.com"
-        }
-    ],
+    "authors": [{
+        "name": "Samuel Štancl",
+        "email": "samuel.stancl@gmail.com"
+    }],
     "require": {
         "ext-json": "*",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "facade/ignition-contracts": "^1.0",
         "ramsey/uuid": "^3.7|^4.0",
         "stancl/jobpipeline": "^1.0",
@@ -19,10 +17,10 @@
     },
     "require-dev": {
         "vlucas/phpdotenv": "^3.3|^4.0|^5.0",
-        "laravel/framework": "^6.0|^7.0|^8.0",
-        "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0",
-        "league/flysystem-aws-s3-v3": "~1.0",
-        "doctrine/dbal": "^2.10",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0|^7.0",
+        "league/flysystem-aws-s3-v3": "~3.0",
+        "doctrine/dbal": "^2.10|^3.1.4",
         "spatie/valuestore": "^1.2.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         "vlucas/phpdotenv": "^3.3|^4.0|^5.0",
         "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
         "orchestra/testbench-browser-kit": "^7.0",
-        "league/flysystem-aws-s3-v3": "~3.0",
-        "doctrine/dbal": "^2.10|^3.1.4",
+        "league/flysystem-aws-s3-v3": "^1.0|^3.0",
+        "doctrine/dbal": "^2.10",
         "spatie/valuestore": "^1.2.5"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "vlucas/phpdotenv": "^3.3|^4.0|^5.0",
         "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
-        "orchestra/testbench-browser-kit": "^7.0",
+        "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0|^7.0",
         "league/flysystem-aws-s3-v3": "^1.0|^3.0",
         "doctrine/dbal": "^2.10",
         "spatie/valuestore": "^1.2.5"

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         "ext-json": "*",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "ramsey/uuid": "^3.7|^4.0",
-        "stancl/jobpipeline": "^1.0",
-        "stancl/virtualcolumn": "^1.0"
+        "stancl/jobpipeline": "^1.5",
+        "stancl/virtualcolumn": "^1.2"
     },
     "require-dev": {
         "vlucas/phpdotenv": "^3.3|^4.0|^5.0",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require-dev": {
         "vlucas/phpdotenv": "^3.3|^4.0|^5.0",
         "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
-        "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0|^7.0",
+        "orchestra/testbench-browser-kit": "^7.0",
         "league/flysystem-aws-s3-v3": "~3.0",
         "doctrine/dbal": "^2.10|^3.1.4",
         "spatie/valuestore": "^1.2.5"
@@ -45,6 +45,12 @@
                 "GlobalCache": "Stancl\\Tenancy\\Facades\\GlobalCache"
             }
         }
+    },
+    "scripts": {
+        "docker-up": "PHP_VERSION=8.0.11 docker-compose up -d",
+        "docker-down": "PHP_VERSION=8.0.11 docker-compose down",
+        "docker-rebuild": "PHP_VERSION=8.0.11 docker-compose up -d --no-deps --build",
+        "test": "./test"
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
     "require": {
         "ext-json": "*",
         "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
-        "facade/ignition-contracts": "^1.0",
         "ramsey/uuid": "^3.7|^4.0",
         "stancl/jobpipeline": "^1.0",
         "stancl/virtualcolumn": "^1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,6 @@ services:
         stdin_open: true
         tty: true
     mysql:
-        platform: linux/x86_64
         image: mysql:5.7
         environment:
             MYSQL_ROOT_PASSWORD: password
@@ -37,7 +36,6 @@ services:
             timeout: 10s
             retries: 10
     mysql2:
-        platform: linux/x86_64
         image: mysql:5.7
         environment:
             MYSQL_ROOT_PASSWORD: password
@@ -49,7 +47,6 @@ services:
             timeout: 10s
             retries: 10
     postgres:
-        platform: linux/x86_64
         image: postgres:11
         environment:
             POSTGRES_PASSWORD: password

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         stdin_open: true
         tty: true
     mysql:
+        platform: linux/x86_64
         image: mysql:5.7
         environment:
             MYSQL_ROOT_PASSWORD: password
@@ -36,6 +37,7 @@ services:
             timeout: 10s
             retries: 10
     mysql2:
+        platform: linux/x86_64
         image: mysql:5.7
         environment:
             MYSQL_ROOT_PASSWORD: password
@@ -47,6 +49,7 @@ services:
             timeout: 10s
             retries: 10
     postgres:
+        platform: linux/x86_64
         image: postgres:11
         environment:
             POSTGRES_PASSWORD: password

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -54,23 +54,20 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
 
         // Storage facade
+        Storage::forgetDisk($this->app['config']['tenancy.filesystem.disks']);
         foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
-            /** @var FilesystemAdapter $filesystemDisk */
-            $filesystemDisk = Storage::disk($disk);
-            $this->originalPaths['disks'][$disk] = $filesystemDisk->getAdapter()->getPathPrefix();
+            $root = $this->app['config']["filesystems.disks.{$disk}.root"];
+            $this->originalPaths['disks'][$disk] = $root;
 
-            if ($root = str_replace(
+            if (!$root = str_replace(
                 '%storage_path%',
                 storage_path(),
                 $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
             )) {
-                $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root);
-            } else {
-                $root = $this->app['config']["filesystems.disks.{$disk}.root"];
-                $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root . "/{$suffix}");
+                $root .= '/' . $suffix;
             }
 
-            $this->app['config']["filesystems.disks.{$disk}.root"] = $finalPrefix;
+            $this->app['config']["filesystems.disks.{$disk}.root"] = $root;
         }
     }
 
@@ -84,13 +81,10 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $this->app['url']->setAssetRoot($this->app['config']['app.asset_url']);
 
         // Storage facade
+
+        Storage::forgetDisk($this->app['config']['tenancy.filesystem.disks']);
         foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
-            /** @var FilesystemAdapter $filesystemDisk */
-            $filesystemDisk = Storage::disk($disk);
-
             $root = $this->originalPaths['disks'][$disk];
-
-            $filesystemDisk->getAdapter()->setPathPrefix($root);
             $this->app['config']["filesystems.disks.{$disk}.root"] = $root;
         }
     }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -64,6 +64,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 storage_path(),
                 $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
             )) {
+                $root = $this->app['config']["filesystems.disks.{$disk}.root"];
                 $root .= '/' . $suffix;
             }
 

--- a/src/Exceptions/TenantCouldNotBeIdentifiedById.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedById.php
@@ -4,25 +4,22 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Exceptions;
 
-use Facade\IgnitionContracts\BaseSolution;
-use Facade\IgnitionContracts\ProvidesSolution;
-use Facade\IgnitionContracts\Solution;
 use Stancl\Tenancy\Contracts\TenantCouldNotBeIdentifiedException;
 
 // todo: in v4 this should be suffixed with Exception
-class TenantCouldNotBeIdentifiedById extends TenantCouldNotBeIdentifiedException implements ProvidesSolution
+class TenantCouldNotBeIdentifiedById extends TenantCouldNotBeIdentifiedException
 {
     public function __construct($tenant_id)
     {
         parent::__construct("Tenant could not be identified with tenant_id: $tenant_id");
     }
 
-    public function getSolution(): Solution
-    {
-        return BaseSolution::create('Tenant could not be identified with that ID')
-            ->setSolutionDescription('Are you sure the ID is correct and the tenant exists?')
-            ->setDocumentationLinks([
-                'Initializing Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants',
-            ]);
-    }
+    // public function getSolution(): Solution
+    // {
+    //     return BaseSolution::create('Tenant could not be identified with that ID')
+    //         ->setSolutionDescription('Are you sure the ID is correct and the tenant exists?')
+    //         ->setDocumentationLinks([
+    //             'Initializing Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants',
+    //         ]);
+    // }
 }

--- a/src/Exceptions/TenantCouldNotBeIdentifiedByPathException.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedByPathException.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Exceptions;
 
-use Facade\IgnitionContracts\BaseSolution;
-use Facade\IgnitionContracts\ProvidesSolution;
-use Facade\IgnitionContracts\Solution;
 use Stancl\Tenancy\Contracts\TenantCouldNotBeIdentifiedException;
 
-class TenantCouldNotBeIdentifiedByPathException extends TenantCouldNotBeIdentifiedException implements ProvidesSolution
+class TenantCouldNotBeIdentifiedByPathException extends TenantCouldNotBeIdentifiedException
 {
     public function __construct($tenant_id)
     {
         parent::__construct("Tenant could not be identified on path with tenant_id: $tenant_id");
     }
 
-    public function getSolution(): Solution
-    {
-        return BaseSolution::create('Tenant could not be identified on this path')
-            ->setSolutionDescription('Did you forget to create a tenant for this path?')
-            ->setDocumentationLinks([
-                'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
-            ]);
-    }
+    // public function getSolution(): Solution
+    // {
+    //     return BaseSolution::create('Tenant could not be identified on this path')
+    //         ->setSolutionDescription('Did you forget to create a tenant for this path?')
+    //         ->setDocumentationLinks([
+    //             'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
+    //         ]);
+    // }
 }

--- a/src/Exceptions/TenantCouldNotBeIdentifiedByRequestDataException.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedByRequestDataException.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Exceptions;
 
-use Facade\IgnitionContracts\BaseSolution;
-use Facade\IgnitionContracts\ProvidesSolution;
-use Facade\IgnitionContracts\Solution;
 use Stancl\Tenancy\Contracts\TenantCouldNotBeIdentifiedException;
 
-class TenantCouldNotBeIdentifiedByRequestDataException extends TenantCouldNotBeIdentifiedException implements ProvidesSolution
+class TenantCouldNotBeIdentifiedByRequestDataException extends TenantCouldNotBeIdentifiedException
 {
     public function __construct($tenant_id)
     {
         parent::__construct("Tenant could not be identified by request data with payload: $tenant_id");
     }
 
-    public function getSolution(): Solution
-    {
-        return BaseSolution::create('Tenant could not be identified with this request data')
-            ->setSolutionDescription('Did you forget to create a tenant with this id?')
-            ->setDocumentationLinks([
-                'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
-            ]);
-    }
+    // public function getSolution(): Solution
+    // {
+    //     return BaseSolution::create('Tenant could not be identified with this request data')
+    //         ->setSolutionDescription('Did you forget to create a tenant with this id?')
+    //         ->setDocumentationLinks([
+    //             'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
+    //         ]);
+    // }
 }

--- a/src/Exceptions/TenantCouldNotBeIdentifiedOnDomainException.php
+++ b/src/Exceptions/TenantCouldNotBeIdentifiedOnDomainException.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Exceptions;
 
-use Facade\IgnitionContracts\BaseSolution;
-use Facade\IgnitionContracts\ProvidesSolution;
-use Facade\IgnitionContracts\Solution;
 use Stancl\Tenancy\Contracts\TenantCouldNotBeIdentifiedException;
 
-class TenantCouldNotBeIdentifiedOnDomainException extends TenantCouldNotBeIdentifiedException implements ProvidesSolution
+class TenantCouldNotBeIdentifiedOnDomainException extends TenantCouldNotBeIdentifiedException
 {
     public function __construct($domain)
     {
         parent::__construct("Tenant could not be identified on domain $domain");
     }
 
-    public function getSolution(): Solution
-    {
-        return BaseSolution::create('Tenant could not be identified on this domain')
-            ->setSolutionDescription('Did you forget to create a tenant for this domain?')
-            ->setDocumentationLinks([
-                'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
-            ]);
-    }
+    // public function getSolution(): Solution
+    // {
+    //     return BaseSolution::create('Tenant could not be identified on this domain')
+    //         ->setSolutionDescription('Did you forget to create a tenant for this domain?')
+    //         ->setDocumentationLinks([
+    //             'Creating Tenants' => 'https://tenancyforlaravel.com/docs/v3/tenants/',
+    //         ]);
+    // }
 }


### PR DESCRIPTION
Based on #654 I tried to make a compatible version with Laravel 9 with an updated Filesystem.

Only issue I have faced so far is the usage of `"facade/ignition-contracts"` since Laravel 9 uses `"spatie/laravel-ignition": "^1.0"` instead of `facade\ignition`. 

I tried to replace and update it too, but I realized that it would cause this version to be able to support only Laravel 8 & 9 with a required update to `spatie/laravel-ignition` for everyone. 

@stancl How could we solve this?