### PR TITLE
[4.x] Add tenancy maintenance drivers and events

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -58,6 +58,8 @@ class TenancyServiceProvider extends ServiceProvider
                     return $event->tenant;
                 })->shouldBeQueued(false), // `false` by default, but you probably want to make this `true` for production.
             ],
+            Events\TenantMaintenanceModeEnabled::class => [],
+            Events\TenantMaintenanceModeDisabled::class => [],
 
             // Domain events
             Events\CreatingDomain::class => [],

--- a/assets/config.php
+++ b/assets/config.php
@@ -253,7 +253,7 @@ return [
      *
      */
     'maintenance' => [
-        'driver' => env('TENANCY_DATABASE_DRIVER', 'database'),
+        'driver' => env('TENANCY_MAINTENANCE_DRIVER', 'database'),
         // 'store'  => 'redis',
     ],
 

--- a/assets/config.php
+++ b/assets/config.php
@@ -243,6 +243,21 @@ return [
     ],
 
     /**
+     * Maintenance mode driver
+     *
+     * These configuration options determine the driver used to determine and
+     * manage Tenancy's "maintenance mode" status. The "cache" driver will
+     * allow maintenance mode to be controlled across multiple machines.
+     *
+     * Supported drivers: "database", "cache"
+     *
+     */
+    'maintenance' => [
+        'driver' => env('TENANCY_DATABASE_DRIVER', 'database'),
+        // 'store'  => 'redis',
+    ],
+
+    /**
      * Should tenancy routes be registered.
      *
      * Tenancy routes include tenant asset routes. By default, this route is

--- a/src/Database/Concerns/MaintenanceMode.php
+++ b/src/Database/Concerns/MaintenanceMode.php
@@ -4,27 +4,68 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Database\Concerns;
 
+use Illuminate\Contracts\Container\BindingResolutionException;
+use Stancl\Tenancy\Maintenance\TenantMaintenanceModeContract;
+
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
  */
 trait MaintenanceMode
 {
-    public function putDownForMaintenance($data = []): void
+    /**
+     * Get an instance of the tenant maintenance mode manager implementation.
+     *
+     * @return TenantMaintenanceModeContract
+     * @throws BindingResolutionException
+     */
+    public function maintenanceMode(): TenantMaintenanceModeContract
     {
-        $this->update([
-            'maintenance_mode' => [
-                'except' => $data['except'] ?? null,
-                'redirect' => $data['redirect'] ?? null,
-                'retry' => $data['retry'] ?? null,
-                'refresh' => $data['refresh'] ?? null,
-                'secret' => $data['secret'] ?? null,
-                'status' => $data['status'] ?? 503,
-            ],
-        ]);
+        return app()->make(TenantMaintenanceModeContract::class);
     }
 
+    /**
+     * Put the tenant into maintenance
+     *
+     * @param  array  $payload
+     * @return void
+     * @throws BindingResolutionException
+     */
+    public function putDownForMaintenance(array $payload = []): void
+    {
+        ray('down');
+        $this->maintenanceMode()->activate($payload);
+    }
+
+    /**
+     * Remove the tenant from maintenance
+     *
+     * @return void
+     * @throws BindingResolutionException
+     */
     public function bringUpFromMaintenance(): void
     {
-        $this->update(['maintenance_mode' => null]);
+        $this->maintenanceMode()->deactivate();
+    }
+
+    /**
+     * Determine if the tenant is in maintenance
+     *
+     * @return bool
+     * @throws BindingResolutionException
+     */
+    public function isDownForMaintenance(): bool
+    {
+        return $this->maintenanceMode()->active();
+    }
+
+    /**
+     * Get the data array which was provided when the tenant was placed into maintenance.
+     *
+     * @return array
+     * @throws BindingResolutionException
+     */
+    public function getMaintenanceData(): array
+    {
+        return $this->maintenanceMode()->data();
     }
 }

--- a/src/Database/Concerns/MaintenanceMode.php
+++ b/src/Database/Concerns/MaintenanceMode.php
@@ -32,7 +32,6 @@ trait MaintenanceMode
      */
     public function putDownForMaintenance(array $payload = []): void
     {
-        ray('down');
         $this->maintenanceMode()->activate($payload);
     }
 

--- a/src/Database/Concerns/MaintenanceMode.php
+++ b/src/Database/Concerns/MaintenanceMode.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Database\Concerns;
 
 use Illuminate\Contracts\Container\BindingResolutionException;
+use Stancl\Tenancy\Events\TenantMaintenanceModeDisabled;
+use Stancl\Tenancy\Events\TenantMaintenanceModeEnabled;
 use Stancl\Tenancy\Maintenance\TenantMaintenanceModeContract;
 
 /**
@@ -33,6 +35,8 @@ trait MaintenanceMode
     public function putDownForMaintenance(array $payload = []): void
     {
         $this->maintenanceMode()->activate($payload);
+
+        event(new TenantMaintenanceModeEnabled($this));
     }
 
     /**
@@ -44,6 +48,8 @@ trait MaintenanceMode
     public function bringUpFromMaintenance(): void
     {
         $this->maintenanceMode()->deactivate();
+
+        event(new TenantMaintenanceModeDisabled($this));
     }
 
     /**

--- a/src/Events/TenantMaintenanceModeDisabled.php
+++ b/src/Events/TenantMaintenanceModeDisabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Events;
+
+class TenantMaintenanceModeDisabled extends Contracts\TenantEvent
+{
+}

--- a/src/Events/TenantMaintenanceModeEnabled.php
+++ b/src/Events/TenantMaintenanceModeEnabled.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Events;
+
+class TenantMaintenanceModeEnabled extends Contracts\TenantEvent
+{
+}

--- a/src/Maintenance/CacheBasedMaintenanceMode.php
+++ b/src/Maintenance/CacheBasedMaintenanceMode.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Stancl\Tenancy\Maintenance;
+
+
+class CacheBasedMaintenanceMode extends \Illuminate\Foundation\CacheBasedMaintenanceMode implements TenantMaintenanceModeContract
+{
+    //
+}

--- a/src/Maintenance/DatabaseBasedMaintenanceMode.php
+++ b/src/Maintenance/DatabaseBasedMaintenanceMode.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Stancl\Tenancy\Maintenance;
+
+
+class DatabaseBasedMaintenanceMode implements TenantMaintenanceModeContract
+{
+
+    public function activate(array $payload): void
+    {
+        tenant()->update([
+            'maintenance_mode' => [
+                'except' => $payload['except'] ?? null,
+                'redirect' => $payload['redirect'] ?? null,
+                'retry' => $payload['retry'] ?? null,
+                'refresh' => $payload['refresh'] ?? null,
+                'secret' => $payload['secret'] ?? null,
+                'status' => $payload['status'] ?? 503,
+            ],
+        ]);
+    }
+
+    public function deactivate(): void
+    {
+        tenant()->update(['maintenance_mode' => null]);
+    }
+
+    public function active(): bool
+    {
+        return !is_null(tenant('maintenance_mode'));
+    }
+
+    public function data(): array
+    {
+        return tenant('maintenance_mode');
+    }
+}

--- a/src/Maintenance/MaintenanceModeManager.php
+++ b/src/Maintenance/MaintenanceModeManager.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Maintenance;
+
+use Illuminate\Support\Manager;
+
+class MaintenanceModeManager extends Manager
+{
+    /**
+     * Create an instance of the file based maintenance driver.
+     *
+     * @return DatabaseBasedMaintenanceMode
+     */
+    protected function createDatabaseDriver(): DatabaseBasedMaintenanceMode
+    {
+        return new DatabaseBasedMaintenanceMode();
+    }
+
+    /**
+     * Create an instance of the cache based maintenance driver.
+     *
+     * @return CacheBasedMaintenanceMode
+     *
+     */
+    protected function createCacheDriver(): CacheBasedMaintenanceMode
+    {
+        return new CacheBasedMaintenanceMode(
+            $this->container->make('cache'),
+            $this->config->get('tenancy.maintenance.store') ?: $this->config->get('cache.default'),
+            tenant()->getTenantKey() . ':down'
+        );
+    }
+
+    /**
+     * Get the default driver name.
+     *
+     * @return string
+     */
+    public function getDefaultDriver(): string
+    {
+        return $this->config->get('tenancy.maintenance.driver', 'database');
+    }
+}

