### PR TITLE
[4.x] Update commands CLI outputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,10 +92,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
       - name: Install php-cs-fixer
         run: composer global require friendsofphp/php-cs-fixer
       - name: Run php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,6 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          token: ${{ secrets.pat }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,9 @@ jobs:
       - name: Run php-cs-fixer
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
       - name: Commit changes from php-cs-fixer
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: EndBug/add-and-commit@v5
         with:
-          branch: ${{ github.head_ref }}
-          commit_author: "PHP CS Fixer"
-          commit_user_email: "phpcsfixer@example.com"
-          commit_message: Fix code style (php-cs-fixer)
+          author_name: "PHP CS Fixer"
+          author_email: "phpcsfixer@example.com"
+          message: Fix code style (php-cs-fixer)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,7 @@ jobs:
       - name: Commit changes from php-cs-fixer
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
+          branch: ${{ github.head_ref }}
           commit_author: "PHP CS Fixer"
           commit_user_email: "phpcsfixer@example.com"
           commit_message: Fix code style (php-cs-fixer)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          token: ${{ secrets.pat }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Install php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.head_ref }}
       - name: Install php-cs-fixer
         run: composer global require friendsofphp/php-cs-fixer
       - name: Run php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
       - name: Install php-cs-fixer
         run: composer global require friendsofphp/php-cs-fixer
       - name: Run php-cs-fixer

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
       - name: Run php-cs-fixer
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
       - name: Commit changes from php-cs-fixer
-        uses: EndBug/add-and-commit@v5
+        uses: EndBug/add-and-commit@v9
         with:
           author_name: "PHP CS Fixer"
           author_email: "phpcsfixer@example.com"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,15 +92,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.head_ref }}
       - name: Install php-cs-fixer
         run: composer global require friendsofphp/php-cs-fixer
       - name: Run php-cs-fixer
         run: $HOME/.composer/vendor/bin/php-cs-fixer fix --config=.php-cs-fixer.php
       - name: Commit changes from php-cs-fixer
-        uses: EndBug/add-and-commit@v9
+        uses: stefanzweifel/git-auto-commit-action@v4
         with:
-          author_name: "PHP CS Fixer"
-          author_email: "phpcsfixer@example.com"
-          message: Fix code style (php-cs-fixer)
+          commit_author: "PHP CS Fixer"
+          commit_user_email: "phpcsfixer@example.com"
+          commit_message: Fix code style (php-cs-fixer)
+

--- a/assets/config.php
+++ b/assets/config.php
@@ -2,16 +2,14 @@
 
 declare(strict_types=1);
 
