### PR TITLE
Put $mockConsoleOutput property back 

### DIFF
--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -23,6 +23,8 @@ use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 
 beforeEach(function () {
+    $this->mockConsoleOutput = false;
+
     Event::listen(
         TenantCreated::class,
         JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -27,6 +27,8 @@ use Stancl\Tenancy\Bootstrappers\QueueTenancyBootstrapper;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 
 beforeEach(function () {
+    $this->mockConsoleOutput = false;
+
     config([
         'tenancy.bootstrappers' => [
             QueueTenancyBootstrapper::class,


### PR DESCRIPTION
This PR adds back the `mockConsoleOutput` property in relevant test files, which got removed from #884 PR. 