### PR TITLE
Feature/update resource in central database

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,9 @@ env:
 
 on:
   push:
-    branches: [ 3.x, 2.x, master ]
+    branches: [ 3.x, 2.x ]
   pull_request:
-    branches: [ 3.x, 2.x, master ]
+    branches: [ 3.x, 2.x ]
 
 jobs:
   tests:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,4 +21,4 @@ services:
     platform: linux/amd64
 ```
 
-to `docker-compose.override.yml` to make `docker-compose up-d` work on M1.
+to `docker-compose.override.yml` to make `docker-compose up -d` work on M1.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,5 +1,5 @@
 # Get Support
 
-If you need help with implementing the package, you can join our community [Discord server](https://discord.gg/7cpgPxv) and ask in `#help`.
+If you need help with implementing the package, you can join our community [Discord server](https://archte.ch/discord) and ask in `#tenancy-help`.
 
 If you're interested in paid consulting from the maintainer, see the [contact page](https://tenancyforlaravel.com/contact/) on our website.

--- a/assets/config.php
+++ b/assets/config.php
@@ -139,7 +139,7 @@ return [
     ],
 
     /**
-     * Redis tenancy config. Used by RedisTenancyBoostrapper.
+     * Redis tenancy config. Used by RedisTenancyBootstrapper.
      *
      * Note: You need phpredis to use Redis tenancy.
      *

--- a/assets/config.php
+++ b/assets/config.php
@@ -168,6 +168,7 @@ return [
         // Stancl\Tenancy\Features\UniversalRoutes::class,
         // Stancl\Tenancy\Features\TenantConfig::class, // https://tenancyforlaravel.com/docs/v3/features/tenant-config
         // Stancl\Tenancy\Features\CrossDomainRedirect::class, // https://tenancyforlaravel.com/docs/v3/features/cross-domain-redirect
+        // Stancl\Tenancy\Features\ViteBundler::class,
     ],
 
     /**

--- a/assets/config.php
+++ b/assets/config.php
@@ -196,4 +196,9 @@ return [
         '--class' => 'DatabaseSeeder', // root seeder class
         // '--force' => true,
     ],
+
+    /** 
+     * Allow the resource be created in the central DB just with the synced attributes.
+    */
+    'created_only_with_synced_attributes' => false,
 ];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,6 +18,7 @@
             <directory suffix=".php">./src</directory>
             <exclude>
                 <file>./src/routes.php</file>
+                <file>./src/Vite.php</file>
             </exclude>
         </whitelist>
     </filter>

--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Controllers;
 
 use Illuminate\Routing\Controller;
+use Throwable;
 
 class TenantAssetsController extends Controller
 {
@@ -15,11 +16,13 @@ class TenantAssetsController extends Controller
         $this->middleware(static::$tenancyMiddleware);
     }
 
-    public function asset($path)
+    public function asset($path = null)
     {
+        abort_if($path === null, 404);
+
         try {
             return response()->file(storage_path("app/public/$path"));
-        } catch (\Throwable $th) {
+        } catch (Throwable $th) {
             abort(404);
         }
     }

--- a/src/Database/Models/Tenant.php
+++ b/src/Database/Models/Tenant.php
@@ -28,6 +28,8 @@ class Tenant extends Model implements Contracts\Tenant
         Concerns\TenantRun,
         Concerns\InvalidatesResolverCache;
 
+    protected static $modelsShouldPreventAccessingMissingAttributes = false;
+
     protected $table = 'tenants';
     protected $primaryKey = 'id';
     protected $guarded = [];

--- a/src/Features/TenantConfig.php
+++ b/src/Features/TenantConfig.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy\Features;
 
 use Illuminate\Contracts\Config\Repository;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Stancl\Tenancy\Contracts\Feature;
 use Stancl\Tenancy\Contracts\Tenant;
