### PR TITLE
Use the hardcoded default path in `TenantDump` only if the path isn't configured

### DIFF
--- a/src/Commands/TenantDump.php
+++ b/src/Commands/TenantDump.php
@@ -23,7 +23,7 @@ class TenantDump extends DumpCommand
     public function handle(ConnectionResolverInterface $connections, Dispatcher $dispatcher): int
     {
         if (is_null($this->option('path'))) {
-            $this->input->setOption('path', database_path('schema/tenant-schema.dump'));
+            $this->input->setOption('path', config('tenancy.migration_parameters.--schema-path') ?? database_path('schema/tenant-schema.dump'));
         }
 
         $tenant = $this->option('tenant')

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -134,6 +134,20 @@ test('dump command generates dump at the passed path', function() {
     expect($schemaPath)->toBeFile();
 });
 
+test('dump command generates dump at the path specified in the tenancy migration parameters config', function() {
+    config(['tenancy.migration_parameters.--schema-path' => $schemaPath = 'tests/Etc/tenant-schema-test.dump']);
+
+    $tenant = Tenant::create();
+
+    Artisan::call('tenants:migrate');
+
+    expect($schemaPath)->not()->toBeFile();
+
+    Artisan::call("tenants:dump --tenant='$tenant->id'");
+
+    expect($schemaPath)->toBeFile();
+});
+
 test('migrate command correctly uses the schema dump located at the configured schema path by default', function () {
     config(['tenancy.migration_parameters.--schema-path' => 'tests/Etc/tenant-schema.dump']);
     $tenant = Tenant::create();


### PR DESCRIPTION
`TenantDump` was only generating the schema dump at the hardcoded path. This PR makes the command try using the path configured in `tenancy.migration_parameters.--schema-path`, and default to the hardcoded path only if the path isn't configured (if `config('tenancy.migration_parameters.--schema-path')` returns `null`).