### PR TITLE
use force in MigrateDatabase and SeedDatabase Job

### DIFF
--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -33,6 +33,7 @@ class MigrateDatabase implements ShouldQueue
     {
         Artisan::call('tenants:migrate', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--force' => true,
         ]);
     }
 }

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -33,6 +33,7 @@ class SeedDatabase implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--force' => true,
         ]);
     }
 }


### PR DESCRIPTION
When running with `APP_ENV=production` jobs could not execute those `Artisan::call` commands. Was throwing `Undefined constant "STDIN"` error.