### PR TITLE
Improve commands CLI output

### DIFF
--- a/src/Commands/ClearPendingTenants.php
+++ b/src/Commands/ClearPendingTenants.php
@@ -17,7 +17,7 @@ class ClearPendingTenants extends Command
 
     public function handle(): int
     {
-        $this->info('Removing pending tenants.');
+        $this->components->info('Removing pending tenants.');
 
         $expirationDate = now();
         // We compare the original expiration date to the new one to check if the new one is different later
@@ -27,8 +27,8 @@ class ClearPendingTenants extends Command
         $olderThanHours = (int) $this->option('older-than-hours');
 
         if ($olderThanDays && $olderThanHours) {
-            $this->line("<options=bold,reverse;fg=red> Cannot use '--older-than-days' and '--older-than-hours' together \n"); // todo@cli refactor all of these styled command outputs to use $this->components
-            $this->line('Please, choose only one of these options.');
+            $this->components->error("Cannot use '--older-than-days' and '--older-than-hours' together");
+            $this->components->error('Please, choose only one of these options.');
 
             return 1; // Exit code for failure
         }
@@ -51,7 +51,7 @@ class ClearPendingTenants extends Command
             ->delete()
             ->count();
 
-        $this->info($deletedTenantCount . ' pending ' . str('tenant')->plural($deletedTenantCount) . ' deleted.');
+        $this->components->info($deletedTenantCount . ' pending ' . str('tenant')->plural($deletedTenantCount) . ' deleted.');
 
         return 0;
     }

--- a/src/Commands/ClearPendingTenants.php
+++ b/src/Commands/ClearPendingTenants.php
@@ -27,8 +27,7 @@ class ClearPendingTenants extends Command
         $olderThanHours = (int) $this->option('older-than-hours');
 
         if ($olderThanDays && $olderThanHours) {
-            $this->components->error("Cannot use '--older-than-days' and '--older-than-hours' together");
-            $this->components->error('Please, choose only one of these options.');
+            $this->components->error("Cannot use '--older-than-days' and '--older-than-hours' together. Please, choose only one of these options.");
 
             return 1; // Exit code for failure
         }

--- a/src/Commands/CreatePendingTenants.php
+++ b/src/Commands/CreatePendingTenants.php
@@ -14,7 +14,7 @@ class CreatePendingTenants extends Command
 
     public function handle(): int
     {
-        $this->info('Creating pending tenants.');
+        $this->components->info('Creating pending tenants.');
 
         $maxPendingTenantCount = (int) ($this->option('count') ?? config('tenancy.pending.count'));
         $pendingTenantCount = $this->getPendingTenantCount();
@@ -30,8 +30,8 @@ class CreatePendingTenants extends Command
             $createdCount++;
         }
 
-        $this->info($createdCount . ' pending ' . str('tenant')->plural($createdCount) . ' created.');
-        $this->info($maxPendingTenantCount . ' pending ' . str('tenant')->plural($maxPendingTenantCount) . ' ready to be used.');
+        $this->components->info($createdCount . ' pending ' . str('tenant')->plural($createdCount) . ' created.');
+        $this->components->info($maxPendingTenantCount . ' pending ' . str('tenant')->plural($maxPendingTenantCount) . ' ready to be used.');
 
         return 0;
     }

--- a/src/Commands/Link.php
+++ b/src/Commands/Link.php
@@ -34,7 +34,7 @@ class Link extends Command
                 $this->createLinks($tenants);
             }
         } catch (Exception $exception) {
-            $this->error($exception->getMessage());
+            $this->components->error($exception->getMessage());
 
             return 1;
         }


### PR DESCRIPTION
This is a simple PR that improves the CLI output using the `components->info/error` methods. Here are some examples. 

Before
<img width="719" alt="Screenshot 2022-12-14 at 3 02 08 PM" src="https://user-images.githubusercontent.com/54532330/207570391-d41658ef-e569-46ef-91a0-e1da51483b1b.png">
<img width="696" alt="Screenshot 2022-12-14 at 3 04 26 PM" src="https://user-images.githubusercontent.com/54532330/207570481-d0754c6c-cd0c-44c9-8240-747a3b5b9785.png">

After 
<img width="769" alt="Screenshot 2022-12-14 at 3 03 08 PM" src="https://user-images.githubusercontent.com/54532330/207570424-5e68b7e2-b1af-4db6-b510-51957e1498ee.png">
<img width="667" alt="Screenshot 2022-12-14 at 3 05 15 PM" src="https://user-images.githubusercontent.com/54532330/207570526-66718c76-353a-4e38-ae23-758cfbdc45f4.png">



