### PR TITLE
[3.x] Update PostgreSQLSchemaManager to set correct config key value

### DIFF
--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\TenantDatabaseManagers;
 
 use Illuminate\Database\Connection;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Stancl\Tenancy\Contracts\TenantDatabaseManager;
 use Stancl\Tenancy\Contracts\TenantWithDatabase;
@@ -47,8 +46,11 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array
     {
-        Arr::has($baseConfig, 'search_path') ? $baseConfig['search_path'] = $databaseName : null;
-        Arr::has($baseConfig, 'schema') ? $baseConfig['schema'] = $databaseName : null;
+        if (version_compare(app()->version(), '9.0', '>=')) {
+            $baseConfig['search_path'] = $databaseName;
+        } else {
+            $baseConfig['schema'] = $databaseName;
+        }
 
         return $baseConfig;
     }

--- a/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
+++ b/src/TenantDatabaseManagers/PostgreSQLSchemaManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\TenantDatabaseManagers;
 
 use Illuminate\Database\Connection;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\DB;
 use Stancl\Tenancy\Contracts\TenantDatabaseManager;
 use Stancl\Tenancy\Contracts\TenantWithDatabase;
@@ -46,7 +47,8 @@ class PostgreSQLSchemaManager implements TenantDatabaseManager
 
     public function makeConnectionConfig(array $baseConfig, string $databaseName): array
     {
-        $baseConfig['schema'] = $databaseName;
+        Arr::has($baseConfig, 'search_path') ? $baseConfig['search_path'] = $databaseName : null;
+        Arr::has($baseConfig, 'schema') ? $baseConfig['schema'] = $databaseName : null;
 
         return $baseConfig;
     }

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -194,7 +194,11 @@ class TenantDatabaseManagerTest extends TestCase
         ]);
         tenancy()->initialize($tenant);
 
-        $this->assertSame($tenant->database()->getName(), config('database.connections.' . config('database.default') . '.schema'));
+        if (config('database.connections.' . config('database.default') . '.search_path') !== null) {
+            $this->assertSame($tenant->database()->getName(), config('database.connections.' . config('database.default') . '.search_path'));
+        } else {
+            $this->assertSame($tenant->database()->getName(), config('database.connections.' . config('database.default') . '.schema'));
+        }
         $this->assertSame($originalDatabaseName, config(['database.connections.pgsql.database']));
     }
 

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -194,7 +194,7 @@ class TenantDatabaseManagerTest extends TestCase
         ]);
         tenancy()->initialize($tenant);
 
-        $schemaConfig = config('database.connections.' . config('database.default') . '.search_path') !== null ? 
+        $schemaConfig = version_compare(app()->version(), '9.0', '>=') ? 
             config('database.connections.' . config('database.default') . '.search_path') :
             config('database.connections.' . config('database.default') . '.schema');
 

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -194,11 +194,11 @@ class TenantDatabaseManagerTest extends TestCase
         ]);
         tenancy()->initialize($tenant);
 
-        if (config('database.connections.' . config('database.default') . '.search_path') !== null) {
-            $this->assertSame($tenant->database()->getName(), config('database.connections.' . config('database.default') . '.search_path'));
-        } else {
-            $this->assertSame($tenant->database()->getName(), config('database.connections.' . config('database.default') . '.schema'));
-        }
+        $schemaConfig = config('database.connections.' . config('database.default') . '.search_path') !== null ? 
+            config('database.connections.' . config('database.default') . '.search_path') :
+            config('database.connections.' . config('database.default') . '.schema');
+
+        $this->assertSame($tenant->database()->getName(), $schemaConfig);
         $this->assertSame($originalDatabaseName, config(['database.connections.pgsql.database']));
     }
 


### PR DESCRIPTION
In Laravel 9.0, the Postgres `schema` config key has been replaced by `search_path` (https://laravel.com/docs/9.x/upgrade#postgres-schema-configuration).

This PR updates the `PostgreSQLSchemaManager` to check which config value is in use and sets it accordingly. It might be worth setting both no matter whether the key exists or not, but I thought this would be the best solution.