-use Stancl\Tenancy\Database\Models\Domain;
-use Stancl\Tenancy\Database\Models\Tenant;
 use Stancl\Tenancy\Middleware;
 use Stancl\Tenancy\Resolvers;
 
 return [
-    'tenant_model' => Tenant::class,
-    'id_generator' => Stancl\Tenancy\UUIDGenerator::class,
+    'tenant_model' => Stancl\Tenancy\Database\Models\Tenant::class,
+    'domain_model' => Stancl\Tenancy\Database\Models\Domain::class,
 
-    'domain_model' => Domain::class,
+    'id_generator' => Stancl\Tenancy\UUIDGenerator::class,
 
     /**
      * The list of domains hosting your central app.

--- a/src/Commands/Down.php
+++ b/src/Commands/Down.php
@@ -22,24 +22,28 @@ class Down extends DownCommand
 
     public function handle(): int
     {
-        // The base down command is heavily used. Instead of saving the data inside a file,
-        // the data is stored the tenant database, which means some Laravel features
-        // are not available with tenants.
-
+        // First we retrieve the compiled payload with all the
+        // parameters given, then for each tenant we will
+        // put down for maintenance and pass the payload.
         $payload = $this->getDownDatabasePayload();
 
-        // This runs for all tenants if no --tenants are specified
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($payload) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
             $tenant->putDownForMaintenance($payload);
         });
 
-        $this->comment('Tenants are now in maintenance mode.');
+        $this->components->info('Tenants are now in maintenance mode.');
 
         return 0;
     }
 
-    /** Get the payload to be placed in the "down" file. */
+    /**
+     * Get the payload to be placed in the "down" file. This
+     * payload is the same as the original function
+     * but without the 'template' option
+     *
+     * @return array
+     */
     protected function getDownDatabasePayload(): array
     {
         return [

--- a/src/Commands/Down.php
+++ b/src/Commands/Down.php
@@ -37,9 +37,7 @@ class Down extends DownCommand
     /**
      * Get the payload to be placed in the "down" file. This
      * payload is the same as the original function
-     * but without the 'template' option
-     *
-     * @return array
+     * but without the 'template' option.
      */
     protected function getDownDatabasePayload(): array
     {

--- a/src/Commands/Down.php
+++ b/src/Commands/Down.php
@@ -22,9 +22,6 @@ class Down extends DownCommand
 
     public function handle(): int
     {
-        // First we retrieve the compiled payload with all the
-        // parameters given, then for each tenant we will
-        // put down for maintenance and pass the payload.
         $payload = $this->getDownDatabasePayload();
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($payload) {

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -10,13 +10,13 @@ class Install extends Command
 {
     protected $signature = 'tenancy:install';
 
-    protected $description = 'Install stancl/tenancy.';
+    protected $description = 'Install Tenancy for Laravel.';
 
     public function handle(): int
     {
         $this->newLine();
 
-        $this->components->task('Publishing config file', function () {
+        $this->components->task('Publishing config file [config/tenancy.php]', function () {
             $this->callSilent('vendor:publish', [
                 '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
                 '--tag' => 'config',
@@ -25,8 +25,8 @@ class Install extends Command
 
         $this->newLine();
 
-        if (!file_exists(base_path('routes/tenant.php'))) {
-            $this->components->task('Publishing routes', function () {
+        if (! file_exists(base_path('routes/tenant.php'))) {
+            $this->components->task('Publishing routes [routes/tenant.php]', function () {
                 $this->callSilent('vendor:publish', [
                     '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
                     '--tag' => 'routes',
@@ -34,11 +34,10 @@ class Install extends Command
             });
             $this->newLine();
         } else {
-            $this->components->warn('File [routes/tenant.php] already existe.');
+            $this->components->warn('File [routes/tenant.php] already exists.');
         }
 
-
-        $this->components->task('Publishing providers', function () {
+        $this->components->task('Publishing service provider [app/Providers/TenancyServiceProvider.php]', function () {
             $this->callSilent('vendor:publish', [
                 '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
                 '--tag' => 'providers',
@@ -56,29 +55,25 @@ class Install extends Command
 
         $this->newLine();
 
-        if (!is_dir(database_path('migrations/tenant'))) {
-            $this->components->task('Creating database/migrations/tenant folder', function () {
+        if (! is_dir(database_path('migrations/tenant'))) {
+            $this->components->task('Creating [database/migrations/tenant] folder', function () {
                 mkdir(database_path('migrations/tenant'));
             });
         } else {
-            $this->components->warn('Folder [database/migrations/tenant] already existe.');
+            $this->components->warn('Folder [database/migrations/tenant] already exists.');
         }
 
-        $this->components->info('✨️ stancl/tenancy installed successfully.');
+        $this->components->info('✨️ Tenancy for Laravel successfully installed.');
 
         $this->askForSupport();
 
         return 0;
     }
 
-    /**
-     * If the user accepts, opens the GitHub project in the browser
-     *
-     * @return void
-     */
+    /** If the user accepts, opens the GitHub project in the browser. */
     public function askForSupport(): void
     {
-        if ($this->components->confirm("Would you like to show your support by starring the project on Github ?", true)) {
+        if ($this->components->confirm('Would you like to show your support by starring the project on GitHub?', true)) {
             if (PHP_OS_FAMILY === 'Darwin') {
                 exec('open https://github.com/archtechx/tenancy');
             }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -23,7 +23,6 @@ class Install extends Command
             ]);
         });
 
-        $this->patienceIsKeyToLife();
         $this->newLine();
 
         if (!file_exists(base_path('routes/tenant.php'))) {
@@ -38,7 +37,6 @@ class Install extends Command
             $this->components->warn('File [routes/tenant.php] already existe.');
         }
 
-        $this->patienceIsKeyToLife();
 
         $this->components->task('Publishing providers', function () {
             $this->callSilent('vendor:publish', [
@@ -47,7 +45,6 @@ class Install extends Command
             ]);
         });
 
-        $this->patienceIsKeyToLife();
         $this->newLine();
 
         $this->components->task('Publishing migrations', function () {
@@ -57,7 +54,6 @@ class Install extends Command
             ]);
         });
 
-        $this->patienceIsKeyToLife();
         $this->newLine();
 
         if (!is_dir(database_path('migrations/tenant'))) {
@@ -70,20 +66,9 @@ class Install extends Command
 
         $this->components->info('✨️ stancl/tenancy installed successfully.');
 
-        $this->patienceIsKeyToLife();
         $this->askForSupport();
 
         return 0;
-    }
-
-    /**
-     * Pause the console execution for 1 second, help the user to have time and read the output
-     *
-     * @return void
-     */
-    public function patienceIsKeyToLife(): void
-    {
-        sleep(1);
     }
 
     /**
@@ -93,7 +78,7 @@ class Install extends Command
      */
     public function askForSupport(): void
     {
-        if ($this->components->confirm("Would you like to show your support by starring the project on github ?", true)) {
+        if ($this->components->confirm("Would you like to show your support by starring the project on Github ?", true)) {
             if (PHP_OS_FAMILY === 'Darwin') {
                 exec('open https://github.com/archtechx/tenancy');
             }

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -12,7 +12,7 @@ class Install extends Command
 
     protected $description = 'Install stancl/tenancy.';
 
-    public function handle(): void
+    public function handle(): int
     {
         $this->newLine();
 
@@ -72,6 +72,8 @@ class Install extends Command
 
         $this->patienceIsKeyToLife();
         $this->askForSupport();
+
+        return 0;
     }
 
     /**

--- a/src/Commands/Install.php
+++ b/src/Commands/Install.php
@@ -14,40 +14,93 @@ class Install extends Command
 
     public function handle(): void
     {
-        $this->comment('Installing stancl/tenancy...');
-        $this->callSilent('vendor:publish', [
-            '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
-            '--tag' => 'config',
-        ]);
-        $this->info('✔️  Created config/tenancy.php');
+        $this->newLine();
 
-        if (! file_exists(base_path('routes/tenant.php'))) {
+        $this->components->task('Publishing config file', function () {
             $this->callSilent('vendor:publish', [
                 '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
-                '--tag' => 'routes',
+                '--tag' => 'config',
             ]);
-            $this->info('✔️  Created routes/tenant.php');
+        });
+
+        $this->patienceIsKeyToLife();
+        $this->newLine();
+
+        if (!file_exists(base_path('routes/tenant.php'))) {
+            $this->components->task('Publishing routes', function () {
+                $this->callSilent('vendor:publish', [
+                    '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
+                    '--tag' => 'routes',
+                ]);
+            });
+            $this->newLine();
         } else {
-            $this->info('Found routes/tenant.php.');
+            $this->components->warn('File [routes/tenant.php] already existe.');
         }
 
-        $this->callSilent('vendor:publish', [
-            '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
-            '--tag' => 'providers',
-        ]);
-        $this->info('✔️  Created TenancyServiceProvider.php');
+        $this->patienceIsKeyToLife();
 
-        $this->callSilent('vendor:publish', [
-            '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
-            '--tag' => 'migrations',
-        ]);
-        $this->info('✔️  Created migrations. Remember to run [php artisan migrate]!');
+        $this->components->task('Publishing providers', function () {
+            $this->callSilent('vendor:publish', [
+                '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
+                '--tag' => 'providers',
+            ]);
+        });
 
-        if (! is_dir(database_path('migrations/tenant'))) {
-            mkdir(database_path('migrations/tenant'));
-            $this->info('✔️  Created database/migrations/tenant folder.');
+        $this->patienceIsKeyToLife();
+        $this->newLine();
+
+        $this->components->task('Publishing migrations', function () {
+            $this->callSilent('vendor:publish', [
+                '--provider' => 'Stancl\Tenancy\TenancyServiceProvider',
+                '--tag' => 'migrations',
+            ]);
+        });
+
+        $this->patienceIsKeyToLife();
+        $this->newLine();
+
+        if (!is_dir(database_path('migrations/tenant'))) {
+            $this->components->task('Creating database/migrations/tenant folder', function () {
+                mkdir(database_path('migrations/tenant'));
+            });
+        } else {
+            $this->components->warn('Folder [database/migrations/tenant] already existe.');
         }
 
-        $this->comment('✨️ stancl/tenancy installed successfully.');
+        $this->components->info('✨️ stancl/tenancy installed successfully.');
+
+        $this->patienceIsKeyToLife();
+        $this->askForSupport();
+    }
+
+    /**
+     * Pause the console execution for 1 second, help the user to have time and read the output
+     *
+     * @return void
+     */
+    public function patienceIsKeyToLife(): void
+    {
+        sleep(1);
+    }
+
+    /**
+     * If the user accepts, opens the GitHub project in the browser
+     *
+     * @return void
+     */
+    public function askForSupport(): void
+    {
+        if ($this->components->confirm("Would you like to show your support by starring the project on github ?", true)) {
+            if (PHP_OS_FAMILY === 'Darwin') {
+                exec('open https://github.com/archtechx/tenancy');
+            }
+            if (PHP_OS_FAMILY === 'Windows') {
+                exec('start https://github.com/archtechx/tenancy');
+            }
+            if (PHP_OS_FAMILY === 'Linux') {
+                exec('xdg-open https://github.com/archtechx/tenancy');
+            }
+        }
     }
 }

--- a/src/Commands/Link.php
+++ b/src/Commands/Link.php
@@ -42,7 +42,7 @@ class Link extends Command
     {
         RemoveStorageSymlinksAction::handle($tenants);
 
-        $this->info('The links have been removed.');
+        $this->components->info('The links have been removed.');
     }
 
     protected function createLinks(LazyCollection $tenants): void
@@ -53,6 +53,6 @@ class Link extends Command
             (bool) ($this->option('force') ?? false),
         );
 
-        $this->info('The links have been created.');
+        $this->components->info('The links have been created.');
     }
 }

--- a/src/Commands/Link.php
+++ b/src/Commands/Link.php
@@ -23,7 +23,7 @@ class Link extends Command
 
     protected $description = 'Create or remove tenant symbolic links.';
 
-    public function handle(): void
+    public function handle(): int
     {
         $tenants = $this->getTenants();
 
@@ -35,7 +35,11 @@ class Link extends Command
             }
         } catch (Exception $exception) {
             $this->error($exception->getMessage());
+
+            return 1;
         }
+
+        return 0;
     }
 
     protected function removeLinks(LazyCollection $tenants): void

--- a/src/Commands/Migrate.php
+++ b/src/Commands/Migrate.php
@@ -43,7 +43,7 @@ class Migrate extends MigrateCommand
         }
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
             event(new MigratingDatabase($tenant));
 

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -23,7 +23,7 @@ final class MigrateFresh extends Command
         $this->setName('tenants:migrate-fresh');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
             $this->components->info("Tenant: {$tenant->getTenantKey()}");
@@ -44,5 +44,6 @@ final class MigrateFresh extends Command
             });
         });
 
+        return 0;
     }
 }

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -36,7 +36,7 @@ class MigrateFresh extends Command
                 ]));
             });
 
-            $this->components->task('Migrating', function () use ($tenant){
+            $this->components->task('Migrating', function () use ($tenant) {
                 $this->callSilent('tenants:migrate', [
                     '--tenants' => [$tenant->getTenantKey()],
                     '--force' => true,

--- a/src/Commands/MigrateFresh.php
+++ b/src/Commands/MigrateFresh.php
@@ -26,20 +26,23 @@ final class MigrateFresh extends Command
     public function handle(): void
     {
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
-            $this->info('Dropping tables.');
-            $this->call('db:wipe', array_filter([
-                '--database' => 'tenant',
-                '--drop-views' => $this->option('drop-views'),
-                '--force' => true,
-            ]));
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
-            $this->info('Migrating.');
-            $this->callSilent('tenants:migrate', [
-                '--tenants' => [$tenant->getTenantKey()],
-                '--force' => true,
-            ]);
+            $this->components->task('Dropping tables', function () {
+                $this->callSilently('db:wipe', array_filter([
+                    '--database' => 'tenant',
+                    '--drop-views' => $this->option('drop-views'),
+                    '--force' => true,
+                ]));
+            });
+
+            $this->components->task('Migrating', function () use ($tenant){
+                $this->callSilent('tenants:migrate', [
+                    '--tenants' => [$tenant->getTenantKey()],
+                    '--force' => true,
+                ]);
+            });
         });
 
-        $this->info('Done.');
     }
 }

--- a/src/Commands/Rollback.php
+++ b/src/Commands/Rollback.php
@@ -37,7 +37,7 @@ class Rollback extends RollbackCommand
         }
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
             event(new RollingBackDatabase($tenant));
 

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -24,7 +24,7 @@ class Run extends Command
         $argvInput = $this->argvInput();
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($argvInput) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
             $this->getLaravel()
                 ->make(Kernel::class)

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -19,7 +19,7 @@ class Run extends Command
     protected $signature = 'tenants:run {commandname : The artisan command.}
                             {--tenants=* : The tenant(s) to run the command for. Default: all}';
 
-    public function handle(): void
+    public function handle(): int
     {
         $argvInput = $this->argvInput();
 
@@ -30,19 +30,21 @@ class Run extends Command
                 ->make(Kernel::class)
                 ->handle($argvInput, new ConsoleOutput);
         });
+
+        return 0;
     }
 
     protected function argvInput(): ArgvInput
     {
-        /** @var string $commandname */
-        $commandname = $this->argument('commandname');
+        /** @var string $commandName */
+        $commandName = $this->argument('commandname');
 
         // Convert string command to array
-        $subcommand = explode(' ', $commandname);
+        $subCommand = explode(' ', $commandName);
 
         // Add "artisan" as first parameter because ArgvInput expects "artisan" as first parameter and later removes it
-        array_unshift($subcommand, 'artisan');
+        array_unshift($subCommand, 'artisan');
 
-        return new ArgvInput($subcommand);
+        return new ArgvInput($subCommand);
     }
 }

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -36,7 +36,7 @@ class Seed extends SeedCommand
         }
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
             event(new SeedingDatabase($tenant));
 

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\ConnectionResolverInterface;
 use Illuminate\Database\Console\DumpCommand;
@@ -23,13 +22,6 @@ class TenantDump extends DumpCommand
 
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
     {
-        $this->tenant()->run(fn () => parent::handle($connections, $dispatcher));
-
-        return Command::SUCCESS;
-    }
-
-    public function tenant(): Tenant
-    {
         $tenant = $this->option('tenant')
             ?? tenant()
             ?? $this->ask('What tenant do you want to dump the schema for?')
@@ -39,9 +31,15 @@ class TenantDump extends DumpCommand
             $tenant = tenancy()->find($tenant);
         }
 
-        throw_if(! $tenant, 'Could not identify the tenant to use for dumping the schema.');
+        if (is_null($tenant)){
+            $this->components->error("Could not find tenant to use for dumping the schema.");
 
-        return $tenant;
+            return 1;
+        }
+
+        parent::handle($connections, $dispatcher);
+
+        return 0;
     }
 
     protected function getOptions(): array

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -32,7 +32,7 @@ class TenantDump extends DumpCommand
         }
 
         if ($tenant === null) {
-            $this->components->error("Could not find tenant to use for dumping the schema.");
+            $this->components->error('Could not find tenant to use for dumping the schema.');
 
             return 1;
         }

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -31,7 +31,7 @@ class TenantDump extends DumpCommand
             $tenant = tenancy()->find($tenant);
         }
 
-        if (is_null($tenant)){
+        if ($tenant === null) {
             $this->components->error("Could not find tenant to use for dumping the schema.");
 
             return 1;

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Stancl\Tenancy\Contracts\Tenant;
 
@@ -22,36 +23,27 @@ class TenantList extends Command
 
         foreach ($tenants as $tenant) {
             /** @var Model&Tenant $tenant */
-            $this->components->twoColumnDetail($this->tenantCli($tenant), $this->domainsCli($tenant));
+            $this->components->twoColumnDetail($this->tenantCLI($tenant), $this->domainsCLI($tenant->domains));
         }
+
+        $this->newLine();
 
         return 0;
     }
 
-    /**
-     * Generate the visual cli output for the tenant name
-     *
-     * @param  Model  $tenant
-     * @return string
-     */
-    protected function tenantCli(Model $tenant): string
+    /** Generate the visual CLI output for the tenant name. */
+    protected function tenantCLI(Model&Tenant $tenant): string
     {
         return "<fg=yellow>{$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}</>";
     }
 
-    /**
-     * Generate the visual cli output for the domain names
-     *
-     * @param  Model  $tenant
-     * @return string|null
-     */
-    protected function domainsCli(Model $tenant): ?string
+    /** Generate the visual CLI output for the domain names. */
+    protected function domainsCLI(?Collection $domains): ?string
     {
-        if (! $tenant->domains) {
-
+        if (! $domains) {
             return null;
         }
 
-        return "<fg=blue;options=bold>{$tenant->domains->pluck('domain')->implode(' ; ')}</>";
+        return "<fg=blue;options=bold>{$domains->pluck('domain')->implode(' / ')}</>";
     }
 }

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -47,7 +47,7 @@ class TenantList extends Command
      */
     protected function domainsCli(Model $tenant): ?string
     {
-        if (is_null($tenant->domains)){
+        if (! $tenant->domains) {
 
             return null;
         }

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -14,7 +14,7 @@ class TenantList extends Command
 
     protected $description = 'List tenants.';
 
-    public function handle(): void
+    public function handle(): int
     {
         $tenants = tenancy()->query()->cursor();
 
@@ -24,6 +24,8 @@ class TenantList extends Command
             /** @var Model&Tenant $tenant */
             $this->components->twoColumnDetail($this->tenantCli($tenant), $this->domainsCli($tenant));
         }
+
+        return 0;
     }
 
     /**

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -16,17 +16,40 @@ class TenantList extends Command
 
     public function handle(): void
     {
-        $this->info('Listing all tenants.');
-
         $tenants = tenancy()->query()->cursor();
+
+        $this->components->info("Listing {$tenants->count()} tenants.");
 
         foreach ($tenants as $tenant) {
             /** @var Model&Tenant $tenant */
-            if ($tenant->domains) {
-                $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
-            } else {
-                $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}");
-            }
+            $this->components->twoColumnDetail($this->tenantCli($tenant), $this->domainsCli($tenant));
         }
+    }
+
+    /**
+     * Generate the visual cli output for the tenant name
+     *
+     * @param  Model  $tenant
+     * @return string
+     */
+    protected function tenantCli(Model $tenant): string
+    {
+        return "<fg=yellow>{$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}</>";
+    }
+
+    /**
+     * Generate the visual cli output for the domain names
+     *
+     * @param  Model  $tenant
+     * @return string|null
+     */
+    protected function domainsCli(Model $tenant): ?string
+    {
+        if (is_null($tenant->domains)){
+
+            return null;
+        }
+
+        return "<fg=blue;options=bold>{$tenant->domains->pluck('domain')->implode(' ; ')}</>";
     }
 }

--- a/src/Commands/Up.php
+++ b/src/Commands/Up.php
@@ -15,7 +15,7 @@ class Up extends Command
 
     protected $description = 'Put tenants out of maintenance mode.';
 
-    public function handle(): void
+    public function handle(): int
     {
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
             $this->components->info("Tenant: {$tenant->getTenantKey()}");
@@ -23,5 +23,7 @@ class Up extends Command
         });
 
         $this->components->info('Tenants are now out of maintenance mode.');
+
+        return 0;
     }
 }

