### PR TITLE
[4.x] Add feature to ignore the resource syncing based on provided condition

### DIFF
--- a/src/Contracts/Syncable.php
+++ b/src/Contracts/Syncable.php
@@ -18,4 +18,6 @@ interface Syncable
 
     /** Get the attributes used for creating the *other* model (i.e. tenant if this is the central one, and central if this is the tenant one). */
     public function getSyncedCreationAttributes(): array|null; // todo come up with a better name
+
+    public function shouldSync(): bool;
 }

--- a/src/Database/Concerns/ResourceSyncing.php
+++ b/src/Database/Concerns/ResourceSyncing.php
@@ -13,7 +13,6 @@ trait ResourceSyncing
     public static function bootResourceSyncing(): void
     {
         static::saved(function (Syncable $model) {
-            dump($model->shouldSync());
             if ($model->shouldSync()) {
                 $model->triggerSyncEvent();
             }

--- a/src/Database/Concerns/ResourceSyncing.php
+++ b/src/Database/Concerns/ResourceSyncing.php
@@ -13,8 +13,10 @@ trait ResourceSyncing
     public static function bootResourceSyncing(): void
     {
         static::saved(function (Syncable $model) {
-            /** @var ResourceSyncing $model */
-            $model->triggerSyncEvent();
+            dump($model->shouldSync());
+            if ($model->shouldSync()) {
+                $model->triggerSyncEvent();
+            }
         });
 
         static::creating(function (self $model) {
@@ -36,5 +38,10 @@ trait ResourceSyncing
     public function getSyncedCreationAttributes(): array|null
     {
         return null;
+    }
+
+    public function shouldSync(): bool
+    {
+        return true;
     }
 }

--- a/src/Database/Models/TenantPivot.php
+++ b/src/Database/Models/TenantPivot.php
@@ -14,7 +14,7 @@ class TenantPivot extends Pivot
         static::saved(function (self $pivot) {
             $parent = $pivot->pivotParent;
 
-            if ($parent instanceof Syncable) {
+            if (($parent instanceof Syncable) && $parent->shouldSync()) {
                 $parent->triggerSyncEvent();
             }
         });

--- a/src/Database/Models/TenantPivot.php
+++ b/src/Database/Models/TenantPivot.php
@@ -14,7 +14,7 @@ class TenantPivot extends Pivot
         static::saved(function (self $pivot) {
             $parent = $pivot->pivotParent;
 
-            if (($parent instanceof Syncable) && $parent->shouldSync()) {
+            if ($parent instanceof Syncable && $parent->shouldSync()) {
                 $parent->triggerSyncEvent();
             }
         });

--- a/t
+++ b/t
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker-compose exec -T test vendor/bin/pest --no-coverage --filter "$@"

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -763,6 +763,25 @@ function creatingResourceInTenantDatabaseCreatesAndMapInCentralDatabase()
     expect(ResourceUser::first()->role)->toBe('commenter');
 }
 
+test('resources are synced only when sync is enabled', function () {
+    [$tenant1, $tenant2] = createTenantsAndRunMigrations();
+
+    tenancy()->initialize($tenant1);
+
+    TenantUserWithDisabledSync::create([
+        'global_id' => 'absd',
+        'name' => 'John Doe',
+        'email' => 'john@localhost',
+        'password' => 'password',
+        'role' => 'commenter',
+    ]);
+
+    tenancy()->end();
+
+    expect(CentralUser::all())->toHaveCount(0);
+
+})->group('current');
+
 /**
  * Create two tenants and run migrations for those tenants.
  */
@@ -977,5 +996,21 @@ class ResourceUserProvidingMixture extends ResourceUser
             'role' => 'admin',
             'password' => 'secret',
         ];
+    }
+}
+
+class CentralUserWithDisabledSync extends CentralUser
+{
+    public function shouldSync(): bool
+    {
+        return false;
+    }
+}
+
+class TenantUserWithDisabledSync extends CentralUser
+{
+    public function shouldSync(): bool
+    {
+        return false;
     }
 }

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -800,7 +800,7 @@ test('resources are synced only when sync is enabled', function () {
         expect(ResourceUser::all())->toHaveCount(0);
         expect(ResourceUser::whereGlobalId('acme')->first())->toBeNull();
     });
-})->group('current');
+});
 
 /**
  * Create two tenants and run migrations for those tenants.


### PR DESCRIPTION
Related PR #889. 

This PR adds the ability to ignore resource synchronization on demand. This adds the new method `shouldSync` which returns `true` by default. You can specify this method in a model like: 
```php
public function shouldSync(): bool
{
    return false;
}
```

You can specify any condition here: 
```php
public function shouldSync(): bool
{
    return $this->sync_me == 'yes'; // can be any condition
}
```

This is a useful feature when you want to ignore the sync on the go or based on condition. The attached PR has an excellent example. 