### PR TITLE
Add AuthTenancyBootstrapper.

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -32,6 +32,7 @@ return [
         Stancl\Tenancy\Bootstrappers\CacheTenancyBootstrapper::class,
         Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper::class,
         Stancl\Tenancy\Bootstrappers\QueueTenancyBootstrapper::class,
+        Stancl\Tenancy\Bootstrappers\AuthTenancyBootstrapper::class,
         // Stancl\Tenancy\Bootstrappers\RedisTenancyBootstrapper::class, // Note: phpredis is needed
     ],
 

--- a/src/Bootstrappers/AuthTenancyBootstrapper.php
+++ b/src/Bootstrappers/AuthTenancyBootstrapper.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Stancl\Tenancy\Bootstrappers;
+
+use Illuminate\Support\Facades\App;
+use Stancl\Tenancy\Contracts\TenancyBootstrapper;
+use Stancl\Tenancy\Contracts\Tenant;
+
+class AuthTenancyBootstrapper implements TenancyBootstrapper
+{
+
+    public function bootstrap(Tenant $tenant)
+    {
+        // empty
+    }
+
+    public function revert()
+    {
+        App::forgetInstance('auth.password');
+    }
+}


### PR DESCRIPTION
Remove the 'auth.password' singleton from the container. This will ensure a new instance is created when another tenant needs it in the same app lifecycle.

Fixes #1052