### PR TITLE
[4.x] Add tenant schema dump command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ psysh
 phpunit_var_*.xml
 coverage/
 clover.xml
+tenant-schema-test.dump

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG=en_GB.UTF-8
 
 # install some OS packages we need
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl mysql-client sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git
+RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl mariadb-client sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git
     # install php extensions
 RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     # && if [ "${PHP_VERSION}" = "7.4" ]; then docker-php-ext-configure gd --with-freetype --with-jpeg; else docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; fi \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV LANG=en_GB.UTF-8
 
 # install some OS packages we need
 RUN apt-get update
-RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git
+RUN apt-get install -y --no-install-recommends libfreetype6-dev libjpeg62-turbo-dev libpng-dev libgmp-dev libldap2-dev netcat curl mysql-client sqlite3 libsqlite3-dev libpq-dev libzip-dev unzip vim-tiny gosu git
     # install php extensions
 RUN docker-php-ext-configure pgsql -with-pgsql=/usr/local/pgsql \
     # && if [ "${PHP_VERSION}" = "7.4" ]; then docker-php-ext-configure gd --with-freetype --with-jpeg; else docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/; fi \

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\DumpCommand;
+use Stancl\Tenancy\Contracts\Tenant;
+use Symfony\Component\Console\Input\InputOption;
+
+class TenantDump extends DumpCommand
+{
+    /**
+     * Create a new command instance.
+     */
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->setName('tenants:dump');
+        $this->specifyParameters();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @param \Illuminate\Database\ConnectionResolverInterface $connections
+     * @param \Illuminate\Contracts\Events\Dispatcher $dispatcher
+     * @return int
+     *
+     * @throws \Throwable
+     */
+    public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
+    {
+        $this->tenant()->run(fn() => parent::handle($connections, $dispatcher));
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Get tenant to use as a template for the schema dump.
+     *
+     * @return \Stancl\Tenancy\Contracts\Tenant
+     *
+     * @throws \Throwable
+     */
+    public function tenant(): Tenant
+    {
+        $tenant = $this->option('tenant')
+            ?? tenant()
+            ?? tenancy()->query()->first()
+            ?? $this->ask('What tenant do you want to dump the schema for?');
+
+        if (! $tenant instanceof Tenant) {
+            $tenant = tenancy()->find($tenant);
+        }
+
+        throw_if(! $tenant, 'Could not identify the tenant to use for dumping the schema.');
+
+        return $tenant;
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions(): array
+    {
+        return array_merge([
+            ['tenant', null, InputOption::VALUE_OPTIONAL, '', null],
+        ], parent::getOptions());
+    }
+}

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -13,9 +13,6 @@ use Symfony\Component\Console\Input\InputOption;
 
 class TenantDump extends DumpCommand
 {
-    /**
-     * Create a new command instance.
-     */
     public function __construct()
     {
         parent::__construct();
@@ -24,15 +21,7 @@ class TenantDump extends DumpCommand
         $this->specifyParameters();
     }
 
-    /**
-     * Execute the console command.
-     *
-     * @param \Illuminate\Database\ConnectionResolverInterface $connections
-     * @param \Illuminate\Contracts\Events\Dispatcher $dispatcher
-     * @return int
-     *
-     * @throws \Throwable
-     */
+
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
     {
         $this->tenant()->run(fn() => parent::handle($connections, $dispatcher));
@@ -40,19 +29,12 @@ class TenantDump extends DumpCommand
         return Command::SUCCESS;
     }
 
-    /**
-     * Get tenant to use as a template for the schema dump.
-     *
-     * @return \Stancl\Tenancy\Contracts\Tenant
-     *
-     * @throws \Throwable
-     */
     public function tenant(): Tenant
     {
         $tenant = $this->option('tenant')
             ?? tenant()
-            ?? tenancy()->query()->first()
-            ?? $this->ask('What tenant do you want to dump the schema for?');
+            ?? $this->ask('What tenant do you want to dump the schema for?')
+            ?? tenancy()->query()->first();
 
         if (! $tenant instanceof Tenant) {
             $tenant = tenancy()->find($tenant);
@@ -63,11 +45,6 @@ class TenantDump extends DumpCommand
         return $tenant;
     }
 
-    /**
-     * Get the console command options.
-     *
-     * @return array
-     */
     protected function getOptions(): array
     {
         return array_merge([

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -88,6 +88,7 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Migrate::class,
             Commands\Rollback::class,
             Commands\TenantList::class,
+            Commands\TenantDump::class,
             Commands\MigrateFresh::class,
         ]);
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -92,6 +92,38 @@ class CommandsTest extends TestCase
     }
 
     /** @test */
+    public function migrate_command_loads_schema_state()
+    {
+        $tenant = Tenant::create();
+
+        $this->assertFalse(Schema::hasTable('schema_users'));
+        $this->assertFalse(Schema::hasTable('users'));
+
+        Artisan::call('tenants:migrate --schema-path="tests/Etc/tenant-schema.dump"');
+
+        $this->assertFalse(Schema::hasTable('schema_users'));
+        $this->assertFalse(Schema::hasTable('users'));
+
+        tenancy()->initialize($tenant);
+
+        // Check for both tables to see if missing migrations also get executed.
+        $this->assertTrue(Schema::hasTable('schema_users'));
+        $this->assertTrue(Schema::hasTable('users'));
+    }
+
+    /** @test */
+    public function dump_command_works()
+    {
+        $tenant = Tenant::create();
+        Artisan::call('tenants:migrate');
+
+        tenancy()->initialize($tenant);
+
+        Artisan::call('tenants:dump --path="tests/Etc/tenant-schema-test.dump"');
+        $this->assertFileExists('tests/Etc/tenant-schema-test.dump');
+    }
+
+    /** @test */
     public function rollback_command_works()
     {
         $tenant = Tenant::create();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -106,7 +106,7 @@ class CommandsTest extends TestCase
 
         tenancy()->initialize($tenant);
 
-        // Check for both tables to see if missing migrations also get executed.
+        // Check for both tables to see if missing migrations also get executed
         $this->assertTrue(Schema::hasTable('schema_users'));
         $this->assertTrue(Schema::hasTable('users'));
     }

--- a/tests/Etc/tenant-schema.dump
+++ b/tests/Etc/tenant-schema.dump
@@ -1,0 +1,66 @@
+/*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
+/*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
+/*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
+/*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
+/*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
+DROP TABLE IF EXISTS `failed_jobs`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `failed_jobs` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `uuid` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `connection` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `queue` text COLLATE utf8mb4_unicode_ci NOT NULL,
+  `payload` longtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `exception` longtext COLLATE utf8mb4_unicode_ci NOT NULL,
+  `failed_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `failed_jobs_uuid_unique` (`uuid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `migrations`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `migrations` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `migration` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `batch` int(11) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `password_resets`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `password_resets` (
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `token` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  KEY `password_resets_email_index` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+DROP TABLE IF EXISTS `users`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `schema_users` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `email_verified_at` timestamp NULL DEFAULT NULL,
+  `password` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `remember_token` varchar(100) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `created_at` timestamp NULL DEFAULT NULL,
+  `updated_at` timestamp NULL DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `users_email_unique` (`email`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+/*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
+
+/*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
+/*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
+/*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
+
+INSERT INTO `migrations` VALUES (2,'2014_10_12_100000_testbench_create_password_resets_table',1);
+INSERT INTO `migrations` VALUES (3,'2019_08_19_000000_testbench_create_failed_jobs_table',1);


### PR DESCRIPTION
Add schema dump command for the tenant context.

It accepts a tenant identifier as tenant option. If the option is not provided, it prompt the user for it or if there is no input, it will try to get the first tenant from the database.

Schema file will be created inside of the database/schema folder with the default name of tenant-schema.sql