### PR TITLE
Fix root URL override example

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -124,12 +124,12 @@ class TenancyServiceProvider extends ServiceProvider
          * Example of CLI tenant URL root override:
          *
          * UrlTenancyBootstrapper::$rootUrlOverride = function (Tenant $tenant) {
-         *    $baseUrl = url('/');
-         *    $scheme = str($baseUrl)->before('://');
-         *    $hostname = str($baseUrl)->after($scheme . '://');
+         *     $baseUrl = env('APP_URL');
+         *     $scheme = str($baseUrl)->before('://');
+         *     $hostname = str($baseUrl)->after($scheme . '://');
          *
-         *    return $scheme . '://' . $tenant->getTenantKey() . '.' . $hostname;
-         *};
+         *     return $scheme . '://' . $tenant->getTenantKey() . '.' . $hostname;
+         * };
          */
     }
 


### PR DESCRIPTION
Using the code from the root URL override example, the URL would get prefixed multiple times because the `$baseUrl` we're prefixing can already be prefixed. This PR updates `$baseUrl` so that it's always `env('APP_URL')`, and updates the formatting of the block comment.