### PR TITLE
Laravel 9 support for JobRetryRequested listener

### DIFF
--- a/src/Bootstrappers/QueueTenancyBootstrapper.php
+++ b/src/Bootstrappers/QueueTenancyBootstrapper.php
@@ -63,8 +63,8 @@ class QueueTenancyBootstrapper implements TenancyBootstrapper
             static::initializeTenancyForQueue($event->job->payload()['tenant_id'] ?? null);
         });
 
-        if (Str::startsWith(app()->version(), '8')) {
-            // JobRetryRequested only exists since Laravel 8
+        if (version_compare(app()->version(), '8.64', '>=')) {
+            // JobRetryRequested only exists since Laravel 8.64
             $dispatcher->listen(JobRetryRequested::class, function ($event) use (&$previousTenant) {
                 $previousTenant = tenant();
 


### PR DESCRIPTION
The `JobRetryRequested` event is also available on Laravel 9. The current code however, only works for Laravel 8 since it checks that the version starts with "8". This PR switches the check to PHP's native `version_compare` function to check that the Laravel version is at least 8.64 (https://github.com/laravel/framework/releases/tag/v8.64.0), since that is where this event was added.