### PR TITLE
Use `invade()` instead of Reflection code

### DIFF
--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -331,15 +331,7 @@ function getDiskPrefix(string $disk): string
     /** @var FilesystemAdapter $disk */
     $disk = Storage::disk($disk);
     $adapter = $disk->getAdapter();
+    $prefix = invade(invade($adapter)->prefixer)->prefix;
 
-     $prefixer = (new ReflectionObject($adapter))->getProperty('prefixer');
-     $prefixer->setAccessible(true);
-
-     // reflection -> instance
-     $prefixer = $prefixer->getValue($adapter);
-
-     $prefix = (new ReflectionProperty($prefixer, 'prefix'));
-     $prefix->setAccessible(true);
-
-     return $prefix->getValue($prefixer);
+    return $prefix;
 }


### PR DESCRIPTION
This PR uses the `invade()` helper instead of the Reflection code. I found only one instance of Reflection code in the codebase, so it's a small improvement.