### PR TITLE
Improve `tenants:run` command

### DIFF
--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -21,7 +21,7 @@ class Run extends Command
      *
      * @var string
      */
-    protected $signature = "tenants:run {commandname : The command's name.}
+    protected $signature = "tenants:run {commandname : The artisan command.}
                             {--tenants=* : The tenant(s) to run the command for. Default: all}";
 
     /**

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Artisan;
 
 class Run extends Command
 {
@@ -21,9 +22,7 @@ class Run extends Command
      * @var string
      */
     protected $signature = "tenants:run {commandname : The command's name.}
-                            {--tenants=* : The tenant(s) to run the command for. Default: all}
-                            {--argument=* : The arguments to pass to the command. Default: none}
-                            {--option=* : The options to pass to the command. Default: none}";
+                            {--tenants=* : The tenant(s) to run the command for. Default: all}";
 
     /**
      * Execute the console command.
@@ -33,23 +32,9 @@ class Run extends Command
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
             $this->line("Tenant: {$tenant->getTenantKey()}");
 
-            $callback = function ($prefix = '') {
-                return function ($arguments, $argument) use ($prefix) {
-                    [$key, $value] = explode('=', $argument, 2);
-                    $arguments[$prefix . $key] = $value;
-
-                    return $arguments;
-                };
-            };
-
-            // Turns ['foo=bar', 'abc=xyz=zzz'] into ['foo' => 'bar', 'abc' => 'xyz=zzz']
-            $arguments = array_reduce($this->option('argument'), $callback(), []);
-
-            // Turns ['foo=bar', 'abc=xyz=zzz'] into ['--foo' => 'bar', '--abc' => 'xyz=zzz']
-            $options = array_reduce($this->option('option'), $callback('--'), []);
-
-            // Run command
-            $this->call($this->argument('commandname'), array_merge($arguments, $options));
+            Artisan::call($this->argument('commandname'));
+            $this->comment('Command output:');
+            $this->info(Artisan::output());
         });
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -174,7 +174,7 @@ test('run command with array of tenants works', function () {
     $tenantId2 = Tenant::create()->getTenantKey();
     Artisan::call('tenants:migrate-fresh');
 
-    pest()->artisan("tenants:run foo --tenants=$tenantId1 --tenants=$tenantId2 --argument='a=foo' --option='b=bar' --option='c=xyz'")
+    pest()->artisan("tenants:run --tenants=$tenantId1 --tenants=$tenantId2 'foo foo --b=bar --c=xyz'")
         ->expectsOutput('Tenant: ' . $tenantId1)
         ->expectsOutput('Tenant: ' . $tenantId2);
 });
@@ -186,7 +186,7 @@ function runCommandWorks(): void
 
     Artisan::call('tenants:migrate', ['--tenants' => [$id]]);
 
-    pest()->artisan("tenants:run foo --tenants=$id --argument='a=foo' --option='b=bar' --option='c=xyz'")
+    pest()->artisan("tenants:run --tenants=$id 'foo foo --b=bar --c=xyz' ")
         ->expectsOutput("User's name is Test command")
         ->expectsOutput('foo')
         ->expectsOutput('xyz');


### PR DESCRIPTION
PR improves the `tenants:run` command. Let's say we want to run the `route:list` command for tenant(s). 

**Current**
`php artisan tenants:run --tenants=xxxxx route:list --option="except-vendor" --option="sort=name" `

**PR proposed**
`php artisan tenants:run --tenants=xxxxx "route:list --except-vendor --sort=name"`

This allows to copy any existing command mentioned in docs and elsewhere simply. PR originally addressed the issue https://github.com/archtechx/tenancy/issues/686.

**Output**
I'm using `Artisan::call` instead of `$this->call` to avoid complex arguments/options extraction and prepare them ecactly as needed for `$this->call` function. 
So using `Artisan::call` is simple. We print the command output, but we lost the command's original colors, and I think that's fine. 
<img width="964" alt="image" src="https://user-images.githubusercontent.com/54532330/182602972-f12575f3-fe32-4bfd-b7cc-499adc64e0a4.png">
