### PR TITLE
[4.x] Add `tenant_path_route`

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Stancl\Tenancy\Contracts\Tenant;
+use Stancl\Tenancy\Resolvers\PathTenantResolver;
 use Stancl\Tenancy\Tenancy;
 
 if (! function_exists('tenancy')) {
@@ -59,11 +60,23 @@ if (! function_exists('global_cache')) {
 if (! function_exists('tenant_route')) {
     function tenant_route(string $domain, $route, $parameters = [], $absolute = true)
     {
-        // replace first occurance of hostname fragment with $domain
+        // replace first occurrence of hostname fragment with $domain
         $url = route($route, $parameters, $absolute);
         $hostname = parse_url($url, PHP_URL_HOST);
         $position = strpos($url, $hostname);
 
         return substr_replace($url, $domain, $position, strlen($hostname));
+    }
+}
+
+if (! function_exists('tenant_path_route')) {
+    function tenant_path_route($route, $parameters = [])
+    {
+        if (! array_key_exists(PathTenantResolver::$tenantParameterName, $parameters)) {
+            $parameters[PathTenantResolver::$tenantParameterName] = optional(tenant())->getTenantKey();
+        }
+        dd($parameters);
+
+        return route($route, $parameters);
     }
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -70,13 +70,12 @@ if (! function_exists('tenant_route')) {
 }
 
 if (! function_exists('tenant_path_route')) {
-    function tenant_path_route($route, $parameters = [])
+    function tenant_path_route(string $route, array $parameters = [], bool $absolute = true): string
     {
         if (! array_key_exists(PathTenantResolver::$tenantParameterName, $parameters)) {
             $parameters[PathTenantResolver::$tenantParameterName] = optional(tenant())->getTenantKey();
         }
-        dd($parameters);
 
-        return route($route, $parameters);
+        return route($route, $parameters, $absolute);
     }
 }

--- a/tests/PathIdentificationTest.php
+++ b/tests/PathIdentificationTest.php
@@ -18,7 +18,7 @@ beforeEach(function () {
     ], function () {
         Route::get('/foo/{a}/{b}', function ($a, $b) {
             return "$a + $b";
-        });
+        })->name('foo');
     });
 });
 
@@ -122,4 +122,15 @@ test('tenant parameter name can be customized', function () {
     $this
         ->withoutExceptionHandling()
         ->get('/acme/foo/abc/xyz');
+});
+
+test('tenant path route helper function test', function () {
+    Tenant::create([
+        'id' => 'acme',
+    ]);
+
+    pest()->get( tenant_path_route('foo', ['a' => 'a', 'b' => 'b']));
+
+    expect(tenancy()->initialized)->toBeTrue();
+    expect(tenant('id'))->toBe('acme');
 });

--- a/tests/PathIdentificationTest.php
+++ b/tests/PathIdentificationTest.php
@@ -124,13 +124,22 @@ test('tenant parameter name can be customized', function () {
         ->get('/acme/foo/abc/xyz');
 });
 
-test('tenant path route helper function test', function () {
-    Tenant::create([
+test('tenant path route helper adds the tenant parameter', function () {
+    $tenant = Tenant::create([
         'id' => 'acme',
     ]);
 
-    pest()->get( tenant_path_route('foo', ['a' => 'a', 'b' => 'b']));
+    tenancy()->initialize($tenant);
 
-    expect(tenancy()->initialized)->toBeTrue();
-    expect(tenant('id'))->toBe('acme');
+    expect(tenant_path_route('foo', ['a' => 'bar', 'b' => 'boo']))->toBe('http://localhost/acme/foo/bar/boo');
+});
+
+test('tenant path route helper does not override the parameter if passed by developer', function () {
+    $tenant = Tenant::create([
+        'id' => 'acme',
+    ]);
+
+    tenancy()->initialize($tenant);
+
+    expect(tenant_path_route('foo', ['tenant' => $tenant->getTenantKey(), 'a' => 'bar', 'b' => 'boo']))->toBe('http://localhost/acme/foo/bar/boo');
 });


### PR DESCRIPTION
This PR adds the helper function, which automatically passes the tenant parameter. 
**Before**
`route('my-route-name', ['tenant' => tenant(), 'my-app-param' => 'foo'])`

**After**
`tenant_path_route('my-route-name', ['my-app-param' => 'foo'])`