### PR TITLE
[3.x] Compatibility with Laravel 9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         php: ["7.4", "8.0"]
-        laravel: ["^6.0", "^8.0"]
+        laravel: ["^6.0", "^8.0", "^9.0"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,9 @@ jobs:
       matrix:
         php: ["7.4", "8.0"]
         laravel: ["^6.0", "^8.0", "^9.0"]
+        exclude:
+          - laravel: "^9.0"
+            php: "7.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -11,16 +11,16 @@
     ],
     "require": {
         "ext-json": "*",
-        "illuminate/support": "^6.0|^7.0|^8.0",
+        "illuminate/support": "^6.0|^7.0|^8.0|^9.0",
         "facade/ignition-contracts": "^1.0",
         "ramsey/uuid": "^3.7|^4.0",
         "stancl/jobpipeline": "^1.0",
         "stancl/virtualcolumn": "^1.0"
     },
     "require-dev": {
-        "laravel/framework": "^6.0|^7.0|^8.0",
-        "orchestra/testbench-browser-kit": "^4.0|^5.0|^6.0",
-        "league/flysystem-aws-s3-v3": "~1.0",
+        "laravel/framework": "^6.0|^7.0|^8.0|^9.0",
+        "orchestra/testbench": "^4.0|^5.0|^6.0|^7.0",
+        "league/flysystem-aws-s3-v3": "^1.0|^3.0",
         "doctrine/dbal": "^2.10",
         "spatie/valuestore": "^1.2.5"
     },

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -54,23 +54,22 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
 
         // Storage facade
-        foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
-            /** @var FilesystemAdapter $filesystemDisk */
-            $filesystemDisk = Storage::disk($disk);
-            $this->originalPaths['disks'][$disk] = $filesystemDisk->getAdapter()->getPathPrefix();
+        Storage::forgetDisk($this->app['config']['tenancy.filesystem.disks']);
 
-            if ($root = str_replace(
+        foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
+            $root = $this->app['config']->get("filesystems.disks.{$disk}.root");
+            $this->originalPaths['disks'][$disk] = $root;
+
+            if (!($root = str_replace(
                 '%storage_path%',
                 storage_path(),
                 $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
-            )) {
-                $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root);
-            } else {
-                $root = $this->app['config']["filesystems.disks.{$disk}.root"];
-                $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root . "/{$suffix}");
+            ))) {
+                $root = "{$root}/{$suffix}";
             }
 
-            $this->app['config']["filesystems.disks.{$disk}.root"] = $finalPrefix;
+            $this->app['config']["filesystems.disks.{$disk}.root"] = $root;
+
         }
     }
 
@@ -84,14 +83,9 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $this->app['url']->setAssetRoot($this->app['config']['app.asset_url']);
 
         // Storage facade
+        Storage::forgetDisk($this->app['config']['tenancy.filesystem.disks']);
         foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
-            /** @var FilesystemAdapter $filesystemDisk */
-            $filesystemDisk = Storage::disk($disk);
-
-            $root = $this->originalPaths['disks'][$disk];
-
-            $filesystemDisk->getAdapter()->setPathPrefix($root);
-            $this->app['config']["filesystems.disks.{$disk}.root"] = $root;
+            $this->app['config']["filesystems.disks.{$disk}.root"] = $this->originalPaths['disks'][$disk];
         }
     }
 }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -57,19 +57,20 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         Storage::forgetDisk($this->app['config']['tenancy.filesystem.disks']);
 
         foreach ($this->app['config']['tenancy.filesystem.disks'] as $disk) {
-            $root = $this->app['config']->get("filesystems.disks.{$disk}.root");
-            $this->originalPaths['disks'][$disk] = $root;
+            $originalRoot = $this->app['config']["filesystems.disks.{$disk}.root"];
+            $this->originalPaths['disks'][$disk] = $originalRoot;
 
-            if (!($root = str_replace(
+            $finalPrefix = str_replace(
                 '%storage_path%',
                 storage_path(),
-                $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
-            ))) {
-                $root = "{$root}/{$suffix}";
+                $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? '',
+            );
+
+            if (! $finalPrefix) {
+                $finalPrefix = $originalRoot . '/'. $suffix;
             }
 
-            $this->app['config']["filesystems.disks.{$disk}.root"] = $root;
-
+            $this->app['config']["filesystems.disks.{$disk}.root"] = $finalPrefix;
         }
     }
 

