### PR TITLE
Fix ArgumentCountError on the TenantAssetsController

### DIFF
--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -15,7 +15,7 @@ class TenantAssetsController extends Controller
         $this->middleware(static::$tenancyMiddleware);
     }
 
-    public function asset($path)
+    public function asset($path = null)
     {
         try {
             return response()->file(storage_path("app/public/$path"));

--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Controllers;
 
 use Illuminate\Routing\Controller;
+use Throwable;
 
 class TenantAssetsController extends Controller
 {
@@ -17,9 +18,11 @@ class TenantAssetsController extends Controller
 
     public function asset($path = null)
     {
+        abort_if(is_null($path), 404);
+
         try {
             return response()->file(storage_path("app/public/$path"));
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             abort(404);
         }
     }

--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -18,7 +18,7 @@ class TenantAssetsController extends Controller
 
     public function asset($path = null)
     {
-        abort_if(is_null($path), 404);
+        abort_if($path === null, 404);
 
         try {
             return response()->file(storage_path("app/public/$path"));

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -34,9 +34,11 @@ class TenantAssetTest extends TestCase
     {
         parent::setUp();
 
-        config(['tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ]]);
+        config([
+            'tenancy.bootstrappers' => [
+                FilesystemTenancyBootstrapper::class,
+            ]
+        ]);
 
         Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
     }
@@ -126,4 +128,19 @@ class TenantAssetTest extends TestCase
 
         $this->assertSame($original, asset('foo'));
     }
+
+    public function test_asset_controller_returns_a_404_when_no_path_is_provided()
+    {
+        TenantAssetsController::$tenancyMiddleware = InitializeTenancyByRequestData::class;
+
+        $tenant = Tenant::create();
+
+        tenancy()->initialize($tenant);
+        $response = $this->get(tenant_asset(null), [
+            'X-Tenant' => $tenant->id,
+        ]);
+
+        $response->assertNotFound();
+    }
+
 }

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -35,8 +35,8 @@ class TenantAssetTest extends TestCase
         parent::setUp();
 
         config(['tenancy.bootstrappers' => [
-                FilesystemTenancyBootstrapper::class,
-            ]]);
+            FilesystemTenancyBootstrapper::class,
+        ]]);
 
         Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
     }

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -34,11 +34,9 @@ class TenantAssetTest extends TestCase
     {
         parent::setUp();
 
-        config([
-            'tenancy.bootstrappers' => [
+        config(['tenancy.bootstrappers' => [
                 FilesystemTenancyBootstrapper::class,
-            ]
-        ]);
+            ]]);
 
         Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
     }


### PR DESCRIPTION
When no `$path` is provided in the `tenant_asset()`, the link that is generated does not contain the `$path` part, but in the route registration {path?} is optional. This results in an `ArgumentCountError`. 

By making it default `null` it now returns an `404` as expected.