### PR TITLE
[4.x] Add `remember` to ImpersonationToken

### DIFF
--- a/assets/impersonation-migrations/2020_05_15_000010_create_tenant_user_impersonation_tokens_table.php
+++ b/assets/impersonation-migrations/2020_05_15_000010_create_tenant_user_impersonation_tokens_table.php
@@ -20,6 +20,7 @@ return new class extends Migration
             $table->string('token', 128)->primary();
             $table->string(Tenancy::tenantKeyColumn());
             $table->string('user_id');
+            $table->boolean('remember');
             $table->string('auth_guard');
             $table->string('redirect_url');
             $table->timestamp('created_at');

--- a/src/Database/Models/ImpersonationToken.php
+++ b/src/Database/Models/ImpersonationToken.php
@@ -18,6 +18,7 @@ use Stancl\Tenancy\Exceptions\StatefulGuardRequiredException;
  * @property string $user_id
  * @property string $auth_guard
  * @property string $redirect_url
+ * @property bool $remember
  * @property Carbon $created_at
  */
 class ImpersonationToken extends Model

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -18,12 +18,13 @@ class UserImpersonation implements Feature
 
     public function bootstrap(Tenancy $tenancy): void
     {
-        $tenancy->macro('impersonate', function (Tenant $tenant, string $userId, string $redirectUrl, string $authGuard = null): ImpersonationToken {
+        $tenancy->macro('impersonate', function (Tenant $tenant, string $userId, string $redirectUrl, string|null $authGuard = null, bool $remember = false): ImpersonationToken {
             return ImpersonationToken::create([
                 Tenancy::tenantKeyColumn() => $tenant->getTenantKey(),
                 'user_id' => $userId,
                 'redirect_url' => $redirectUrl,
                 'auth_guard' => $authGuard,
+                'remember' => $remember,
             ]);
         });
     }
@@ -44,7 +45,7 @@ class UserImpersonation implements Feature
 
         abort_unless($tokenTenantId === $currentTenantId, 403);
 
-        Auth::guard($token->auth_guard)->loginUsingId($token->user_id);
+        Auth::guard($token->auth_guard)->loginUsingId($token->user_id, $token->remember);
 
         $token->delete();
 


### PR DESCRIPTION
This PR adds a `remember` bool column to the ImpersonationToken migration. `tenancy()->impersonate()` now accepts `$remember` as a parameter (`false` by default).