### PR TITLE
Fix tenant identification in assets when using path-identification

### DIFF
--- a/assets/routes.php
+++ b/assets/routes.php
@@ -8,6 +8,6 @@ Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsCo
     ->where('path', '(.*)')
     ->name('stancl.tenancy.asset');
 
-Route::get('/{tenant}/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
+Route::get('/{tenant}/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@assetWithPath')
     ->where('path', '(.*)')
     ->name('stancl.tenancy.asset.path');

--- a/assets/routes.php
+++ b/assets/routes.php
@@ -7,3 +7,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/tenancy/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
     ->where('path', '(.*)')
     ->name('stancl.tenancy.asset');
+
+Route::get('/{tenant}/assets/{path?}', 'Stancl\Tenancy\Controllers\TenantAssetsController@asset')
+    ->where('path', '(.*)')
+    ->name('stancl.tenancy.asset.path');

--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -39,7 +39,7 @@ class TenantAssetsController extends Controller
         $basePath = storage_path("app/public");
         $requestPath = realpath($basePath . '/' . $path);
 
-        $validPath = substr($requestPath, 0, strlen($basePath)) === $basePath;
+        $validPath = $requestPath && substr($requestPath, 0, strlen($basePath)) === $basePath;
         abort_if($validPath === false, 404);
 
         try {

--- a/src/Controllers/TenantAssetsController.php
+++ b/src/Controllers/TenantAssetsController.php
@@ -26,4 +26,26 @@ class TenantAssetsController extends Controller
             abort(404);
         }
     }
+    
+     public function assetWithPath($path = null)
+    {
+        abort_if($path === null, 404);
+
+        /**
+         * Prevents path traversal attack in asset requests
+         *
+         * @see https://www.stackhawk.com/blog/laravel-path-traversal-guide-examples-and-prevention/
+         */
+        $basePath = storage_path("app/public");
+        $requestPath = realpath($basePath . '/' . $path);
+
+        $validPath = substr($requestPath, 0, strlen($basePath)) === $basePath;
+        abort_if($validPath === false, 404);
+
+        try {
+            return response()->file($requestPath);
+        } catch (Throwable $th) {
+            abort(404);
+        }
+    }
 }

--- a/src/Resolvers/PathTenantResolver.php
+++ b/src/Resolvers/PathTenantResolver.php
@@ -36,6 +36,13 @@ class PathTenantResolver extends Contracts\CachedTenantResolver
 
         throw new TenantCouldNotBeIdentifiedByPathException($id);
     }
+    
+    public function resolved(Tenant $tenant, ...$args): void
+    {
+        $route = $args[0];
+
+        $route->forgetParameter(static::$tenantParameterName);
+    }
 
     public function getArgsForTenant(Tenant $tenant): array
     {

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -36,9 +36,11 @@ if (! function_exists('tenant')) {
 
 if (! function_exists('tenant_asset')) {
     /** @return string */
-    function tenant_asset($asset)
+    function tenant_asset($asset, $usePathIdentification = false)
     {
-        return route('stancl.tenancy.asset', ['path' => $asset]);
+        return $usePathIdentification === true ? 
+            route('stancl.tenancy.asset.path', ['path' => $asset, 'tenant' => tenant(tenant()->getTenantKeyName())]) : 
+            route('stancl.tenancy.asset', ['path' => $asset]);
     }
 }
 


### PR DESCRIPTION
By default, calling `tenant_asset()` results in an asset URL like '/tenancy/assets/{path}`. This works fine for everything except path-identification since the tenant_id is required to be in the path itself.

These fixes add a second parameter to `tenant_asset(string $path, bool $usePathIdentification = false)` which uses a different route to enable proper URLs can be generated.

This restored functionality required a few other tweaks and some extra protection against path traversal attacks.