### PR TITLE
[4.x] Drop tenant databases on `migrate:fresh`

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -129,7 +129,7 @@ return [
             // 'pgsql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
         ],
 
-        'drop_tenant_databases_on_migrate_fresh' => true
+        'drop_tenant_databases_on_migrate_fresh' => false
     ],
 
     /**

--- a/assets/config.php
+++ b/assets/config.php
@@ -129,7 +129,7 @@ return [
             // 'pgsql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
         ],
 
-        'drop_tenant_databases_on_migrate_fresh' => false
+        'drop_tenant_databases_on_migrate_fresh' => true
     ],
 
     /**

--- a/assets/config.php
+++ b/assets/config.php
@@ -116,20 +116,21 @@ return [
             'pgsql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
             'sqlsrv' => Stancl\Tenancy\Database\TenantDatabaseManagers\MicrosoftSQLDatabaseManager::class,
 
-        /**
-         * Use this database manager for MySQL to have a DB user created for each tenant database.
-         * You can customize the grants given to these users by changing the $grants property.
-         */
+            /**
+             * Use this database manager for MySQL to have a DB user created for each tenant database.
+             * You can customize the grants given to these users by changing the $grants property.
+             */
             // 'mysql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PermissionControlledMySQLDatabaseManager::class,
 
-        /**
-         * Disable the pgsql manager above, and enable the one below if you
-         * want to separate tenant DBs by schemas rather than databases.
-         */
+            /**
+             * Disable the pgsql manager above, and enable the one below if you
+             * want to separate tenant DBs by schemas rather than databases.
+             */
             // 'pgsql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
         ],
 
-        'drop_tenant_databases_on_migrate_fresh' => false
+        // todo docblock
+        'drop_tenant_databases_on_migrate_fresh' => false,
     ],
 
     /**

--- a/assets/config.php
+++ b/assets/config.php
@@ -128,6 +128,8 @@ return [
          */
             // 'pgsql' => Stancl\Tenancy\Database\TenantDatabaseManagers\PostgreSQLSchemaManager::class, // Separate by schema instead of database
         ],
+
+        'drop_tenant_databases_on_migrate_fresh' => false
     ],
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "doctrine/dbal": "^2.10",
         "spatie/valuestore": "^1.2.5",
         "pestphp/pest": "^1.21",
-        "nunomaduro/larastan": "^1.0"
+        "nunomaduro/larastan": "^1.0",
+        "spatie/invade": "^1.1"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,6 @@
 includes:
     - ./vendor/nunomaduro/larastan/extension.neon
+    - ./vendor/spatie/invade/phpstan-extension.neon
 
 parameters:
     paths:

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -5,13 +5,19 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Commands;
 
 use Illuminate\Database\Console\Migrations\FreshCommand;
