### PR TITLE
Fix composer dump autoload issue on fresh installation

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -63,12 +63,12 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             $finalPrefix = str_replace(
                 '%storage_path%',
                 storage_path(),
-                $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? '',
+                $this->app['config']["tenancy.filesystem.root_override.{$disk}"] ?? ''
             );
 
-            if (! $finalPrefix) {
+            if (!$finalPrefix) {
                 $finalPrefix = $originalRoot
-                    ? rtrim($originalRoot, '/') . '/'. $suffix
+                    ? rtrim($originalRoot, '/') . '/' . $suffix
                     : $suffix;
             }
 


### PR DESCRIPTION
There was a commer after the last parameter of str_replace() on line 63 this affect composer autoload to complete after instalation


Thanks.