### PR TITLE
Reverse bootstrappers when reverting to central

### DIFF
--- a/src/Listeners/RevertToCentralContext.php
+++ b/src/Listeners/RevertToCentralContext.php
@@ -14,7 +14,7 @@ class RevertToCentralContext
     {
         event(new RevertingToCentralContext($event->tenancy));
 
-        foreach ($event->tenancy->getBootstrappers() as $bootstrapper) {
+        foreach (array_reverse($event->tenancy->getBootstrappers()) as $bootstrapper) {
             $bootstrapper->revert();
         }
 


### PR DESCRIPTION
Some of my bootstrappers are depending on previous bootstrappers but when reverting it needs to run in reverse order.
Submitting to v4 since this might be a breaking change (currently I am overriding this file).