+use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 
 class MigrateFreshOverride extends FreshCommand
 {
     public function handle()
     {
-        dd('overriden');
-        tenancy()->model()::all()->each->delete();
+        tenancy()->model()::all()->each(function(TenantWithDatabase $tenant) {
+            if (method_exists($tenant, 'domains')) {
+                $tenant->domains()->delete();
+            }
+
+            $tenant->delete();
+        });
 
         return parent::handle();
     }

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -11,7 +11,7 @@ class MigrateFreshOverride extends FreshCommand
 {
     public function handle()
     {
-        tenancy()->model()::all()->each(function(TenantWithDatabase $tenant) {
+        tenancy()->model()::all()->each(function (TenantWithDatabase $tenant) {
             if (method_exists($tenant, 'domains')) {
                 $tenant->domains()->delete();
             }

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -11,13 +11,7 @@ class MigrateFreshOverride extends FreshCommand
 {
     public function handle()
     {
-        tenancy()->model()::all()->each(function(TenantWithDatabase $tenant) {
-            if (method_exists($tenant, 'domains')) {
-                $tenant->domains()->delete();
-            }
-
-            $tenant->delete();
-        });
+        tenancy()->model()::all()->each->delete();
 
         return parent::handle();
     }

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Stancl\Tenancy\Commands;
 
 use Illuminate\Database\Console\Migrations\FreshCommand;

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -10,7 +10,9 @@ class MigrateFreshOverride extends FreshCommand
 {
     public function handle()
     {
-        tenancy()->model()::all()->each->delete();
+        if (config('tenancy.database.drop_tenant_databases_on_migrate_fresh')) {
+            tenancy()->model()::cursor()->each->delete();
+        }
 
         return parent::handle();
     }

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Database\Console\Migrations\FreshCommand;
+
+class MigrateFreshOverride extends FreshCommand
+{
+    public function handle()
+    {
+        dd('overriden');
+        tenancy()->model()::all()->each->delete();
+
+        return parent::handle();
+    }
+}

--- a/src/Commands/MigrateFreshOverride.php
+++ b/src/Commands/MigrateFreshOverride.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Commands;
 
 use Illuminate\Database\Console\Migrations\FreshCommand;
-use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 
 class MigrateFreshOverride extends FreshCommand
 {

--- a/src/Events/Contracts/TenantEvent.php
+++ b/src/Events/Contracts/TenantEvent.php
@@ -7,7 +7,7 @@ namespace Stancl\Tenancy\Events\Contracts;
 use Illuminate\Queue\SerializesModels;
 use Stancl\Tenancy\Contracts\Tenant;
 
-abstract class TenantEvent
+abstract class TenantEvent // todo we could add a feature to JobPipeline that automatically gets data for the send() from here
 {
     use SerializesModels;
 

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -91,9 +91,13 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Up::class,
         ]);
 
-        if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
-            $this->app->extend(FreshCommand::class, fn () => new Commands\MigrateFreshOverride);
-        }
+        $this->app->extend(FreshCommand::class, function (FreshCommand $originalCommand) {
+            if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
+                return new Commands\MigrateFreshOverride;
+            }
+
+            return $originalCommand;
+        });
 
         $this->publishes([
             __DIR__ . '/../assets/config.php' => config_path('tenancy.php'),

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -73,7 +73,7 @@ class TenancyServiceProvider extends ServiceProvider
         });
 
         if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
-            $this->app->extend('command.migrate.fresh', fn() => new Commands\MigrateFreshOverride);
+            $this->app->extend('command.migrate.fresh', fn () => new Commands\MigrateFreshOverride);
         }
     }
 
@@ -149,7 +149,7 @@ class TenancyServiceProvider extends ServiceProvider
     public function provides()
     {
         return [
-            'command.migrate.fresh'
+            'command.migrate.fresh',
         ];
     }
 }

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace Stancl\Tenancy;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Console\Events\CommandStarting;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\Tenant;
+use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Enums\LogMode;
 use Stancl\Tenancy\Events\Contracts\TenancyEvent;
 use Stancl\Tenancy\Resolvers\DomainTenantResolver;
-use Illuminate\Console\Events\CommandStarting;
-use Illuminate\Support\Facades\Schema;
-use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 
 class TenancyServiceProvider extends ServiceProvider
 {
@@ -133,7 +133,7 @@ class TenancyServiceProvider extends ServiceProvider
             $tenantModel = tenancy()->model();
 
             if ($event->command === 'migrate:fresh' && Schema::hasTable($tenantModel->getTable())) {
-                $tenantModel::all()->each(function(Tenant $tenant) {
+                $tenantModel::all()->each(function (Tenant $tenant) {
                     if (method_exists($tenant, 'domains')) {
                         $tenant->domains()->delete();
                     }

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -91,12 +91,8 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Up::class,
         ]);
 
-        $this->app->extend(FreshCommand::class, function (FreshCommand $originalCommand) {
-            if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
-                return new Commands\MigrateFreshOverride;
-            }
-
-            return $originalCommand;
+        $this->app->extend(FreshCommand::class, function () {
+            return new Commands\MigrateFreshOverride;
         });
 
         $this->publishes([

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy;
 
 use Illuminate\Cache\CacheManager;
+use Illuminate\Database\Console\Migrations\FreshCommand;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
@@ -71,10 +72,6 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->bind('globalCache', function ($app) {
             return new CacheManager($app);
         });
-
-        if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
-            $this->app->extend('command.migrate.fresh', fn () => new Commands\MigrateFreshOverride);
-        }
     }
 
     /* Bootstrap services. */
@@ -95,7 +92,7 @@ class TenancyServiceProvider extends ServiceProvider
         ]);
 
         if ($this->app['config']['tenancy.database.drop_tenant_databases_on_migrate_fresh']) {
-            $this->commands(Commands\MigrateFreshOverride::class);
+            $this->app->extend(FreshCommand::class, fn () => new Commands\MigrateFreshOverride);
         }
 
         $this->publishes([
@@ -144,12 +141,5 @@ class TenancyServiceProvider extends ServiceProvider
 
             return $instance;
         });
-    }
-
-    public function provides()
-    {
-        return [
-            'command.migrate.fresh',
-        ];
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -267,6 +267,25 @@ test('run command works when sub command asks questions and accepts arguments', 
     expect($user->email)->toBe('email@localhost');
 });
 
+test('migrate fresh command deletes tenant databases', function() {
+    /** @var Tenant[] $tenants */
+    $tenants = [
+        Tenant::create(),
+        Tenant::create(),
+        Tenant::create(),
+    ];
+
+    foreach ($tenants as $tenant) {
+        expect($tenant->database()->manager()->databaseExists($tenant->database()->getName()))->toBeTrue();
+    }
+
+    pest()->artisan('migrate:fresh');
+
+    foreach ($tenants as $tenant) {
+        expect($tenant->database()->manager()->databaseExists($tenant->database()->getName()))->toBeFalse();
+    }
+});
+
 // todo@tests
 function runCommandWorks(): void
 {

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -18,16 +18,11 @@ use Stancl\Tenancy\Events\TenantCreated;
 use Stancl\Tenancy\Events\TenantDeleted;
 use Stancl\Tenancy\Tests\Etc\TestSeeder;
 use Stancl\Tenancy\Events\DeletingTenant;
-use Stancl\Tenancy\TenancyServiceProvider;
 use Stancl\Tenancy\Tests\Etc\ExampleSeeder;
 use Stancl\Tenancy\Events\TenancyInitialized;
-use Illuminate\Console\ContainerCommandLoader;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
-use Illuminate\Contracts\Foundation\Application;
 use Stancl\Tenancy\Listeners\RevertToCentralContext;
-use Illuminate\Database\Console\Migrations\FreshCommand;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
-use Symfony\Component\Console\CommandLoader\CommandLoaderInterface;
 
 
 beforeEach(function () {
@@ -276,9 +271,8 @@ test('run command works when sub command asks questions and accepts arguments', 
     expect($user->email)->toBe('email@localhost');
 });
 
-test('migrate fresh command only deletes tenant databases if drop_tenant_databases_on_migrate_fresh is true', function() {
-    Event::listen(
-        DeletingTenant::class,
+test('migrate fresh command only deletes tenant databases if drop_tenant_databases_on_migrate_fresh is true', function (bool $dropTenantDBsOnMigrateFresh) {
+    Event::listen(DeletingTenant::class,
         JobPipeline::make([DeleteDomains::class])->send(function (DeletingTenant $event) {
             return $event->tenant;
         })->shouldBeQueued(false)->toListener()
@@ -291,9 +285,8 @@ test('migrate fresh command only deletes tenant databases if drop_tenant_databas
         })->shouldBeQueued(false)->toListener()
     );
 
-
-    config(['tenancy.database.drop_tenant_databases_on_migrate_fresh' => false]);
-    app()->forgetInstance(FreshCommand::class);
+    config(['tenancy.database.drop_tenant_databases_on_migrate_fresh' => $dropTenantDBsOnMigrateFresh]);
+    $shouldHaveDBAfterMigrateFresh = ! $dropTenantDBsOnMigrateFresh;
 
     /** @var Tenant[] $tenants */
     $tenants = [
@@ -315,32 +308,9 @@ test('migrate fresh command only deletes tenant databases if drop_tenant_databas
     ]);
 
     foreach ($tenants as $tenant) {
-        expect($tenantHasDatabase($tenant))->toBeTrue();
+        expect($tenantHasDatabase($tenant))->toBe($shouldHaveDBAfterMigrateFresh);
     }
-
-    config(['tenancy.database.drop_tenant_databases_on_migrate_fresh' => true]);
-    app()->forgetInstance(FreshCommand::class);
-
-    $tenants = [
-        Tenant::create(),
-        Tenant::create(),
-        Tenant::create(),
-    ];
-
-    foreach ($tenants as $tenant) {
-        expect($tenantHasDatabase($tenant))->toBeTrue();
-    }
-
-    pest()->artisan('migrate:fresh', [
-        '--force' => true,
-        '--path' => __DIR__ . '/../assets/migrations',
-        '--realpath' => true,
-    ]);
-
-    foreach ($tenants as $tenant) {
-        expect($tenantHasDatabase($tenant))->toBeFalse();
-    }
-});
+})->with([true, false]);
 
 // todo@tests
 function runCommandWorks(): void


### PR DESCRIPTION
@stancl, I'm drafting this as a follow-up on [the comments on BC](https://3.basecamp.com/5170965/buckets/23651018/todos/5400823470). From the conversation:

Samuel:

> The general goal is that sometimes, it's appropriate to delete tenant DBs when running migrate:fresh. Reason: when you run migrate:fresh you generally expect your DB to become clean, so it'd make sense to also delete databases.
> 
> Some thoughts:
> We probably only want to delete DBs of the tenants that are currently in the `tenants` table and will be removed when migrate:fresh runs. We don't want to use any logic like detecting tenant DBs based on the configured prefix (e.g. tenant_) because someone could have those DBs for other purposes such as testing (e.g. tenant_tests)
> We can't modify the default Laravel command, but we likely also don't want to add a new command. One way to handle this could be checking if migrate:fresh dispatches any events. I think `migrate` does, so `migrate:fresh` could have some specific ones too. Then, we could simply do Tenants::all()->each->delete() or something like that in a listener

me:

> The `migrate:fresh` command dispatches a bunch of events. `DatabaseRefreshed` is the most specific one (before that gets dispatched, there's a bunch of `StatementPrepared` and `QueryExecuted` events, and these probably aren't useful to us). Also, the `migrate:refresh` command dispatches DatabaseRefreshed too, so the event is not specific to `migrate:fresh`.

> Maybe this is too hacky, but it's the most accurate thing I found so far:

> There's a `CommandStarting` event. The event has a `$command` property which we can access, and if we call `migrate:fresh`, the property's value would be "migrate:fresh". So we could listen for that event and if the property's value equals "migrate:fresh", delete the tenant databases.