### PR TITLE
Tenancy Fake method added to Tenancy Facade.

### DIFF
--- a/src/Facades/Tenancy.php
+++ b/src/Facades/Tenancy.php
@@ -15,6 +15,8 @@ class Tenancy extends Facade
 
     public static function fake()
     {
-        static::swap(new TenancyFake);
+        static::swap($fake = new TenancyFake);
+
+        return $fake;
     }
 }

--- a/src/Facades/Tenancy.php
+++ b/src/Facades/Tenancy.php
@@ -12,4 +12,9 @@ class Tenancy extends Facade
     {
         return \Stancl\Tenancy\Tenancy::class;
     }
+
+    public static function fake()
+    {
+        static::swap(new TenancyFake);
+    }
 }

--- a/src/Facades/TenancyFake.php
+++ b/src/Facades/TenancyFake.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Stancl\Tenancy\Facades;
+
+use Stancl\Tenancy\Database\Models\Tenant;
+use Stancl\Tenancy\Tenancy;
+
+class TenancyFake extends Tenancy
+{
+    public function initialize($tenant): void
+    {
+        if (!is_object($tenant)) {
+            $tenantId = $tenant;
+            $tenant = $this->find($tenantId);
+        }
+
+        if ($this->initialized && $this->tenant->id === $tenant->id) {
+            return;
+        }
+
+        // TODO: Remove this (so that runForMultiple() is still performant) and make the FS bootstrapper work either way
+        if ($this->initialized) {
+            $this->end();
+        }
+
+        $this->tenant = $tenant;
+
+        $this->initialized = true;
+    }
+
+    public function end(): void
+    {
+        if (!$this->initialized) {
+            return;
+        }
+
+        $this->initialized = false;
+
+        $this->tenant = null;
+    }
+
+    public function find($id): ?Tenant
+    {
+        return new Tenant(['id' => $id]);
+    }
+}

--- a/tests/TenancyFacadeTest.php
+++ b/tests/TenancyFacadeTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests;
+
+use Illuminate\Support\Facades\Event;
+use Stancl\Tenancy\Database\Models\Tenant as ModelsTenant;
+use Stancl\Tenancy\Events\EndingTenancy;
+use Stancl\Tenancy\Events\InitializingTenancy;
+use Stancl\Tenancy\Events\TenancyEnded;
+use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Facades\Tenancy;
+
+class TenantFacadeTest extends TestCase
+{
+    /** @test */
+    public function tenancy_events_not_dispatched_when_faked()
+    {
+        Event::fake();
+        $tenant = Tenant::create(['id' => 'tenant_id']);
+
+        // Asserting the Tenant is created inside the database
+        Event::assertDispatched(TenantCreated::class);
+
+        // Faking the Tenancy facade now, which will not dispatch any events
+        Tenancy::fake();
+
+        tenancy()->initialize($tenant);
+        Event::assertNotDispatched(TenantRetrieved::class);
+        Event::assertNotDispatched(InitializingTenancy::class);
+        Event::assertNotDispatched(TenancyInitialized::class);
+
+        tenancy()->end();
+        Event::assertNotDispatched(EndingTenancy::class);
+        Event::assertNotDispatched(TenancyEnded::class);
+    }
+
+    /** @test */
+    public function tenancy_is_resolved_when_faked()
+    {
+        Event::fake();
+        // The following line can be changed, by using Mockery | Not sure, not much experience
+        $tenant = new Tenant(['id' => 'tenant_1']);
+
+        // Faking the Tenancy facade now
+        Tenancy::fake();
+
+        // Fake initializing Tenancy using Tenant Model Instance
+        tenancy()->initialize($tenant);
+        Event::assertNotDispatched(TenantRetrieved::class);
+        $this->assertEquals($tenant->id, tenant('id'));
+
+        // Fake initializing Tenancy using string
+        tenancy()->initialize($tenantId = 'tenant_2');
+        Event::assertNotDispatched(TenantRetrieved::class);
+        $this->assertEquals($tenantId, tenant('id'));
+    }
+}
+
+class Tenant extends ModelsTenant
+{
+    protected $table = 'tenants';
+
+    protected $dispatchesEvents = [
+        'created' => TenantCreated::class,
+        'retrieved' => TenantRetrieved::class,
+    ];
+}
+
+class TenantRetrieved
+{
+    public function __construct(Tenant $tenant)
+    {
+        // 
+    }
+}
+
+class TenantCreated
+{
+    public function __construct(Tenant $tenant)
+    {
+        // 
+    }
+}


### PR DESCRIPTION
The aim of this PR is to allow faking of tenancy when it comes to testing.

We can call the fake method on Tenancy facade to resolve the `TenancyFake` class in subsequent calls.

```php
use Stancl\Tenancy\Database\Models\Tenant;
use Stancl\Tenancy\Facades\Tenancy;

Tenancy::fake();

tenancy()->initialize('tenant_string');

echo tenant('id');
// 'tenant_string'



tenancy()->initialize(new Tenant(['id' => 'tenant_object']));

echo tenant('id');
// 'tenant_object'

```

