### PR TITLE
Allow defining the tenant connection template using array syntax in config

### DIFF
--- a/src/Database/DatabaseConfig.php
+++ b/src/Database/DatabaseConfig.php
@@ -87,7 +87,7 @@ class DatabaseConfig
     {
         $this->tenant->setInternal('db_name', $this->getName());
 
-        if ($this->connectionDriverManager($this->getTemplateConnectionName()) instanceof Contracts\ManagesDatabaseUsers) {
+        if ($this->connectionDriverManager($this->getTemplateConnectionDriver()) instanceof Contracts\ManagesDatabaseUsers) {
             $this->tenant->setInternal('db_username', $this->getUsername() ?? (static::$usernameGenerator)($this->tenant));
             $this->tenant->setInternal('db_password', $this->getPassword() ?? (static::$passwordGenerator)($this->tenant));
         }
@@ -97,11 +97,24 @@ class DatabaseConfig
         }
     }
 
-    public function getTemplateConnectionName(): string
+    public function getTemplateConnectionDriver(): string
     {
-        return $this->tenant->getInternal('db_connection')
-            ?? config('tenancy.database.template_tenant_connection')
-            ?? config('tenancy.database.central_connection');
+        return $this->getTemplateConnection()['driver'];
+    }
+
+    public function getTemplateConnection(): array
+    {
+        if ($template = $this->tenant->getInternal('db_connection')) {
+            return config("database.connections.{$template}");
+        }
+
+        if ($template = config('tenancy.database.template_tenant_connection')) {
+            return is_array($template) ? $template : config("database.connections.{$template}");
+        }
+
+        $template = config('tenancy.database.central_connection');
+
+        return config("database.connections.{$template}");
     }
 
     public function getTenantHostConnectionName(): string
