### PR TITLE
Adding a new session value 'tenancy_impersonated_by' when you are impersonating a tenant.

### DIFF
--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -52,6 +52,10 @@ class UserImpersonation implements Feature
         Auth::guard($token->auth_guard)->loginUsingId($token->user_id);
 
         $token->delete();
+        
+        session()->put(
+            'tenancy_impersonated_by', Auth::user()?->getAuthIdentifier()
+        );
 
         return redirect($token->redirect_url);
     }

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -54,7 +54,7 @@ class UserImpersonation implements Feature
         $token->delete();
         
         session()->put(
-            'tenancy_impersonated_by', Auth::user()?->getAuthIdentifier()
+            'tenancy_impersonated_by', optional(Auth::user())->getAuthIdentifier()
         );
 
         return redirect($token->redirect_url);


### PR DESCRIPTION
This PR adds a new session value `tenancy_impersonated_by` in the tenant scope when you are impersonating a tenant.

This is similar to how Laravel Nova adds the `nova_impersonated_by session` value and could be used to identify when you are impersonating, who is impersonating. This may be useful for additional application logic and UI niceties such as an impersonation banner.