### PR TITLE
[4.x] Add feature that allow to determine when model is syncable

### DIFF
--- a/src/Contracts/Syncable.php
+++ b/src/Contracts/Syncable.php
@@ -15,4 +15,6 @@ interface Syncable
     public function getSyncedAttributeNames(): array;
 
     public function triggerSyncEvent();
+
+    public function isSyncEnabled();
 }

--- a/src/Database/Models/TenantPivot.php
+++ b/src/Database/Models/TenantPivot.php
@@ -16,7 +16,7 @@ class TenantPivot extends Pivot
         static::saved(function (self $pivot) {
             $parent = $pivot->pivotParent;
 
-            if ($parent instanceof Syncable) {
+            if ($parent instanceof Syncable && $parent->isSyncEnabled()) {
                 $parent->triggerSyncEvent();
             }
         });

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -90,6 +90,61 @@ class ResourceSyncingTest extends TestCase
     }
 
     /** @test */
+    public function resources_are_synced_only_sync_is_enabled()
+    {
+        CentralUser::create([
+            'global_id' => 'acme',
+            'name' => 'John Doe',
+            'email' => 'john@localhost',
+            'password' => 'secret',
+            'role' => 'commenter', // unsynced
+        ]);
+
+        $tenant = ResourceTenant::create();
+        $this->migrateTenants();
+
+        $tenant->run(function() {
+            ResourceUser::create([
+                'name' => 'Foo',
+                'email' => 'foo@email.com',
+                'password' => 'secret',
+                'global_id' => 'acme',
+                'role' => 'not_sync',
+            ]);
+        });
+
+        $centralUser = CentralUser::first();
+        $this->assertSame('John Doe',  $centralUser->name); // not sync
+        $this->assertSame('john@localhost',  $centralUser->email); // not sync
+        $this->assertSame('secret',  $centralUser->password); // not sync
+    }
+
+    /** @test */
+    public function central_users_are_synced_only_sync_is_enabled()
+    {
+        $centralUser = CentralUser::create([
+            'global_id' => 'acme',
+            'name' => 'John Doe',
+            'email' => 'john@localhost',
+            'password' => 'secret',
+            'role' => 'not_sync', // unsynced
+        ]);
+
+        $t1 = ResourceTenant::create([
+            'id' => 't1',
+        ]);
+        $this->migrateTenants();
+
+        $centralUser->tenants()->attach('t1');
+
+        $t1->run(function () {
+            // assert user not exsits
+            $this->assertCount(0, ResourceUser::all());
+        });
+
+    }
+
+    /** @test */
     public function only_the_synced_columns_are_updated_in_the_central_db()
     {
         // Create user in central DB
@@ -618,6 +673,11 @@ class CentralUser extends Model implements SyncMaster
         return static::class;
     }
 
+    public function isSyncEnabled()
+    {
+        $this->role !== 'not_sync';
+    }
+
     public function getSyncedAttributeNames(): array
     {
         return [
@@ -649,6 +709,11 @@ class ResourceUser extends Model implements Syncable
     public function getCentralModelName(): string
     {
         return CentralUser::class;
+    }
+
+    public function isSyncEnabled()
+    {
+        $this->role !== 'not_sync';
     }
 
     public function getSyncedAttributeNames(): array


### PR DESCRIPTION
Sometimes is necessary to ignore resource synchronization.
In my case, i have `contacts` in tenant tables and these contacts can be or not an user. This way, i want to synchronize with central only contacts that contains `email` attribute defined.

Using the example bellow:

```php
// Contact represents a tenant user
class Contact extends Authenticatable implements Syncable
{
    use HasFactory,       
        ResourceSyncing;

    /**
     * The attributes that are mass assignable.
     *
     * @var array<int, string>
     */
    protected $fillable = [
        'name',
        'email',
        'password'
    ];

    /**
     * The attributes that should be hidden for arrays.
     *
     * @var array<int, string>
     */
    protected $hidden = [
        'password',
        'api_token'
    ];  

    /**
     * The global identifier key value
     *
     * @return string
     */
    public function getGlobalIdentifierKey()
    {
        return $this->getAttribute($this->getGlobalIdentifierKeyName());
    }

    /**
     * The global identifier key name
     *
     * @return string
     */
    public function getGlobalIdentifierKeyName(): string
    {
        return 'email';
    }

    /**
     * The central model class
     *
     * @return string
     */
    public function getCentralModelName(): string
    {
        return CentralUser::class;
    }

    /**
     * The synced attribute names
     *
     * @return array
     */
    public function getSyncedAttributeNames(): array
    {
        return [
            'name',
            'password',
        ];
    }

    /**
     * Synchronize only contacts that have email attribute defined
     *
     * @return bool
     */
    public function isSyncEnabled(): bool
    {
        return $this->email !== null;
    }
 ```
 
 ```php
 class CentralUser extends Authenticatable implements MustVerifyEmail, SyncMaster
{
    use HasApiTokens,
        HasFactory,
        Notifiable,
        ResourceSyncing,
        CentralConnection;

    /**
     * The attributes that are mass assignable.
     *
     * @var array<int, string>
     */
    protected $fillable = [
        'name',
        'email',
        'password',
    ];

    /**
     * The attributes that should be hidden for serialization.
     *
     * @var array<int, string>
     */
    protected $hidden = [
        'password',
        'remember_token',
    ];

    /**
     * The attributes that should be cast.
     *
     * @var array<string, string>
     */
    protected $casts = [
        'email_verified_at' => 'datetime',
    ];

    /**
     * The users relationship definition
     *
     * @return BelongsToMany
     */
    public function tenants(): BelongsToMany
    {
        return $this->belongsToMany(Tenant::class, 'tenant_users', 'email', 'tenant_id', 'email')
            ->using(TenantPivot::class);
    }


    /**
     * The global identifier key value
     *
     * @return string
     */
    public function getGlobalIdentifierKey()
    {
        return $this->getAttribute($this->getGlobalIdentifierKeyName());
    }

    /**
     * The global identifier key name
     *
     * @return string
     */
    public function getGlobalIdentifierKeyName(): string
    {
        return 'email';
    }

    /**
     * The central model class
     *
     * @return string
     */
    public function getCentralModelName(): string
    {
        return static::class;
    }

    /**
     * The tenant model class
     *
     * @return string
     */
    public function getTenantModelName(): string
    {
        return Contact::class;
    }

    /**
     * The synced attribute names
     *
     * @return array
     */
    public function getSyncedAttributeNames(): array
    {
        return [
            'name',
            'password'
        ];
    }
}
```
Using:

```php

$user = CentralUser::create([
    'name' => 'Steve',
    'email' => 'steve@test.com'
]);

$user = CentralUser::create([
    'name' => 'Bill',
    'email' => 'bill@test.com'
]);

// it will not be synced
$contact = Contact::create([
     'name' => 'Steve Jobs'
]);

//it will be synced
$contact = Contact::create([
      'name' => 'Bill',
      'email' => 'bill@test.com'
]);

```
The same logic can be applyed with central user.
With this PR, is possible to determine a kind of `users` (in my case `contacts`) must be synced