@@ -114,8 +127,7 @@ class DatabaseConfig
      */
     public function connection(): array
     {
-        $template = $this->getTemplateConnectionName();
-        $templateConnection = config("database.connections.{$template}");
+        $templateConnection = $this->getTemplateConnection();
 
         return $this->manager()->makeConnectionConfig(
             array_merge($templateConnection, $this->tenantConfig()),
@@ -129,10 +141,9 @@ class DatabaseConfig
     public function hostConnection(): array
     {
         $config = $this->tenantConfig();
-        $template = $this->getTemplateConnectionName();
-        $templateConnection = config("database.connections.{$template}");
+        $templateConnection = $this->getTemplateConnection();
 
-        if ($this->connectionDriverManager($template) instanceof Contracts\ManagesDatabaseUsers) {
+        if ($this->connectionDriverManager($this->getTemplateConnectionDriver()) instanceof Contracts\ManagesDatabaseUsers) {
             // We're removing the username and password because user with these credentials is not created yet
             // If you need to provide username and password when using PermissionControlledMySQLDatabaseManager,
             // consider creating a new connection and use it as `tenancy_db_connection` tenant config key

--- a/src/Database/DatabaseConfig.php
+++ b/src/Database/DatabaseConfig.php
@@ -109,12 +109,17 @@ class DatabaseConfig
         }
 
         if ($template = config('tenancy.database.template_tenant_connection')) {
-            return is_array($template) ? $template : config("database.connections.{$template}");
+            return is_array($template) ? array_merge($this->getCentralConnection(), $template) : config("database.connections.{$template}");
         }
 
-        $template = config('tenancy.database.central_connection');
+        return $this->getCentralConnection();
+    }
 
-        return config("database.connections.{$template}");
+    protected function getCentralConnection(): array
+    {
+        $centralConnectionName = config('tenancy.database.central_connection');
+
+        return config("database.connections.{$centralConnectionName}");
     }
 
     public function getTenantHostConnectionName(): string

--- a/src/Database/DatabaseConfig.php
+++ b/src/Database/DatabaseConfig.php
@@ -207,7 +207,7 @@ class DatabaseConfig
         $tenantHostConnectionName = $this->getTenantHostConnectionName();
         config(["database.connections.{$tenantHostConnectionName}" => $this->hostConnection()]);
 
-        $manager = $this->connectionDriverManager($tenantHostConnectionName);
+        $manager = $this->connectionDriverManager(config("database.connections.{$tenantHostConnectionName}.driver"));
 
         if ($manager instanceof Contracts\StatefulTenantDatabaseManager) {
             $manager->setConnection($tenantHostConnectionName);
@@ -222,10 +222,8 @@ class DatabaseConfig
      *
      * @throws DatabaseManagerNotRegisteredException
      */
-    protected function connectionDriverManager(string $connectionName): Contracts\TenantDatabaseManager
+    protected function connectionDriverManager(string $driver): Contracts\TenantDatabaseManager
     {
-        $driver = config("database.connections.{$connectionName}.driver");
-
         $databaseManagers = config('tenancy.database.managers');
 
         if (! array_key_exists($driver, $databaseManagers)) {

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -390,7 +390,7 @@ test('path used by sqlite manager can be customized', function () {
     expect(file_exists($customPath . '/' . $name))->toBeTrue();
 });
 
-test('template tenant connection value can be connection name or connection array', function () {
+test('you can define the connection template array in template_tenant_connection or use a name of an existing connection template', function () {
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -411,7 +411,7 @@ test('template tenant connection config can be both connection name or connectio
     expect($manager->database()->getConfig('host'))->toBe('mysql');
 
     config([
-        'tenancy.database.template_tenant_connection' =>  [
+        'tenancy.database.template_tenant_connection' => [
             'driver' => 'mysql',
             'url' => null,
             'host' => 'mysql2',

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -390,7 +390,7 @@ test('path used by sqlite manager can be customized', function () {
     expect(file_exists($customPath . '/' . $name))->toBeTrue();
 });
 
-test('template tenant connection config can be both connection name or connection array', function () {
+test('template tenant connection value can be connection name or connection array', function () {
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -436,7 +436,7 @@ test('the tenant connection template can be specified either by name or as a con
 
     /** @var MySQLDatabaseManager $manager */
     $manager = $tenant->database()->manager();
-    expect($manager->databaseExists($name))->toBeTrue();
+    expect($manager->databaseExists($name))->toBeTrue(); // tenant connection works
     expect($manager->database()->getConfig('host'))->toBe('mysql2');
 });
 
@@ -460,7 +460,7 @@ test('partial tenant connection templates get merged into the central connection
 
     /** @var MySQLDatabaseManager $manager */
     $manager = $tenant->database()->manager();
-    expect($manager->databaseExists($name))->toBeTrue();
+    expect($manager->databaseExists($name))->toBeTrue(); // tenant connection works
     expect($manager->database()->getConfig('host'))->toBe('mysql2');
     expect($manager->database()->getConfig('url'))->toBeNull();
 });

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -438,7 +438,7 @@ test('template tenant connection config can be both connection name or connectio
     $manager = $tenant->database()->manager();
     expect($manager->databaseExists($name))->toBeTrue();
     expect($manager->database()->getConfig('host'))->toBe('mysql2');
-})->group('current');
+});
 
 // Datasets
 dataset('database_managers', [

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -390,7 +390,7 @@ test('path used by sqlite manager can be customized', function () {
     expect(file_exists($customPath . '/' . $name))->toBeTrue();
 });
 
-test('you can define the connection template array in template_tenant_connection or use a name of an existing connection template', function () {
+test('the tenant connection template can be specified either by name or as a connection array', function () {
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());
@@ -440,7 +440,7 @@ test('you can define the connection template array in template_tenant_connection
     expect($manager->database()->getConfig('host'))->toBe('mysql2');
 });
 
-test('you can define the partial connection template array in template_tenant_connection and it will be completed by merging into the central connection', function () {
+test('partial tenant connection templates get merged into the central connection template', function () {
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -440,7 +440,7 @@ test('you can define the connection template array in template_tenant_connection
     expect($manager->database()->getConfig('host'))->toBe('mysql2');
 });
 
-test('template tenant connection value can be partial database config', function () {
+test('you can define the partial connection template array in template_tenant_connection and it will be completed by merging into the central connection', function () {
     Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
         return $event->tenant;
     })->toListener());


### PR DESCRIPTION
Closes https://github.com/archtechx/tenancy/issues/529

This PR allows defining the template connection using an array or partial array (partial database configuration).  When the configuration is partial, it will use the rest from the central connection.

## Usages 

1. Using full database configuration array like this: 
```php
'template_tenant_connection' => [
    'driver' => 'mysql',
    'url' => null,
    'host' => 'mysql2',
    'port' => '3306',
    'database' => 'main',
    'username' => 'root',
    'password' => 'password',
    'unix_socket' => '',
    'charset' => 'utf8mb4',
    'collation' => 'utf8mb4_unicode_ci',
    'prefix' => '',
    'prefix_indexes' => true,
    'strict' => true,
    'engine' => null,
    'options' => [],
],
```

2. Using partial database configuration. The rest will be picked from the central connection.
```php
'template_tenant_connection' => [
    'host' => 'mysql2',
],
```

3. You can still use the connection name from `config/database.php` like this: 
```php
'template_tenant_connection' => 'mysql'
```