### PR TITLE
[4.x] Make `tenants:migrate` default to configured schema path

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -258,6 +258,7 @@ return [
     'migration_parameters' => [
         '--force' => true, // This needs to be true to run migrations in production.
         '--path' => [database_path('migrations/tenant')],
+        '--schema-path' => database_path('schema/tenant-schema.dump'),
         '--realpath' => true,
     ],
 

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
-use Stancl\Tenancy\Contracts\Tenant;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\Console\DumpCommand;
-use Symfony\Component\Console\Input\InputOption;
 use Illuminate\Database\ConnectionResolverInterface;
+use Illuminate\Database\Console\DumpCommand;
+use Stancl\Tenancy\Contracts\Tenant;
+use Symfony\Component\Console\Input\InputOption;
 
 class TenantDump extends DumpCommand
 {

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Commands;
 
-use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Database\ConnectionResolverInterface;
-use Illuminate\Database\Console\DumpCommand;
 use Stancl\Tenancy\Contracts\Tenant;
+use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Database\Console\DumpCommand;
 use Symfony\Component\Console\Input\InputOption;
+use Illuminate\Database\ConnectionResolverInterface;
 
 class TenantDump extends DumpCommand
 {
@@ -22,6 +22,10 @@ class TenantDump extends DumpCommand
 
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
     {
+        if (is_null($this->option('path'))) {
+            $this->input->setOption('path', config('tenancy.migration_parameters.--schema-path'));
+        }
+
         $tenant = $this->option('tenant')
             ?? tenant()
             ?? $this->ask('What tenant do you want to dump the schema for?')

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -23,7 +23,7 @@ class TenantDump extends DumpCommand
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
     {
         if (is_null($this->option('path'))) {
-            $this->input->setOption('path', config('tenancy.migration_parameters.--schema-path'));
+            $this->input->setOption('path', database_path('schema/tenant-schema.dump'));
         }
 
         $tenant = $this->option('tenant')


### PR DESCRIPTION
This PR solves https://github.com/archtechx/tenancy/issues/978 by adding the `--schema-path` migration command parameter to the `migration_parameters` config. This makes `tenants:migrate` use the dump file to which the path leads to (if the file exists – that's handled by the underlying Laravel command, `tenants:migrate` just passes the path to `migrate` along with the other `migration_parameters`).

The TenantDump command now defaults to the configured path. That solves the issue where the tenant dump file name could be the same as the central DB dump's name ([this BC to-do](https://3.basecamp.com/5170965/buckets/23651018/todos/5445406155#__recording_5466770611)).