--- a/src/Maintenance/TenantMaintenanceModeContract.php
+++ b/src/Maintenance/TenantMaintenanceModeContract.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Stancl\Tenancy\Maintenance;
+
+use Illuminate\Contracts\Foundation\MaintenanceMode;
+
+interface TenantMaintenanceModeContract extends MaintenanceMode
+{
+
+}

--- a/src/Middleware/CheckTenantForMaintenanceMode.php
+++ b/src/Middleware/CheckTenantForMaintenanceMode.php
@@ -17,8 +17,8 @@ class CheckTenantForMaintenanceMode extends CheckForMaintenanceMode
             throw new TenancyNotInitializedException;
         }
 
-        if (tenant('maintenance_mode')) {
-            $data = tenant('maintenance_mode');
+        if (tenant()->isDownForMaintenance()) {
+            $data = tenant()->getMaintenanceData();
 
             if (isset($data['secret']) && $request->path() === $data['secret']) {
                 return $this->bypassResponse($data['secret']);

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -12,6 +12,8 @@ use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Enums\LogMode;
 use Stancl\Tenancy\Events\Contracts\TenancyEvent;
+use Stancl\Tenancy\Maintenance\MaintenanceModeManager;
+use Stancl\Tenancy\Maintenance\TenantMaintenanceModeContract;
 use Stancl\Tenancy\Resolvers\DomainTenantResolver;
 
 class TenancyServiceProvider extends ServiceProvider
@@ -43,6 +45,8 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->bind(Domain::class, function () {
             return DomainTenantResolver::$currentDomain;
         });
+
+        $this->registerMaintenanceModeManager();
 
         // Make sure bootstrappers are stateful (singletons).
         foreach ($this->app['config']['tenancy.bootstrappers'] ?? [] as $bootstrapper) {
@@ -136,5 +140,21 @@ class TenancyServiceProvider extends ServiceProvider
 
             return $instance;
         });
+    }
+
+
+    /**
+     * Register the maintenance mode manager service.
+     *
+     * @return void
+     */
+    public function registerMaintenanceModeManager(): void
+    {
+        $this->app->singleton(MaintenanceModeManager::class);
+
+        $this->app->bind(
+            TenantMaintenanceModeContract::class,
+            fn () => $this->app->make(MaintenanceModeManager::class)->driver()
+        );
     }
 }


### PR DESCRIPTION
As a follow up of the conversation from the doc repo https://github.com/stancl/tenancy-docs/issues/214 and because #761 was merge.

I figured this package could also get the privilege of maintenance drivers like Laravel has done. This PR imitates exactly how Laravel handles its maintenance mode. Here is what have been added :

- Two tenancy drivers `database` & `cache` (whereas Laravel has `file` & `cache`). Note: The `file` driver cannot be done without touching the _public/index.php_
- A new config `tenancy.maintenance.driver` which will determine which driver to use (database by default) and `tenance.mainenance.store` which will determine the store to use when the driver is _cache_.
- A new .env variable `TENANCY_MAINTENANCE_DRIVER` (Laravel didn't make an environment variable, so maybe we shouldn't add one)
- Events are now thrown when a tenant is put into or out of maintenance mode.

> ⚠️Note : The cache driver doesn't seem to be using the prefixed added by the package in the bootstrapper for the cache. So I've prefixed the cache key with the tenant key... But it's not ideal because it really should be complying to how the package handles the cache prefixes for identified tenants. I'm open to any suggestions. Everything works, though.