--- a/src/Middleware/CheckTenantForMaintenanceMode.php
+++ b/src/Middleware/CheckTenantForMaintenanceMode.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Middleware;
 
 use Closure;
-use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Http\Middleware\CheckForMaintenanceMode;
 use Stancl\Tenancy\Exceptions\TenancyNotInitializedException;
 use Symfony\Component\HttpFoundation\IpUtils;
@@ -29,7 +29,12 @@ class CheckTenantForMaintenanceMode extends CheckForMaintenanceMode
                 return $next($request);
             }
 
-            throw new MaintenanceModeException($data['time'], $data['retry'], $data['message']);
+            throw new HttpException(
+                503,
+                'Service Unavailable',
+                null,
+                isset($data['retry']) ? ['Retry-After' => $data['retry']] : []
+            );
         }
 
         return $next($request);

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -194,7 +194,7 @@ class BootstrapperTest extends TestCase
         // Check that disk prefixes respect the root_override logic
         $this->assertSame($expected_storage_path . '/app/', $this->getDiskPrefix('local'));
         $this->assertSame($expected_storage_path . '/app/public/', $this->getDiskPrefix('public'));
-        $this->assertSame('/tenant' . tenant('id') . '/', $this->getDiskPrefix('s3'));
+        $this->assertSame('tenant' . tenant('id') . '/', ltrim($this->getDiskPrefix('s3'), '/'));
 
         // Check suffixing logic
         $new_storage_path = storage_path();

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -4,23 +4,27 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 
-use Illuminate\Support\Facades\Cache;
+use Illuminate\Filesystem\FilesystemAdapter;
+use ReflectionObject;
+use ReflectionProperty;
+use Illuminate\Support\Str;
 use Illuminate\Support\Facades\DB;
+use Stancl\JobPipeline\JobPipeline;
+use Stancl\Tenancy\Tests\Etc\Tenant;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Redis;
 use Illuminate\Support\Facades\Storage;
-use Stancl\JobPipeline\JobPipeline;
-use Stancl\Tenancy\Bootstrappers\CacheTenancyBootstrapper;
-use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
-use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
-use Stancl\Tenancy\Bootstrappers\RedisTenancyBootstrapper;
 use Stancl\Tenancy\Events\TenancyEnded;
-use Stancl\Tenancy\Events\TenancyInitialized;
-use Stancl\Tenancy\Events\TenantCreated;
 use Stancl\Tenancy\Jobs\CreateDatabase;
+use Stancl\Tenancy\Events\TenantCreated;
+use Stancl\Tenancy\Events\TenancyInitialized;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
 use Stancl\Tenancy\Listeners\RevertToCentralContext;
-use Stancl\Tenancy\Tests\Etc\Tenant;
+use Stancl\Tenancy\Bootstrappers\CacheTenancyBootstrapper;
+use Stancl\Tenancy\Bootstrappers\RedisTenancyBootstrapper;
+use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
+use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 
 class BootstrapperTest extends TestCase
 {
@@ -165,6 +169,7 @@ class BootstrapperTest extends TestCase
         $tenant2 = Tenant::create();
 
         tenancy()->initialize($tenant1);
+
         Storage::disk('public')->put('foo', 'bar');
         $this->assertSame('bar', Storage::disk('public')->get('foo'));
 
@@ -184,9 +189,38 @@ class BootstrapperTest extends TestCase
         $this->assertFalse(Storage::disk('public')->exists('foo'));
         $this->assertFalse(Storage::disk('public')->exists('abc'));
 
+        $expected_storage_path = $old_storage_path . '/tenant' . tenant('id'); // /tenant = suffix base
+
+        // Check that disk prefixes respect the root_override logic
+        $this->assertSame($expected_storage_path . '/app/', $this->getDiskPrefix('local'));
+        $this->assertSame($expected_storage_path . '/app/public/', $this->getDiskPrefix('public'));
+        $this->assertSame('/tenant' . tenant('id') . '/', $this->getDiskPrefix('s3'));
+
         // Check suffixing logic
         $new_storage_path = storage_path();
-        $this->assertEquals($old_storage_path . '/' . config('tenancy.filesystem.suffix_base') . tenant('id'), $new_storage_path);
+        $this->assertEquals($expected_storage_path, $new_storage_path);
+    }
+
+    protected function getDiskPrefix(string $disk): string
+    {
+        /** @var FilesystemAdapter $disk */
+        $disk = Storage::disk($disk);
+        $adapter = $disk->getAdapter();
+
+        if (! Str::startsWith(app()->version(), '9.')) {
+            return $adapter->getPrefix();
+        }
+
+        $prefixer = (new ReflectionObject($adapter))->getProperty('prefixer');
+        $prefixer->setAccessible(true);
+
+        // reflection -> instance
+        $prefixer = $prefixer->getValue($adapter);
+
+        $prefix = (new ReflectionProperty($prefixer, 'prefix'));
+        $prefix->setAccessible(true);
+
+        return $prefix->getValue($prefixer);
     }
 
     // for queues see QueueTest

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -187,27 +187,6 @@ class BootstrapperTest extends TestCase
         // Check suffixing logic
         $new_storage_path = storage_path();
         $this->assertEquals($old_storage_path . '/' . config('tenancy.filesystem.suffix_base') . tenant('id'), $new_storage_path);
