### PR TITLE
[4.x] Make `TenantDump` work when called outside the tenant context

### DIFF
--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -41,7 +41,7 @@ class TenantDump extends DumpCommand
             return 1;
         }
 
-        $tenant->run(fn() => parent::handle($connections, $dispatcher));
+        $tenant->run(fn () => parent::handle($connections, $dispatcher));
 
         return 0;
     }

--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -41,7 +41,7 @@ class TenantDump extends DumpCommand
             return 1;
         }
 
-        parent::handle($connections, $dispatcher);
+        $tenant->run(fn() => parent::handle($connections, $dispatcher));
 
         return 0;
     }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -134,7 +134,7 @@ test('dump command generates dump at the passed path', function() {
     expect($schemaPath)->toBeFile();
 });
 
-test('migrate command correctly uses the dump located at the configured schema path by default', function () {
+test('migrate command correctly uses the schema dump located at the configured schema path by default', function () {
     config(['tenancy.migration_parameters.--schema-path' => 'tests/Etc/tenant-schema.dump']);
     $tenant = Tenant::create();
 

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -29,10 +29,6 @@ beforeEach(function () {
         unlink($schemaPath);
     }
 
-    if (file_exists($schemaPath = database_path('tenant-schema.dump'))) {
-        unlink($schemaPath);
-    }
-
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -25,7 +25,7 @@ use Stancl\Tenancy\Listeners\RevertToCentralContext;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
 
 beforeEach(function () {
-    if (file_exists($schemaPath = database_path('schema/tenant-schema.dump'))) {
+    if (file_exists($schemaPath = 'tests/Etc/tenant-schema-test.dump')) {
         unlink($schemaPath);
     }
 
@@ -111,28 +111,45 @@ test('migrate command loads schema state', function () {
 
 test('dump command works', function () {
     $tenant = Tenant::create();
+    $schemaPath = 'tests/Etc/tenant-schema-test.dump';
+
     Artisan::call('tenants:migrate');
 
-    tenancy()->initialize($tenant);
+    expect($schemaPath)->not()->toBeFile();
 
-    Artisan::call('tenants:dump --path="tests/Etc/tenant-schema-test.dump"');
-    expect('tests/Etc/tenant-schema-test.dump')->toBeFile();
-});
-
-test('tenant dump file gets created as tenant-schema.dump in the database schema folder by default', function() {
-    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = database_path('schema/tenant-schema.dump')]);
-
-    $tenant = Tenant::create();
-    Artisan::call('tenants:migrate');
-
-    tenancy()->initialize($tenant);
-
-    Artisan::call('tenants:dump');
+    Artisan::call('tenants:dump ' . "--tenant='$tenant->id' --path='$schemaPath'");
 
     expect($schemaPath)->toBeFile();
 });
 
-test('migrate command uses the correct schema path by default', function () {
+test('dump command generates dump at the path specified in the tenancy migration parameters config', function() {
+    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = 'tests/Etc/tenant-schema-test.dump']);
+
+    $tenant = Tenant::create();
+
+    Artisan::call('tenants:migrate');
+
+    expect($schemaPath)->not()->toBeFile();
+
+    Artisan::call("tenants:dump --tenant='$tenant->id'");
+
+    expect($schemaPath)->toBeFile();
+});
+
+test('tenant dump file gets created at the path specified in the tenancy migration parameters config', function() {
+    $tenant = Tenant::create();
+    $schemaPath = 'tests/Etc/tenant-schema-test.dump';
+
+    Artisan::call('tenants:migrate');
+
+    expect($schemaPath)->not()->toBeFile();
+
+    Artisan::call("tenants:dump --tenant='$tenant->id' --path='$schemaPath'");
+
+    expect($schemaPath)->toBeFile();
+});
+
+test('migrate command correctly uses the dump located at the configured schema path by default', function () {
     config(['tenancy.migration_parameters.--schema-path' => 'tests/Etc/tenant-schema.dump']);
     $tenant = Tenant::create();
 
@@ -146,6 +163,7 @@ test('migrate command uses the correct schema path by default', function () {
 
     tenancy()->initialize($tenant);
 
+    // schema_users is a table included in the tests/Etc/tenant-schema dump
     // Check for both tables to see if missing migrations also get executed
     expect(Schema::hasTable('schema_users'))->toBeTrue();
     expect(Schema::hasTable('users'))->toBeTrue();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -134,19 +134,6 @@ test('dump command generates dump at the passed path', function() {
     expect($schemaPath)->toBeFile();
 });
 
-test('tenant dump file gets created at the path specified in the tenancy migration parameters config', function() {
-    $tenant = Tenant::create();
-    $schemaPath = 'tests/Etc/tenant-schema-test.dump';
-
-    Artisan::call('tenants:migrate');
-
-    expect($schemaPath)->not()->toBeFile();
-
-    Artisan::call("tenants:dump --tenant='$tenant->id' --path='$schemaPath'");
-
-    expect($schemaPath)->toBeFile();
-});
-
 test('migrate command correctly uses the dump located at the configured schema path by default', function () {
     config(['tenancy.migration_parameters.--schema-path' => 'tests/Etc/tenant-schema.dump']);
     $tenant = Tenant::create();

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -29,6 +29,10 @@ beforeEach(function () {
         unlink($schemaPath);
     }
 
+    if (file_exists($schemaPath = database_path('tenant-schema.dump'))) {
+        unlink($schemaPath);
+    }
+
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());
@@ -122,16 +126,14 @@ test('dump command works', function () {
     expect($schemaPath)->toBeFile();
 });
 
-test('dump command generates dump at the path specified in the tenancy migration parameters config', function() {
-    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = 'tests/Etc/tenant-schema-test.dump']);
-
+test('dump command generates dump at the passed path', function() {
     $tenant = Tenant::create();
 
     Artisan::call('tenants:migrate');
 
-    expect($schemaPath)->not()->toBeFile();
+    expect($schemaPath = 'tests/Etc/tenant-schema-test.dump')->not()->toBeFile();
 
-    Artisan::call("tenants:dump --tenant='$tenant->id'");
+    Artisan::call("tenants:dump --tenant='$tenant->id' --path='$schemaPath'");
 
     expect($schemaPath)->toBeFile();
 });


### PR DESCRIPTION
Calling the `TenantDump` command outside the tenant context (e.g., `artisan tenants:dump --tenant=acme` in the terminal) dumps the **central** database. This happens because the command doesn't run the parent as the tenant passed in the `--tenant` option.

This PR fixes the problem by moving the command's `parent::handle()` call inside `$tenants->run()`.