### PR TITLE
Manual mode improvements (use correct event type, add new listeners)

### DIFF
--- a/src/Listeners/CreateTenantConnection.php
+++ b/src/Listeners/CreateTenantConnection.php
@@ -20,6 +20,7 @@ class CreateTenantConnection
         /** @var TenantWithDatabase $tenant */
         $tenant = $event->tenancy->tenant;
 
+        $this->database->purgeTenantConnection();
         $this->database->createTenantConnection($tenant);
     }
 }

--- a/src/Listeners/CreateTenantConnection.php
+++ b/src/Listeners/CreateTenantConnection.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy\Listeners;
 
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Database\DatabaseManager;
+use Stancl\Tenancy\Events\Contracts\TenancyEvent;
 use Stancl\Tenancy\Events\Contracts\TenantEvent;
 
 class CreateTenantConnection
@@ -15,10 +16,10 @@ class CreateTenantConnection
     ) {
     }
 
-    public function handle(TenantEvent $event): void
+    public function handle(TenancyEvent $event): void
     {
-        /** @var TenantWithDatabase */
-        $tenant = $event->tenant;
+        /** @var TenantWithDatabase $tenant */
+        $tenant = $event->tenancy->tenant;
 
         $this->database->createTenantConnection($tenant);
     }

--- a/src/Listeners/CreateTenantConnection.php
+++ b/src/Listeners/CreateTenantConnection.php
@@ -7,7 +7,6 @@ namespace Stancl\Tenancy\Listeners;
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 use Stancl\Tenancy\Database\DatabaseManager;
 use Stancl\Tenancy\Events\Contracts\TenancyEvent;
