### PR TITLE
[3.x][Filesystem] Provide an additional argument for tenant name path

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -65,7 +65,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 storage_path(),
                 $subject
             )) {
-                $root = str_replace('%tenant%', $suffix, $subject);
+                $root = str_replace('%tenant%', $suffix, $root);
                 $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root);
             } else {
                 $root = $this->app['config']["filesystems.disks.{$disk}.root"];

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -58,12 +58,14 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             /** @var FilesystemAdapter $filesystemDisk */
             $filesystemDisk = Storage::disk($disk);
             $this->originalPaths['disks'][$disk] = $filesystemDisk->getAdapter()->getPathPrefix();
+            $subject = $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? '';
 
             if ($root = str_replace(
                 '%storage_path%',
                 storage_path(),
-                $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
+                $subject
             )) {
+                $root = str_replace('%tenant%', $suffix, $subject);
                 $filesystemDisk->getAdapter()->setPathPrefix($finalPrefix = $root);
             } else {
                 $root = $this->app['config']["filesystems.disks.{$disk}.root"];


### PR DESCRIPTION
## Summary of changes
During the work of an application that uses Google Cloud Storage as the main storage method. I found that if we want to save a file without overriding the default root path for GCS, the `FilesystemTenancyBootstrapper` adds an additional folder in the GCS Filesystem called `/`.

![image](https://user-images.githubusercontent.com/46312870/156723494-3460de1f-8556-4be7-82cf-987021a1627d.png)

So I decided to pass a custom folder path.

### Case 1: using %storage_path%
If we try to use the param %storage_path% this will add the full path to our project into the GCS filesystem.
![image](https://user-images.githubusercontent.com/46312870/156723743-abe4cf68-5bfd-4103-b3f3-dc372084589a.png)

### Case 2: using a custom path without %storage_path%
I tried to pass a custom path, but this does not include the tenant folder. so the files from all tenants are mixed with each other (not expected)
![image](https://user-images.githubusercontent.com/46312870/157093971-2145c6f4-cc98-4964-9291-9c81e237083a.png)

So my resolution includes a minor update to the `$finalPrefix` variable. If we add a %tenant% variable, this will let us pass a more customizable path. So we can pass the `/a/random/path/for/my/tenant/%tenant%` path or any other path manually for each tenant in filesystems like GCS or S3