### PR TITLE
Add session state when impersonating tenant 

### DIFF
--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -48,6 +48,23 @@ class UserImpersonation implements Feature
 
         $token->delete();
 
+        session()->put('tenancy_impersonation', true);
+
         return redirect($token->redirect_url);
+    }
+
+    public static function isImpersonating(): bool
+    {
+        return session()->has('tenancy_impersonation');
+    }
+
+    /**
+     * Logout and forget session
+     */
+    public static function stop(): void
+    {
+        auth()->logout();
+
+        session()->forget('tenancy_impersonation');
     }
 }

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -59,7 +59,7 @@ class UserImpersonation implements Feature
     }
 
     /**
-     * Logout and forget session
+     * Logout and forget session.
      */
     public static function stop(): void
     {

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -48,14 +48,14 @@ class UserImpersonation implements Feature
 
         $token->delete();
 
-        session()->put('tenancy_impersonation', true);
+        session()->put('tenancy_impersonating', true);
 
         return redirect($token->redirect_url);
     }
 
     public static function isImpersonating(): bool
     {
-        return session()->has('tenancy_impersonation');
+        return session()->has('tenancy_impersonating');
     }
 
     /**
@@ -65,6 +65,6 @@ class UserImpersonation implements Feature
     {
         auth()->logout();
 
-        session()->forget('tenancy_impersonation');
+        session()->forget('tenancy_impersonating');
     }
 }

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -61,7 +61,7 @@ class UserImpersonation implements Feature
     /**
      * Logout and forget session.
      */
-    public static function stop(): void
+    public static function leave(): void
     {
         auth()->logout();
 

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -59,7 +59,7 @@ class UserImpersonation implements Feature
     }
 
     /**
-     * Logout and forget session.
+     * Logout from the current domain and forget impersonation session.
      */
     public static function leave(): void
     {

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -61,7 +61,7 @@ class UserImpersonation implements Feature
     /**
      * Logout from the current domain and forget impersonation session.
      */
-    public static function leave(): void
+    public static function leave(): void // todo possibly rename
     {
         auth()->logout();
 

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 use Carbon\Carbon;
 use Carbon\CarbonInterval;
-use Illuminate\Database\Schema\Blueprint;
-use Illuminate\Support\Facades\Hash;
-use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 use Illuminate\Auth\TokenGuard;
 use Illuminate\Auth\SessionGuard;
@@ -333,14 +330,6 @@ class ImpersonationUser extends Authenticable
 class AnotherImpersonationUser extends Authenticable
 {
     protected $guarded = [];
-
-    protected $table = 'users';
-}
-
-class Admin extends Authenticable
-{
-    protected $guarded = [];
-    public $timestamps = false;
 
     protected $table = 'users';
 }

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -85,7 +85,7 @@ test('tenant user can be impersonated on a tenant domain', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonation'))->toBeTrue();
+    expect(session('tenancy_impersonating'))->toBeTrue();
 
     // Leave impersonation
     UserImpersonation::leave();

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -88,7 +88,7 @@ test('tenant user can be impersonated on a tenant domain', function () {
     expect(session('tenancy_impersonation'))->toBeTrue();
 
     // Leave impersonation
-    UserImpersonation::stop();
+    UserImpersonation::leave();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
     expect(session('tenancy_impersonation'))->toBeNull();
@@ -134,7 +134,7 @@ test('tenant user can be impersonated on a tenant path', function () {
     expect(session('tenancy_impersonation'))->toBeTrue();
 
     // Leave impersonation
-    UserImpersonation::stop();
+    UserImpersonation::leave();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
     expect(session('tenancy_impersonation'))->toBeNull();

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -91,7 +91,7 @@ test('tenant user can be impersonated on a tenant domain', function () {
     UserImpersonation::leave();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
-    expect(session('tenancy_impersonation'))->toBeNull();
+    expect(session('tenancy_impersonating'))->toBeNull();
 
     // Assert can't access the tenant dashboard
     pest()->get('http://foo.localhost/dashboard')
@@ -131,13 +131,13 @@ test('tenant user can be impersonated on a tenant path', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonation'))->toBeTrue();
+    expect(session('tenancy_impersonating'))->toBeTrue();
 
     // Leave impersonation
     UserImpersonation::leave();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
-    expect(session('tenancy_impersonation'))->toBeNull();
+    expect(session('tenancy_impersonating'))->toBeNull();
 
     // Assert can't access the tenant dashboard
     pest()->get('/acme/dashboard')


### PR DESCRIPTION
Closes #548 

# Problem 
When impersonating a tenant, there is no indication of whether we are impersonating. A common use case shows a banner saying "Impersonating" and a button to stop/leave impersonation. 

# Solution 
This PR adds the session key `tenancy_impersonation` when impersonating a tenant. Now this session key can be used to show banner etc. There are also new methods added. 

- `isImpersonating()` to check if the tenant is being impersonated
- `leave()` to leave impersonation. It logout the user and remove the session impersonation state. **You need to handle redirection here**, `leave()` doesn't enforce any redirection. 

## Usage 
[Setup Impersonation](https://tenancyforlaravel.com/docs/v3/features/user-impersonation) same as you do in V3. You can use the impersonation state as follows: 
```php
// TRUE if you are impersonating.
UserImpersonation::isImpersonating();

// Logout from the current domain and forget impersonation session.
UserImpersonation::leave();
```
You need to handle redirection when leaving impersonation. Something like this in tenant routes: 
```php
Route::get('impersonantion/leave', function() {
  UserImpersonantion::leave();
  
  return redirect()->to(config('app.url') . '/dashboard') // redirect to central domain dashboard. 
}) 
```

## Important points you should know about the Impersonation feature in this package. 

- When using domain/subdomain identification, the central or admin user auth session will be preserved because each tenant has a different domain. I'm simple words, You can have two tabs side by side one with an admin logged-in user and one with tenant impersonation. 
- When using path/request data identification, the central or admin user auth session will be destroyed because it's on the same domain. In simple words, the admin will be logged out because we are starting another auth session on the same domain. 
- Setting the `SESSION_DOMAIN` env var can change the behavior of this feature, e.g., sharing sessions with subdomains will destroy auth sessions from other domains. 

### Working when using domain/subdomain

https://user-images.githubusercontent.com/54532330/207320271-65501f21-751d-4b8c-b5dd-d8cdb744f653.mov

### Working when using path identification

https://user-images.githubusercontent.com/54532330/207322104-656cd932-ad90-419d-a6e7-c3c36d7c2817.mov