-use Stancl\Tenancy\Events\Contracts\TenantEvent;
 
 class CreateTenantConnection
 {

--- a/src/Listeners/UseCentralConnection.php
+++ b/src/Listeners/UseCentralConnection.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Listeners;
+
+use Illuminate\Foundation\Application;
+use Stancl\Tenancy\Database\DatabaseManager;
+use Stancl\Tenancy\Events\Contracts\TenancyEvent;
+
+class UseCentralConnection
+{
+    public function __construct(
+        protected DatabaseManager $database,
+        protected Application $app
+    ) {
+    }
+
+    public function handle(TenancyEvent $event): void
+    {
+        $this->database->purgeTenantConnection();
+        $this->database->setDefaultConnection($this->app['config']->get('tenancy.database.central_connection'));
+    }
+}

--- a/src/Listeners/UseCentralConnection.php
+++ b/src/Listeners/UseCentralConnection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Listeners;
 
-use Illuminate\Foundation\Application;
 use Stancl\Tenancy\Database\DatabaseManager;
 use Stancl\Tenancy\Events\Contracts\TenancyEvent;
 
@@ -12,13 +11,11 @@ class UseCentralConnection
 {
     public function __construct(
         protected DatabaseManager $database,
-        protected Application $app
     ) {
     }
 
     public function handle(TenancyEvent $event): void
     {
-        $this->database->purgeTenantConnection();
-        $this->database->setDefaultConnection($this->app['config']->get('tenancy.database.central_connection'));
+        $this->database->reconnectToCentral();
     }
 }

--- a/src/Listeners/UseTenantConnection.php
+++ b/src/Listeners/UseTenantConnection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Listeners;
+
+use Stancl\Tenancy\Database\DatabaseManager;
+use Stancl\Tenancy\Events\Contracts\TenancyEvent;
+
+class UseTenantConnection
+{
+    public function __construct(
+        protected DatabaseManager $database,
+    ) {
+    }
+
+    public function handle(TenancyEvent $event): void
+    {
+        $this->database->setDefaultConnection('tenant');
+    }
+}

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -3,18 +3,35 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
+use Stancl\JobPipeline\JobPipeline;
+use Stancl\Tenancy\Events\TenancyEnded;
 use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Events\TenantCreated;
+use Stancl\Tenancy\Jobs\CreateDatabase;
 use Stancl\Tenancy\Listeners\CreateTenantConnection;
+use Stancl\Tenancy\Listeners\UseCentralConnection;
+use Stancl\Tenancy\Listeners\UseTenantConnection;
 use \Stancl\Tenancy\Tests\Etc\Tenant;
 
 test('manual tenancy initialization works', function () {
     Event::listen(TenancyInitialized::class, CreateTenantConnection::class);
+    Event::listen(TenancyInitialized::class, UseTenantConnection::class);
+    Event::listen(TenancyEnded::class, UseCentralConnection::class);
 
     $tenant = Tenant::create();
 
-    expect(array_keys(config('database.connections')))->not()->toContain('tenant');
+    expect(array_keys(app('db')->getConnections()))->toBe(['central']);
+    pest()->assertArrayNotHasKey('tenant', config('database.connections'));
 
     tenancy()->initialize($tenant);
-    
-    expect(array_keys(config('database.connections')))->toContain('tenant');
+
+    expect(app('db')->getDefaultConnection())->toBe('tenant');
+    expect(array_keys(app('db')->getConnections()))->toBe(['central', 'tenant']);
+    pest()->assertArrayHasKey('tenant', config('database.connections'));
+
+    tenancy()->end();
+
+    expect(array_keys(app('db')->getConnections()))->toBe(['central']);
+    expect(config('database.connections.tenant'))->toBeNull();
+    expect(app('db')->getDefaultConnection())->toBe(config('tenancy.database.central_connection'));
 });

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -12,7 +12,9 @@ test('manual tenancy initialization works', function () {
 
     $tenant = Tenant::create();
 
-    tenancy()->initialize($tenant);
+    expect(array_keys(config('database.connections')))->not()->toContain('tenant');
 
-    expect(tenancy()->initialized)->toBeTrue();
+    tenancy()->initialize($tenant);
+    
+    expect(array_keys(config('database.connections')))->toContain('tenant');
 });

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -24,6 +24,7 @@ test('manual tenancy initialization works', function () {
 
     $tenant = Tenant::create();
 
+    expect(app('db')->getDefaultConnection())->toBe('central');
     expect(array_keys(app('db')->getConnections()))->toBe(['central', 'tenant_host_connection']);
     pest()->assertArrayNotHasKey('tenant', config('database.connections'));
 

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -30,7 +30,7 @@ test('manual tenancy initialization works', function () {
 
     tenancy()->initialize($tenant);
     
-    // Use the `tenant` connection to make sure the connection is useable and `tenant` connection is created inside the `db` class
+    // Trigger creation of the tenant connection
     createUsersTable();
 
     expect(app('db')->getDefaultConnection())->toBe('tenant');

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Listeners\CreateTenantConnection;
+use \Stancl\Tenancy\Tests\Etc\Tenant;
+
+test('manual tenancy initialization works', function () {
+    Event::listen(TenancyInitialized::class, CreateTenantConnection::class);
+
+    $tenant = Tenant::create();
+
+    tenancy()->initialize($tenant);
+
+    expect(tenancy()->initialized)->toBeTrue();
+});

--- a/tests/ManualModeTest.php
+++ b/tests/ManualModeTest.php
@@ -29,6 +29,8 @@ test('manual tenancy initialization works', function () {
     pest()->assertArrayNotHasKey('tenant', config('database.connections'));
 
     tenancy()->initialize($tenant);
+    
+    // Use the `tenant` connection to make sure the connection is useable and `tenant` connection is created inside the `db` class
     createUsersTable();
 
     expect(app('db')->getDefaultConnection())->toBe('tenant');


### PR DESCRIPTION
closes #899 

This PR fixes the issue described in #899, which is related to initializing tenancy manually using the `CreateTenantConnection` listener. The problem was, `CreateTenantConnection` expected "TenantEvent $event" while it received `TenancyEvent`. 

PR also added the new listeners to match the automatic bootstrappers test. 

- `UseTenantConnection` listener that calls `DatabaseManager::setDefaultConnection('tenant')`
- `UseCentralConnection` listener that calls DatabaseManager::reconnectToCentral()

Also, added tests to ensure manual tenancy initialization works fine. 