### PR TITLE
Cache crash fix for `3.x`

### DIFF
--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -36,9 +36,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
         $key = $this->getCacheKey(...$args);
 
-        if ($this->cache->has($key)) {
-            $tenant = $this->cache->get($key);
-
+        if ($tenant = $this->cache->get($key)) {
             $this->resolved($tenant, ...$args);
 
             return $tenant;


### PR DESCRIPTION
This PR introduces the change from https://github.com/archtechx/tenancy/pull/1005 to `3.x`