### PR TITLE
CachedTenantResolver missing cache case crash fix.

### DIFF
--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -27,9 +27,8 @@ abstract class CachedTenantResolver implements TenantResolver
 
         $key = $this->getCacheKey(...$args);
 
-        if ($this->cache->has($key)) {
-            $tenant = $this->cache->get($key);
-
+        $tenant = $this->cache->has($key) ? $this->cache->get($key) : null;
+        if ($tenant) {
             $this->resolved($tenant, ...$args);
 
             return $tenant;

--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -27,8 +27,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
         $key = $this->getCacheKey(...$args);
 
-        $tenant = $this->cache->has($key) ? $this->cache->get($key) : null;
-        if ($tenant) {
+        if ($tenant = $this->cache->get($key)) {
             $this->resolved($tenant, ...$args);
 
             return $tenant;


### PR DESCRIPTION
**Issue**: In case cache is broken or invalidated in parallel with request Resolver might crash because `has->($key)` will return `true`, but `$tenant` var will be `null`.

I do understand that this might not be the main issue, but still it`s better to find tenant without cache, then crash :)