--- a/src/Commands/Up.php
+++ b/src/Commands/Up.php
@@ -18,10 +18,10 @@ class Up extends Command
     public function handle(): void
     {
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) {
-            $this->line("Tenant: {$tenant['id']}");
+            $this->components->info("Tenant: {$tenant->getTenantKey()}");
             $tenant->bringUpFromMaintenance();
         });
 
-        $this->comment('Tenants are now out of maintenance mode.');
+        $this->components->info('Tenants are now out of maintenance mode.');
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -168,7 +168,7 @@ test('install command works', function () {
     }
 
     pest()->artisan('tenancy:install')
-        ->expectsConfirmation('Would you like to show your support by starring the project on github ?', 'no')
+        ->expectsConfirmation('Would you like to show your support by starring the project on Github ?', 'no')
         ->assertExitCode(0);
     expect(base_path('routes/tenant.php'))->toBeFile();
     expect(base_path('config/tenancy.php'))->toBeFile();
@@ -223,8 +223,7 @@ test('link command works', function() {
 
     pest()->artisan('tenants:link', [
         '--remove' => true,
-    ])
-        ->assertExitCode(0);
+    ])->assertExitCode(0);
 
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantId1"));
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantId2"));

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -168,7 +168,7 @@ test('install command works', function () {
     }
 
     pest()->artisan('tenancy:install')
-        ->expectsConfirmation('Would you like to show your support by starring the project on Github ?', 'no')
+        ->expectsConfirmation('Would you like to show your support by starring the project on GitHub?', 'no')
         ->assertExitCode(0);
     expect(base_path('routes/tenant.php'))->toBeFile();
     expect(base_path('config/tenancy.php'))->toBeFile();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -167,7 +167,9 @@ test('install command works', function () {
         mkdir($dir, 0777, true);
     }
 
-    pest()->artisan('tenancy:install');
+    pest()->artisan('tenancy:install')
+        ->expectsConfirmation('Would you like to show your support by starring the project on github ?', 'no')
+        ->assertExitCode(0);
     expect(base_path('routes/tenant.php'))->toBeFile();
     expect(base_path('config/tenancy.php'))->toBeFile();
     expect(app_path('Providers/TenancyServiceProvider.php'))->toBeFile();
@@ -210,7 +212,8 @@ test('run command with array of tenants works', function () {
 test('link command works', function() {
     $tenantId1 = Tenant::create()->getTenantKey();
     $tenantId2 = Tenant::create()->getTenantKey();
-    pest()->artisan('tenants:link');
+    pest()->artisan('tenants:link')
+        ->assertExitCode(0);
 
     $this->assertDirectoryExists(storage_path("tenant-$tenantId1/app/public"));
     $this->assertEquals(storage_path("tenant-$tenantId1/app/public/"), readlink(public_path("public-$tenantId1")));
@@ -220,7 +223,8 @@ test('link command works', function() {
 
     pest()->artisan('tenants:link', [
         '--remove' => true,
-    ]);
+    ])
+        ->assertExitCode(0);
 
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantId1"));
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantId2"));
@@ -252,8 +256,9 @@ test('run command works when sub command asks questions and accepts arguments', 
 
     pest()->artisan("tenants:run --tenants=$id 'user:addwithname Abrar' ")
         ->expectsQuestion('What is your email?', 'email@localhost')
-        ->expectsOutput("Tenant: $id")
-        ->expectsOutput("User created: Abrar(email@localhost)");
+        ->expectsOutputToContain("Tenant: $id.")
+        ->expectsOutput("User created: Abrar(email@localhost)")
+        ->assertExitCode(0);
 
     // Assert we are in central context
     expect(tenancy()->initialized)->toBeFalse();

--- a/tests/MaintenanceModeTest.php
+++ b/tests/MaintenanceModeTest.php
@@ -44,12 +44,18 @@ test('tenants can be put into maintenance mode using artisan commands', function
 
     pest()->get('http://acme.localhost/foo')->assertStatus(200);
 
+    pest()->artisan('tenants:down')
+        ->expectsOutputToContain('Tenants are now in maintenance mode.')
+        ->assertExitCode(0);
+
     Artisan::call('tenants:down');
 
     tenancy()->end(); // End tenancy before making a request
     pest()->get('http://acme.localhost/foo')->assertStatus(503);
 
-    Artisan::call('tenants:up');
+    pest()->artisan('tenants:up')
+        ->expectsOutputToContain('Tenants are now out of maintenance mode.')
+        ->assertExitCode(0);
 
     tenancy()->end(); // End tenancy before making a request
     pest()->get('http://acme.localhost/foo')->assertStatus(200);


### PR DESCRIPTION
Now that 4.x will have Laravel 9 as a minimum requirement, the cli output can be updated to the new Laravel standard:

Here's every change:
- All commands now uses the new Laravel CLI output (with `$this->components->info()`)
- The `tenanc:install` command will now offer to open the Github repo to add a star (Inspired by [Pest](https://github.com/pestphp/pest/blob/3d16183a9377c6c24c6385fb9a76e8c1fbb87860/src/Console/Thanks.php#L42))
- All commands now always return a success or failure confirmation

Preview of the CLI outpts:

### Listing tenants:
The id of the tenant are displayed on the left whereas the domains are on the right.
<img width="1070" alt="Screen Shot 2022-10-08 at 23 57 09" src="https://user-images.githubusercontent.com/44996807/194738054-1a868d7f-8838-4a02-9ee4-31a39affccb6.png">

### Commands running on multiple tenants :
<img width="420" alt="Screen Shot 2022-10-09 at 00 14 00" src="https://user-images.githubusercontent.com/44996807/194738056-2d61f236-f094-4dc3-af32-f0eb6f1dec30.png">

### Install tenancy:
<img width="1068" alt="Screen Shot 2022-10-08 at 23 57 38" src="https://user-images.githubusercontent.com/44996807/194738058-ed95863c-3fc3-4179-be63-79c79135f42f.png">