### PR TITLE
Add cookie option on Initialize Tenancy by Request identification

### DIFF
--- a/src/Middleware/InitializeTenancyByRequestData.php
+++ b/src/Middleware/InitializeTenancyByRequestData.php
@@ -33,13 +33,18 @@ class InitializeTenancyByRequestData extends IdentificationMiddleware
 
     protected function getPayload(Request $request): ?string
     {
-        $tenant = null;
         if (static::$header && $request->hasHeader(static::$header)) {
-            $tenant = $request->header(static::$header);
-        } elseif (static::$queryParameter && $request->has(static::$queryParameter)) {
-            $tenant = $request->get(static::$queryParameter);
+            return $request->header(static::$header);
         }
 
-        return $tenant;
+        if (static::$queryParameter && $request->has(static::$queryParameter)) {
+            return $request->get(static::$queryParameter);
+        }
+
+        if (static::$header && $request->hasCookie(static::$header)) {
+            return $request->cookie(static::$header);
+        }
+
+        return null;
     }
 }

--- a/src/Middleware/InitializeTenancyByRequestData.php
+++ b/src/Middleware/InitializeTenancyByRequestData.php
@@ -12,6 +12,7 @@ use Stancl\Tenancy\Tenancy;
 class InitializeTenancyByRequestData extends IdentificationMiddleware
 {
     public static string $header = 'X-Tenant';
+    public static string $cookie = 'X-Tenant';
     public static string $queryParameter = 'tenant';
     public static ?Closure $onFail = null;
 
@@ -41,8 +42,8 @@ class InitializeTenancyByRequestData extends IdentificationMiddleware
             return $request->get(static::$queryParameter);
         }
 
-        if (static::$header && $request->hasCookie(static::$header)) {
-            return $request->cookie(static::$header);
+        if (static::$cookie && $request->hasCookie(static::$cookie)) {
+            return $request->cookie(static::$cookie);
         }
 
         return null;

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -20,6 +20,7 @@ beforeEach(function () {
 
 afterEach(function () {
     InitializeTenancyByRequestData::$header = 'X-Tenant';
+    InitializeTenancyByRequestData::$cookie = 'X-Tenant';
     InitializeTenancyByRequestData::$queryParameter = 'tenant';
 });
 
@@ -46,7 +47,7 @@ test('query parameter identification works', function () {
 });
 
 test('cookie identification works', function () {
-    InitializeTenancyByRequestData::$header = 'X-Tenant';
+    InitializeTenancyByRequestData::$cookie = 'X-Tenant';
     $tenant = Tenant::create();
 
     $this

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -26,13 +26,11 @@ afterEach(function () {
 test('header identification works', function () {
     InitializeTenancyByRequestData::$header = 'X-Tenant';
     $tenant = Tenant::create();
-    $tenant2 = Tenant::create();
 
     $this
         ->withoutExceptionHandling()
-        ->get('test', [
-            'X-Tenant' => $tenant->id,
-        ])
+        ->withHeader('X-Tenant', $tenant->id)
+        ->get('test')
         ->assertSee($tenant->id);
 });
 
@@ -40,10 +38,20 @@ test('query parameter identification works', function () {
     InitializeTenancyByRequestData::$queryParameter = 'tenant';
 
     $tenant = Tenant::create();
-    $tenant2 = Tenant::create();
 
     $this
         ->withoutExceptionHandling()
         ->get('test?tenant=' . $tenant->id)
+        ->assertSee($tenant->id);
+});
+
+test('cookie identification works', function () {
+    InitializeTenancyByRequestData::$header = 'X-Tenant';
+    $tenant = Tenant::create();
+
+    $this
+        ->withoutExceptionHandling()
+        ->withUnencryptedCookie('X-Tenant', $tenant->id)
+        ->get('test',)
         ->assertSee($tenant->id);
 });


### PR DESCRIPTION
This PR adds the cookie identification using in `InitializeTenancyByRequestData` middleware. 

## Use case

When using `InitializeTenancyByRequestData`In a SPA front-end we need to set a header on every request sent to our backend or set query params with tenant id.
So in this approach, When a user login will receive an X-Tenant cookie with the value tenant id from Authentication Controller, which will be used on the next requests to identify the tenant.

## Usage 
Let's say you have SPA or using the API from any client. 

```php
Route::middleware(InitializeTenancyByRequestData::class)->get('/test', function () {
    return 'Tenant id: ' . tenant('id');
});
```

Now request should have a cookie. 

```php
$response->withCookie(cookie('X-Tenant', $tenant, 120));
```

Closes https://github.com/archtechx/tenancy/issues/895