@@ -45,7 +46,7 @@ class TenantConfig implements Feature
     {
         /** @var Tenant|Model $tenant */
         foreach (static::$storageToConfigMap as $storageKey => $configKey) {
-            $override = $tenant->getAttribute($storageKey);
+            $override = Arr::get($tenant, $storageKey);
 
             if (! is_null($override)) {
                 if (is_array($configKey)) {

--- a/src/Features/ViteBundler.php
+++ b/src/Features/ViteBundler.php
@@ -11,7 +11,8 @@ use Stancl\Tenancy\Vite;
 
 class ViteBundler implements Feature
 {
-    protected Application $app;
+    /** @var Application */
+    protected $app;
 
     public function __construct(Application $app)
     {

--- a/src/Features/ViteBundler.php
+++ b/src/Features/ViteBundler.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Features;
+
+use Illuminate\Foundation\Application;
+use Illuminate\Foundation\Vite as FoundationVite;
+use Stancl\Tenancy\Contracts\Feature;
+use Stancl\Tenancy\Tenancy;
+use Stancl\Tenancy\Vite as StanclVite;
+
+class ViteBundler implements Feature
+{
+    public function __construct(protected Application $app) { }
+
+    public function bootstrap(Tenancy $tenancy): void
+    {
+        $this->app->singleton(FoundationVite::class, StanclVite::class);
+    }
+}

--- a/src/Features/ViteBundler.php
+++ b/src/Features/ViteBundler.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\Features;
 
 use Illuminate\Foundation\Application;
-use Illuminate\Foundation\Vite as FoundationVite;
 use Stancl\Tenancy\Contracts\Feature;
 use Stancl\Tenancy\Tenancy;
-use Stancl\Tenancy\Vite as StanclVite;
+use Stancl\Tenancy\Vite;
 
 class ViteBundler implements Feature
 {
@@ -21,6 +20,6 @@ class ViteBundler implements Feature
 
     public function bootstrap(Tenancy $tenancy): void
     {
-        $this->app->singleton(FoundationVite::class, StanclVite::class);
+        $this->app->singleton(\Illuminate\Foundation\Vite::class, Vite::class);
     }
 }

--- a/src/Features/ViteBundler.php
+++ b/src/Features/ViteBundler.php
@@ -12,7 +12,12 @@ use Stancl\Tenancy\Vite as StanclVite;
 
 class ViteBundler implements Feature
 {
-    public function __construct(protected Application $app) { }
+    protected Application $app;
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
 
     public function bootstrap(Tenancy $tenancy): void
     {

--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -60,7 +60,10 @@ class UpdateSyncedResource extends QueueableListener
             } else {
                 // If the resource doesn't exist at all in the central DB,we create
                 // the record with all attributes, not just the synced ones.
-                $centralModel = $event->model->getCentralModelName()::create($syncedAttributes);
+                $centralModel = $event->model->getCentralModelName()::create(
+                    config('tenancy.created_only_with_synced_attributes') ? $syncedAttributes
+                    : $event->model->getAttributes()
+                );
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             }
         });

--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -60,7 +60,7 @@ class UpdateSyncedResource extends QueueableListener
             } else {
                 // If the resource doesn't exist at all in the central DB,we create
                 // the record with all attributes, not just the synced ones.
-                $centralModel = $event->model->getCentralModelName()::create($event->model->getAttributes());
+                $centralModel = $event->model->getCentralModelName()::create($syncedAttributes);
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             }
         });

--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -36,9 +36,7 @@ abstract class CachedTenantResolver implements TenantResolver
 
         $key = $this->getCacheKey(...$args);
 
-        if ($this->cache->has($key)) {
-            $tenant = $this->cache->get($key);
-
+        if ($tenant = $this->cache->get($key)) {
             $this->resolved($tenant, ...$args);
 
             return $tenant;

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -65,6 +65,7 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->singleton(Commands\Rollback::class, function ($app) {
             return new Commands\Rollback($app['migrator']);
         });
+
         $this->app->singleton(Commands\Seed::class, function ($app) {
             return new Commands\Seed($app['db']);
         });

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Stancl\Tenancy;
+
+use Illuminate\Foundation\Vite as BaseVite;
+
+class Vite extends BaseVite
+{
+    /**
+     * Generate an asset path for the application.
+     *
+     * @param  string  $path
+     * @param  bool|null  $secure
+     * @return string
+     */
+    protected function assetPath($path, $secure = null)
+    {
+        return global_asset($path);
+    }
+}

--- a/src/Vite.php
+++ b/src/Vite.php
@@ -4,7 +4,7 @@ namespace Stancl\Tenancy;
 
 use Illuminate\Foundation\Vite as BaseVite;
 
-class Vite extends BaseVite
+class Vite extends BaseVite // todo move to a different directory in v4
 {
     /**
      * Generate an asset path for the application.

--- a/tests/Features/ViteBundlerTest.php
+++ b/tests/Features/ViteBundlerTest.php
@@ -3,30 +3,33 @@
 declare(strict_types=1);
 
 use Illuminate\Foundation\Vite as FoundationVite;
-use Illuminate\Support\Facades\App;
 use Stancl\Tenancy\Features\ViteBundler;
 use Stancl\Tenancy\Tests\Etc\Tenant;
+use Stancl\Tenancy\Tests\TestCase;
 use Stancl\Tenancy\Vite as StanclVite;
 
+class ViteBundlerTest extends TestCase
+{
+    /** @test */
+    public function the_vite_helper_uses_our_custom_class()
+    {
+        $vite = app(\Illuminate\Foundation\Vite::class);
 
-test('replaces the vite helper instance with custom class', function () {
-    $vite = app(\Illuminate\Foundation\Vite::class);
+        $this->assertInstanceOf(FoundationVite::class, $vite);
+        $this->assertNotInstanceOf(StanclVite::class, $vite);
 
-    expect($vite)->toBeInstanceOf(FoundationVite::class);
+        config([
+            'tenancy.features' => [ViteBundler::class],
+        ]);
 
-    expect($vite)->not->toBeInstanceOf(StanclVite::class);
+        $tenant = Tenant::create();
 
-    config([
-        'tenancy.features' => [ViteBundler::class],
-    ]);
+        tenancy()->initialize($tenant);
 
-    $tenant = Tenant::create();
+        app()->forgetInstance(\Illuminate\Foundation\Vite::class);
 
-    tenancy()->initialize($tenant);
+        $vite = app(\Illuminate\Foundation\Vite::class);
 
-    app()->forgetInstance(\Illuminate\Foundation\Vite::class);
-
-    $vite = app(\Illuminate\Foundation\Vite::class);
-
-    expect($vite)->toBeInstanceOf(StanclVite::class);
-});
+        $this->assertInstanceOf(StanclVite::class, $vite);
+    }
+}

--- a/tests/Features/ViteBundlerTest.php
+++ b/tests/Features/ViteBundlerTest.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use Illuminate\Foundation\Vite as FoundationVite;
 use Stancl\Tenancy\Features\ViteBundler;
 use Stancl\Tenancy\Tests\Etc\Tenant;
 use Stancl\Tenancy\Tests\TestCase;
@@ -19,7 +18,7 @@ class ViteBundlerTest extends TestCase
 
         $vite = app(\Illuminate\Foundation\Vite::class);
 
-        $this->assertInstanceOf(FoundationVite::class, $vite);
+        $this->assertInstanceOf(\Illuminate\Foundation\Vite::class, $vite);
         $this->assertNotInstanceOf(StanclVite::class, $vite);
 
         config([

--- a/tests/Features/ViteBundlerTest.php
+++ b/tests/Features/ViteBundlerTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Vite as FoundationVite;
+use Illuminate\Support\Facades\App;
+use Stancl\Tenancy\Features\ViteBundler;
+use Stancl\Tenancy\Tests\Etc\Tenant;
+use Stancl\Tenancy\Vite as StanclVite;
+
+
+test('replaces the vite helper instance with custom class', function () {
+    $vite = app(\Illuminate\Foundation\Vite::class);
+
+    expect($vite)->toBeInstanceOf(FoundationVite::class);
+
+    expect($vite)->not->toBeInstanceOf(StanclVite::class);
+
+    config([
+        'tenancy.features' => [ViteBundler::class],
+    ]);
+
+    $tenant = Tenant::create();
+
+    tenancy()->initialize($tenant);
+
+    app()->forgetInstance(\Illuminate\Foundation\Vite::class);
+
+    $vite = app(\Illuminate\Foundation\Vite::class);
+
+    expect($vite)->toBeInstanceOf(StanclVite::class);
+});

--- a/tests/Features/ViteBundlerTest.php
+++ b/tests/Features/ViteBundlerTest.php
@@ -13,6 +13,10 @@ class ViteBundlerTest extends TestCase
     /** @test */
     public function the_vite_helper_uses_our_custom_class()
     {
+        if (version_compare(app()->version(), '9.0', '<')) {
+            $this->markTestSkipped('Vite is only used in Laravel 9+');
+        }
+
         $vite = app(\Illuminate\Foundation\Vite::class);
 
         $this->assertInstanceOf(FoundationVite::class, $vite);

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -126,4 +126,19 @@ class TenantAssetTest extends TestCase
 
         $this->assertSame($original, asset('foo'));
     }
+
+    public function test_asset_controller_returns_a_404_when_no_path_is_provided()
+    {
+        TenantAssetsController::$tenancyMiddleware = InitializeTenancyByRequestData::class;
+
+        $tenant = Tenant::create();
+
+        tenancy()->initialize($tenant);
+        $response = $this->get(tenant_asset(null), [
+            'X-Tenant' => $tenant->id,
+        ]);
+
+        $response->assertNotFound();
+    }
+
 }


### PR DESCRIPTION
This PR introduces the possibility of creating a resource in the central database related to a resource from the tenant database only with synced attributes if this resource doesn't exist.

### Solution

PR introduces the new config key, which is a boolean with a "false" default value.

### Usage

Set the value of the following config key to "true" for enabling this possibility.

`'created_only_with_synced_attributes' => true,`