### PR TITLE
Close tenant connections after jobs

### DIFF
--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -181,6 +181,20 @@ test('the tenant used by the job doesnt change when the current tenant changes',
     expect(pest()->valuestore->get('tenant_id'))->toBe('The current tenant id is: acme');
 });
 
+test('tenant connections do not persist after tenant jobs get processed', function() {
+    withTenantDatabases();
+
+    $tenant = Tenant::create();
+
+    tenancy()->initialize($tenant);
+
+    dispatch(new TestJob(pest()->valuestore));
+
+    pest()->artisan('queue:work --once');
+
+    expect(collect(DB::select('SHOW FULL PROCESSLIST'))->pluck('db'))->not()->toContain($tenant->database()->getName());
+});
+
 function createValueStore(): void
 {
     $valueStorePath = __DIR__ . '/Etc/tmp/queuetest.json';

--- a/tests/QueueTest.php
+++ b/tests/QueueTest.php
@@ -206,8 +206,6 @@ test('tenant connections do not persist after tenant jobs get processed', functi
 
     pest()->artisan('queue:work --once');
 
-    expect(tenancy()->initialized)->toBeFalse();
-
     expect(collect(DB::select('SHOW FULL PROCESSLIST'))->pluck('db'))->not()->toContain($tenant->database()->getName());
 });
 


### PR DESCRIPTION
This PR changes QueryTenancyBootstrapper so that after a job gets processed, the context gets reverted to the previous one. This prevents having extra tenant connections that wouldn't get closed (should fix #1022).