### PR TITLE
Unlink tenant schema path before each test in CommandsTest

### DIFF
--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -54,6 +54,11 @@ afterEach(function () {
     }
 });
 
+function tenantSchemaPath(): string
+{
+    return database_path('schema/tenant-schema.dump');
+}
+
 test('migrate command doesnt change the db connection', function () {
     expect(Schema::hasTable('users'))->toBeFalse();
 
@@ -121,7 +126,7 @@ test('dump command works', function () {
 });
 
 test('tenant dump file gets created as tenant-schema.dump in the database schema folder by default', function() {
-    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = database_path('schema/tenant-schema.dump')]);
+    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = tenantSchemaPath()]);
 
     $tenant = Tenant::create();
     Artisan::call('tenants:migrate');

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -26,7 +26,7 @@ use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 
 
 beforeEach(function () {
-    if (file_exists($schemaPath = tenantSchemaPath())) {
+    if (file_exists($schemaPath = database_path('schema/tenant-schema.dump'))) {
         unlink($schemaPath);
     }
 
@@ -57,11 +57,6 @@ afterEach(function () {
         unlink(base_path('config/tenancy.php'));
     }
 });
-
-function tenantSchemaPath(): string
-{
-    return database_path('schema/tenant-schema.dump');
-}
 
 test('migrate command doesnt change the db connection', function () {
     expect(Schema::hasTable('users'))->toBeFalse();
@@ -130,7 +125,7 @@ test('dump command works', function () {
 });
 
 test('tenant dump file gets created as tenant-schema.dump in the database schema folder by default', function() {
-    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = tenantSchemaPath()]);
+    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = database_path('schema/tenant-schema.dump')]);
 
     $tenant = Tenant::create();
     Artisan::call('tenants:migrate');

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -26,6 +26,10 @@ use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 
 
 beforeEach(function () {
+    if (file_exists($schemaPath = tenantSchemaPath())) {
+        unlink($schemaPath);
+    }
+
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());
@@ -136,7 +140,6 @@ test('tenant dump file gets created as tenant-schema.dump in the database schema
     Artisan::call('tenants:dump');
 
     expect($schemaPath)->toBeFile();
-    unlink($schemaPath);
 });
 
 test('migrate command uses the correct schema path by default', function () {


### PR DESCRIPTION
~~Also added the `tenantSchemaPath` function so that if we want to change the schema path in the test, we only have to do that in a single place. Though the method is used only two times in the file, so maybe it isn't needed?~~ 