### PR TITLE
Convert newly added tests to pests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, shift-64622] # todo0 remove shift-64622 branch before merge
+    branches: [ master ]
 
 jobs:
   tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, shift-64622] # todo0 remove shift-64622 branch before merge
 
 jobs:
   tests:

--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -40,7 +40,13 @@ class TenancyServiceProvider extends ServiceProvider
             Events\TenantSaved::class => [],
             Events\UpdatingTenant::class => [],
             Events\TenantUpdated::class => [],
-            Events\DeletingTenant::class => [],
+            Events\DeletingTenant::class => [
+                JobPipeline::make([
+                    Jobs\DeleteDomains::class,
+                ])->send(function (Events\DeletingTenant $event) {
+                    return $event->tenant;
+                })->shouldBeQueued(false),
+            ],
             Events\TenantDeleted::class => [
                 JobPipeline::make([
                     Jobs\DeleteDatabase::class,

--- a/assets/migrations/2019_09_15_000020_create_domains_table.php
+++ b/assets/migrations/2019_09_15_000020_create_domains_table.php
@@ -21,7 +21,7 @@ class CreateDomainsTable extends Migration
             $table->string('tenant_id');
 
             $table->timestamps();
-            $table->foreign('tenant_id')->references('id')->on('tenants')->onUpdate('cascade')->onDelete('cascade');
+            $table->foreign('tenant_id')->references('id')->on('tenants')->onUpdate('cascade');
         });
     }
 

--- a/src/Jobs/DeleteDomains.php
+++ b/src/Jobs/DeleteDomains.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Stancl\Tenancy\Contracts\TenantWithDatabase;
+use Stancl\Tenancy\Database\Models\Domain;
+use Stancl\Tenancy\Events\DatabaseDeleted;
+use Stancl\Tenancy\Events\DeletingDatabase;
+use Stancl\Tenancy\Events\DeletingDomain;
+use Stancl\Tenancy\Events\DomainDeleted;
+
+class DeleteDomains
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    /** @var TenantWithDatabase */
+    protected $tenant;
+
+    public function __construct(TenantWithDatabase $tenant)
+    {
+        $this->tenant = $tenant;
+    }
+
+    public function handle()
+    {
+        $this->tenant->domains->each->delete();
+    }
+}

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -16,8 +16,7 @@ test('tenants can be resolved using the cached resolver', function () {
         'domain' => 'acme',
     ]);
 
-    expect($tenant->is(app(DomainTenantResolver::class)->resolve('acme')))->toBeTrue();
-    expect($tenant->is(app(DomainTenantResolver::class)->resolve('acme')))->toBeTrue();
+    expect($tenant->is(app(DomainTenantResolver::class)->resolve('acme')))->toBeTrue()->toBeTrue();
 });
 
 test('the underlying resolver is not touched when using the cached resolver', function () {

--- a/tests/DeleteDomainsJobTest.php
+++ b/tests/DeleteDomainsJobTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests;
+
+use Stancl\Tenancy\Database\Concerns\HasDomains;
+use Stancl\Tenancy\Jobs\DeleteDomains;
+
+class DeleteDomainsJobTest extends TestCase
+{
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        config(['tenancy.tenant_model' => DatabaseAndDomainTenant::class]);
+    }
+
+    /** @test */
+    public function job_delete_domains_successfully()
+    {
+        $tenant = DatabaseAndDomainTenant::create();
+
+        $tenant->domains()->create([
+            'domain' => 'foo.localhost',
+        ]);
+        $tenant->domains()->create([
+            'domain' => 'bar.localhost',
+        ]);
+
+        $this->assertSame($tenant->domains()->count(), 2);
+
+        (new DeleteDomains($tenant))->handle();
+
+        $this->assertSame($tenant->refresh()->domains()->count(), 0);
+    }
+}
+
+class DatabaseAndDomainTenant extends Etc\Tenant
+{
+    use HasDomains;
+}

--- a/tests/DeleteDomainsJobTest.php
+++ b/tests/DeleteDomainsJobTest.php
@@ -19,11 +19,11 @@ test('job delete domains successfully', function (){
         'domain' => 'bar.localhost',
     ]);
 
-    $this->assertSame($tenant->domains()->count(), 2);
+    expect($tenant->domains()->count())->toBe(2);
 
     (new DeleteDomains($tenant))->handle();
 
-    $this->assertSame($tenant->refresh()->domains()->count(), 0);
+    expect($tenant->refresh()->domains()->count())->toBe(0);
 });
 
 class DatabaseAndDomainTenant extends \Stancl\Tenancy\Tests\Etc\Tenant


### PR DESCRIPTION
- New tests added in the [[4.x] Don't use onDeleteCascade in the migrations](https://github.com/archtechx/tenancy/pull/883#issuecomment-1190135781) PR. 

- https://github.com/archtechx/tenancy/pull/884#issuecomment-1169234684 as for this review, I couldn't find many places to change Pest expectations to chains.