### PR TITLE
Add docker-compose MSSQL service health checks

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
                 condition: service_healthy
             redis:
                 condition: service_healthy
+            # mssql:
+            #    condition: service_healthy
         volumes:
             - .:/var/www/html:delegated
         environment:
@@ -74,4 +76,8 @@ services:
         environment:
           - ACCEPT_EULA=Y
           - SA_PASSWORD=P@ssword # todo reuse values from env above
-        # todo missing health check
+        healthcheck:
+            test: /opt/mssql-tools/bin/sqlcmd -S localhost -U sa -P P@ssword -Q "SELECT 1" -b -o /dev/null
+            interval: 10s
+            timeout: 10s
+            retries: 10


### PR DESCRIPTION
This PR adds the missing health checks for the `mssql` service in `docker-compose.yml`. For the M1 image `azure-sql-edge`, they removed the `mssql-tools`, so checks are failing M1 for now. As discussed internally, I've commented out the code which stops containers from going up if the service is unhealthy. 