### PR TITLE
[4.x] Set `app.url` config in UrlTenancyBootstrapper

### DIFF
--- a/src/Bootstrappers/UrlTenancyBootstrapper.php
+++ b/src/Bootstrappers/UrlTenancyBootstrapper.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Bootstrappers;
 
 use Closure;
+use Illuminate\Config\Repository;
 use Illuminate\Contracts\Routing\UrlGenerator;
 use Stancl\Tenancy\Contracts\TenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Tenant;
@@ -16,6 +17,7 @@ class UrlTenancyBootstrapper implements TenancyBootstrapper
 
     public function __construct(
         protected UrlGenerator $urlGenerator,
+        protected Repository $config,
     ) {
     }
 
@@ -24,12 +26,16 @@ class UrlTenancyBootstrapper implements TenancyBootstrapper
         $this->originalRootUrl = $this->urlGenerator->to('/');
 
         if (static::$rootUrlOverride) {
-            $this->urlGenerator->forceRootUrl((static::$rootUrlOverride)($tenant));
+            $newRootUrl = (static::$rootUrlOverride)($tenant);
+
+            $this->urlGenerator->forceRootUrl($newRootUrl);
+            $this->config->set('app.url', $newRootUrl);
         }
     }
 
     public function revert(): void
     {
         $this->urlGenerator->forceRootUrl($this->originalRootUrl);
+        $this->config->set('app.url', $this->originalRootUrl);
     }
 }

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -396,6 +396,7 @@ test('url bootstrapper overrides the root url when tenancy gets initialized and 
     });
 
     $baseUrl = url(route('home'));
+    config(['app.url' => $baseUrl]);
 
     $rootUrlOverride = function (Tenant $tenant) use ($baseUrl) {
         $scheme = str($baseUrl)->before('://');

--- a/tests/BootstrapperTest.php
+++ b/tests/BootstrapperTest.php
@@ -413,14 +413,17 @@ test('url bootstrapper overrides the root url when tenancy gets initialized and 
 
     expect(url(route('home')))->toBe($baseUrl);
     expect(URL::to('/'))->toBe($baseUrl);
+    expect(config('app.url'))->toBe($baseUrl);
 
     tenancy()->initialize($tenant);
 
     expect(url(route('home')))->toBe($tenantUrl);
     expect(URL::to('/'))->toBe($tenantUrl);
+    expect(config('app.url'))->toBe($tenantUrl);
 
     tenancy()->end();
 
     expect(url(route('home')))->toBe($baseUrl);
     expect(URL::to('/'))->toBe($baseUrl);
+    expect(config('app.url'))->toBe($baseUrl);
 });

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,17 +4,17 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Tests;
 
-use Dotenv\Dotenv;
-use Illuminate\Foundation\Application;
-use Illuminate\Support\Facades\Redis;
 use PDO;
-use Stancl\Tenancy\Bootstrappers\BatchTenancyBootstrapper;
-use Stancl\Tenancy\Bootstrappers\RedisTenancyBootstrapper;
-use Stancl\Tenancy\Facades\GlobalCache;
+use Dotenv\Dotenv;
 use Stancl\Tenancy\Facades\Tenancy;
-use Stancl\Tenancy\TenancyServiceProvider;
 use Stancl\Tenancy\Tests\Etc\Tenant;
+use Illuminate\Support\Facades\Redis;
+use Illuminate\Foundation\Application;
+use Stancl\Tenancy\Facades\GlobalCache;
+use Stancl\Tenancy\TenancyServiceProvider;
+use Stancl\Tenancy\Bootstrappers\UrlTenancyBootstrapper;
 use Stancl\Tenancy\Bootstrappers\MailTenancyBootstrapper;
+use Stancl\Tenancy\Bootstrappers\RedisTenancyBootstrapper;
 
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
@@ -106,6 +106,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
             ],
             'tenancy.bootstrappers.redis' => RedisTenancyBootstrapper::class, // todo1 change this to []? two tests in TenantDatabaseManagerTest are failing with that
             'tenancy.bootstrappers.mail' => MailTenancyBootstrapper::class,
+            'tenancy.bootstrappers.url' => UrlTenancyBootstrapper::class,
             'queue.connections.central' => [
                 'driver' => 'sync',
                 'central' => true,
@@ -116,6 +117,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
         $app->singleton(RedisTenancyBootstrapper::class); // todo (Samuel) use proper approach eg config for singleton registration
         $app->singleton(MailTenancyBootstrapper::class);
+        $app->singleton(UrlTenancyBootstrapper::class);
     }
 
     protected function getPackageProviders($app)


### PR DESCRIPTION
This PR expands https://github.com/archtechx/tenancy/pull/1044. Instead of updating just the URL generator's root URL, we also update the `app.url` config, so that the app URL override is also reflected there.