### PR TITLE
[4.x] Fix exception solutions were not showing 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^8.1",
         "ext-json": "*",
         "illuminate/support": "^9.0",
-        "facade/ignition-contracts": "^1.0",
+        "spatie/ignition": "^1.4",
         "ramsey/uuid": "^4.0",
         "stancl/jobpipeline": "^1.0",
         "stancl/virtualcolumn": "^1.0"

--- a/src/Contracts/TenantCouldNotBeIdentifiedException.php
+++ b/src/Contracts/TenantCouldNotBeIdentifiedException.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Contracts;
 
 use Exception;
-use Facade\IgnitionContracts\BaseSolution;
-use Facade\IgnitionContracts\ProvidesSolution;
-use Facade\IgnitionContracts\Solution;
+use Spatie\Ignition\Contracts\BaseSolution;
+use Spatie\Ignition\Contracts\ProvidesSolution;
 
 abstract class TenantCouldNotBeIdentifiedException extends Exception implements ProvidesSolution
 {
@@ -42,7 +41,7 @@ abstract class TenantCouldNotBeIdentifiedException extends Exception implements 
     }
 
     /** Get the Ignition description. */
-    public function getSolution(): Solution
+    public function getSolution(): BaseSolution
     {
         return BaseSolution::create($this->solutionTitle)
             ->setSolutionDescription($this->solutionDescription)


### PR DESCRIPTION
This PR removed the `facade/ignition-contracts` package in the favour of `spatie/ignition`. 

**Why**
Exceptions were not showing solutions because in Laravel 9, they changed the structure of these repos (part of it is that Ignition got moved under Spatie namespace from Facade). for example
![image](https://user-images.githubusercontent.com/54532330/187422379-c0b5b9d1-7007-4a0c-b94b-8c0276ec82a7.png)


**After** installing the `spatie/ignition`.
<img width="1367" alt="Screenshot 2022-08-30 at 4 05 17 PM" src="https://user-images.githubusercontent.com/54532330/187422519-69c9cc2b-987c-4769-95b9-28d730f5dfce.png">
<img width="1369" alt="Screenshot 2022-08-30 at 4 05 27 PM" src="https://user-images.githubusercontent.com/54532330/187422607-03b42bca-e770-4041-bdea-9dd821a0e454.png">
<img width="1370" alt="Screenshot 2022-08-30 at 4 05 47 PM" src="https://user-images.githubusercontent.com/54532330/187422640-dbf3497a-e01c-406f-8ee2-643cea5e4495.png">

