### PR TITLE
Add missing import statement

### DIFF
--- a/src/Middleware/InitializeTenancyByRequestData.php
+++ b/src/Middleware/InitializeTenancyByRequestData.php
@@ -6,6 +6,7 @@ namespace Stancl\Tenancy\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use Stancl\Tenancy\Contracts\TenantResolver;
 use Stancl\Tenancy\Resolvers\RequestDataTenantResolver;
 use Stancl\Tenancy\Tenancy;
 


### PR DESCRIPTION
In the `InitializeTenancyByRequestData` class, `TenantResolver` interface is referenced in the type annotation, but it is not imported. Therefore I have added an import statement.