### PR TITLE
Improve code of pending tenants

### DIFF
--- a/src/Commands/ClearPendingTenants.php
+++ b/src/Commands/ClearPendingTenants.php
@@ -23,8 +23,8 @@ class ClearPendingTenants extends Command
         // We compare the original expiration date to the new one to check if the new one is different later
         $originalExpirationDate = $expirationDate->copy()->toImmutable();
 
-        $olderThanDays = $this->option('older-than-days');
-        $olderThanHours = $this->option('older-than-hours');
+        $olderThanDays = (int) $this->option('older-than-days');
+        $olderThanHours = (int) $this->option('older-than-hours');
 
         if ($olderThanDays && $olderThanHours) {
             $this->line("<options=bold,reverse;fg=red> Cannot use '--older-than-days' and '--older-than-hours' together \n"); // todo@cli refactor all of these styled command outputs to use $this->components

--- a/src/Commands/ClearPendingTenants.php
+++ b/src/Commands/ClearPendingTenants.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Builder;
 class ClearPendingTenants extends Command
 {
     protected $signature = 'tenants:pending-clear
-                            {--all : Override the default settings and deletes all pending tenants}
                             {--older-than-days= : Deletes all pending tenants older than the amount of days}
                             {--older-than-hours= : Deletes all pending tenants older than the amount of hours}';
 
@@ -24,28 +23,22 @@ class ClearPendingTenants extends Command
         // We compare the original expiration date to the new one to check if the new one is different later
         $originalExpirationDate = $expirationDate->copy()->toImmutable();
 
-        // Skip the time constraints if the 'all' option is given
-        if (! $this->option('all')) {
-            /** @var ?int $olderThanDays */
-            $olderThanDays = $this->option('older-than-days');
+        $olderThanDays = $this->option('older-than-days');
+        $olderThanHours = $this->option('older-than-hours');
 
-            /** @var ?int $olderThanHours */
-            $olderThanHours = $this->option('older-than-hours');
+        if ($olderThanDays && $olderThanHours) {
+            $this->line("<options=bold,reverse;fg=red> Cannot use '--older-than-days' and '--older-than-hours' together \n"); // todo@cli refactor all of these styled command outputs to use $this->components
+            $this->line('Please, choose only one of these options.');
 
-            if ($olderThanDays && $olderThanHours) {
-                $this->line("<options=bold,reverse;fg=red> Cannot use '--older-than-days' and '--older-than-hours' together \n"); // todo@cli refactor all of these styled command outputs to use $this->components
-                $this->line('Please, choose only one of these options.');
+            return 1; // Exit code for failure
+        }
 
-                return 1; // Exit code for failure
-            }
+        if ($olderThanDays) {
+            $expirationDate->subDays($olderThanDays);
+        }
 
-            if ($olderThanDays) {
-                $expirationDate->subDays($olderThanDays);
-            }
-
-            if ($olderThanHours) {
-                $expirationDate->subHours($olderThanHours);
-            }
+        if ($olderThanHours) {
+            $expirationDate->subHours($olderThanHours);
         }
 
         $deletedTenantCount = tenancy()

--- a/src/Commands/ClearPendingTenants.php
+++ b/src/Commands/ClearPendingTenants.php
@@ -41,8 +41,7 @@ class ClearPendingTenants extends Command
             $expirationDate->subHours($olderThanHours);
         }
 
-        $deletedTenantCount = tenancy()
-            ->query()
+        $deletedTenantCount = tenancy()->query()
             ->onlyPending()
             ->when($originalExpirationDate->notEqualTo($expirationDate), function (Builder $query) use ($expirationDate) {
                 $query->where($query->getModel()->getColumnForQuery('pending_since'), '<', $expirationDate->timestamp);

--- a/src/Commands/CreatePendingTenants.php
+++ b/src/Commands/CreatePendingTenants.php
@@ -30,8 +30,8 @@ class CreatePendingTenants extends Command
             $createdCount++;
         }
 
-        $this->info($createdCount . ' ' . str('tenant')->plural($createdCount) . ' created.');
-        $this->info($maxPendingTenantCount . ' ' . str('tenant')->plural($maxPendingTenantCount) . ' ready to be used.');
+        $this->info($createdCount . ' pending ' . str('tenant')->plural($createdCount) . ' created.');
+        $this->info($maxPendingTenantCount . ' pending ' . str('tenant')->plural($maxPendingTenantCount) . ' ready to be used.');
 
         return 0;
     }

--- a/src/Commands/CreatePendingTenants.php
+++ b/src/Commands/CreatePendingTenants.php
@@ -39,8 +39,7 @@ class CreatePendingTenants extends Command
     /** Calculate the number of currently available pending tenants. */
     protected function getPendingTenantCount(): int
     {
-        return tenancy()
-            ->query()
+        return tenancy()->query()
             ->onlyPending()
             ->count();
     }

--- a/src/Concerns/HasTenantOptions.php
+++ b/src/Concerns/HasTenantOptions.php
@@ -23,8 +23,7 @@ trait HasTenantOptions
 
     protected function getTenants(): LazyCollection
     {
-        return tenancy()
-            ->query()
+        return tenancy()->query()
             ->when($this->option('tenants'), function ($query) {
                 $query->whereIn(tenancy()->model()->getTenantKeyName(), $this->option('tenants'));
             })

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -67,23 +67,6 @@ test('CreatePendingTenants command cannot run with both time constraints', funct
         ->assertFailed();
 });
 
-test('CreatePendingTenants commands all option overrides any config constraints', function () {
-    Tenant::createPending();
-    Tenant::createPending();
-
-    tenancy()->model()->query()->onlyPending()->first()->update([
-        'pending_since' => now()->subDays(10)
-    ]);
-
-    config(['tenancy.pending.older_than_days' => 4]);
-
-    Artisan::call(ClearPendingTenants::class, [
-        '--all' => true
-    ]);
-
-    expect(Tenant::onlyPending()->count())->toBe(0);
-});
-
 test('tenancy can check if there are any pending tenants', function () {
     expect(Tenant::onlyPending()->exists())->toBeFalse();
 


### PR DESCRIPTION
While documenting the pending tenants feature, I discovered that the `ClearPendingTenants` command probably doesn't need the `--all` option.

The option was there so that the time constraint options (e.g. `--older-than-days`) from config could have been overridden. Now that the options can only be passed, I don't think the option is needed.