### PR TITLE
[4.x] Maintenance events

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -58,6 +58,8 @@ class TenancyServiceProvider extends ServiceProvider
                     return $event->tenant;
                 })->shouldBeQueued(false), // `false` by default, but you probably want to make this `true` for production.
             ],
+            Events\TenantMaintenanceModeEnabled::class => [],
+            Events\TenantMaintenanceModeDisabled::class => [],
 
             // Domain events
             Events\CreatingDomain::class => [],

--- a/src/Database/Concerns/MaintenanceMode.php
+++ b/src/Database/Concerns/MaintenanceMode.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 namespace Stancl\Tenancy\Database\Concerns;
+use Stancl\Tenancy\Events\TenantMaintenanceModeDisabled;
+use Stancl\Tenancy\Events\TenantMaintenanceModeEnabled;
 
 /**
  * @mixin \Illuminate\Database\Eloquent\Model
@@ -21,10 +23,14 @@ trait MaintenanceMode
                 'status' => $data['status'] ?? 503,
             ],
         ]);
+
+        event(new TenantMaintenanceModeEnabled($this));
     }
 
     public function bringUpFromMaintenance(): void
     {
         $this->update(['maintenance_mode' => null]);
+
+        event(new TenantMaintenanceModeDisabled($this));
     }
 }

--- a/src/Events/TenantMaintenanceModeDisabled.php
+++ b/src/Events/TenantMaintenanceModeDisabled.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Events;
+
+class TenantMaintenanceModeDisabled extends Contracts\TenantEvent
+{
+    //
+}

--- a/src/Events/TenantMaintenanceModeEnabled.php
+++ b/src/Events/TenantMaintenanceModeEnabled.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Events;
+
+class TenantMaintenanceModeEnabled extends Contracts\TenantEvent
+{
+    //
+}


### PR DESCRIPTION
This PR adds events when maintenance mode are enabled and disabled.

Down for maintenance mode will fire : 
`\Stancl\Tenancy\Events\TenantMaintenanceModeEnabled::class`

Back from maintenance mode will fire : 
`\Stancl\Tenancy\Events\TenantMaintenanceModeDisabled::class`