### PR TITLE
Add support for nested tenant config override

### DIFF
--- a/src/Features/TenantConfig.php
+++ b/src/Features/TenantConfig.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy\Features;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Stancl\Tenancy\Contracts\Feature;
 use Stancl\Tenancy\Contracts\Tenant;
@@ -45,7 +46,7 @@ class TenantConfig implements Feature
     {
         /** @var Tenant|Model $tenant */
         foreach (static::$storageToConfigMap as $storageKey => $configKey) {
-            $override = $tenant->getAttribute($storageKey);
+            $override = Arr::get($tenant, $storageKey);
 
             if (! is_null($override)) {
                 if (is_array($configKey)) {


### PR DESCRIPTION
This PR adds the ability to assign from nested JSON values on the Tenant model while staying backwards compatible with the existing implementation.

Essentially eloquent's model `getAttribute` is replaced with the Laravel helper function `Arr::get` when the values are extracted from the tenent model which allows for dot notated paths to be used to map nested JSON values.

For example this allows implementations such as the following
```php
\Stancl\Tenancy\Features\TenantConfig::$storageToConfigMap = [
    'whitelabel.config.theme' => 'whitelabel.theme',
];
```