-
-        foreach (config('tenancy.filesystem.disks') as $disk) {
-            $suffix = config('tenancy.filesystem.suffix_base') . tenant('id');
-
-            /** @var FilesystemAdapter $filesystemDisk */
-            $filesystemDisk = Storage::disk($disk);
-
-            $current_path_prefix = $filesystemDisk->getAdapter()->getPathPrefix();
-
-            if ($override = config("tenancy.filesystem.root_override.{$disk}")) {
-                $correct_path_prefix = str_replace('%storage_path%', storage_path(), $override);
-            } else {
-                if ($base = $old_storage_facade_roots[$disk]) {
-                    $correct_path_prefix = $base . "/$suffix/";
-                } else {
-                    $correct_path_prefix = "$suffix/";
-                }
-            }
-
-            $this->assertSame($correct_path_prefix, $current_path_prefix);
-        }
     }
 
     // for queues see QueueTest

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -208,7 +208,7 @@ class BootstrapperTest extends TestCase
         $adapter = $disk->getAdapter();
 
         if (! Str::startsWith(app()->version(), '9.')) {
-            return $adapter->getPrefix();
+            return $adapter->getPathPrefix();
         }
 
         $prefixer = (new ReflectionObject($adapter))->getProperty('prefixer');

--- a/tests/Etc/ConsoleKernel.php
+++ b/tests/Etc/ConsoleKernel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests\Etc;
 
-use Orchestra\Testbench\Console\Kernel;
+use Orchestra\Testbench\Foundation\Console\Kernel;
 
 class ConsoleKernel extends Kernel
 {

--- a/tests/MaintenanceModeTest.php
+++ b/tests/MaintenanceModeTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 
+use Symfony\Component\HttpKernel\Exception\HttpException;
 use Illuminate\Foundation\Http\Exceptions\MaintenanceModeException;
 use Illuminate\Support\Facades\Route;
 use Stancl\Tenancy\Database\Concerns\MaintenanceMode;
 use Stancl\Tenancy\Middleware\CheckTenantForMaintenanceMode;
 use Stancl\Tenancy\Middleware\InitializeTenancyByDomain;
 use Stancl\Tenancy\Tests\Etc\Tenant;
+use Symfony\Component\HttpKernel\Exception\ServiceUnavailableHttpException;
 
 class MaintenanceModeTest extends TestCase
 {
@@ -32,7 +34,7 @@ class MaintenanceModeTest extends TestCase
 
         $tenant->putDownForMaintenance();
 
-        $this->expectException(MaintenanceModeException::class);
+        $this->expectException(HttpException::class);
         $this->withoutExceptionHandling()
             ->get('http://acme.localhost/foo');
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -87,6 +87,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
                 'public',
                 's3',
             ],
+            'filesystems.disks.s3.bucket' => 'foo',
             'tenancy.redis.tenancy' => env('TENANCY_TEST_REDIS_TENANCY', true),
             'database.redis.client' => env('TENANCY_TEST_REDIS_CLIENT', 'phpredis'),
             'tenancy.redis.prefixed_connections' => ['default'],


### PR DESCRIPTION
There were some more changes required before getting the package to work with Laravel 9. I've added testing on L9 to the workflow so we can be sure it's compatible before we merge.

Thank you @CodeSkills for the work in your PR. I've made sure to add you as a co-author for the commit regarding the `FilesystemTenancyBootstrapper`.