### PR TITLE
Make universal routes work for controller middleware

### DIFF
--- a/src/Features/UniversalRoutes.php
+++ b/src/Features/UniversalRoutes.php
@@ -35,7 +35,7 @@ class UniversalRoutes implements Feature
 
     public static function routeHasMiddleware(Route $route, $middleware): bool
     {
-        if (in_array($middleware, $route->middleware(), true)) {
+        if (in_array($middleware, $route->computedMiddleware, true)) {
             return true;
         }
 

--- a/src/Features/UniversalRoutes.php
+++ b/src/Features/UniversalRoutes.php
@@ -35,7 +35,7 @@ class UniversalRoutes implements Feature
 
     public static function routeHasMiddleware(Route $route, $middleware): bool
     {
-        if (in_array($middleware, $route->computedMiddleware, true)) {
+        if (in_array($middleware, $route->computedMiddleware ?? $route->middleware(), true)) {
             return true;
         }
 


### PR DESCRIPTION
This PR allows support for controller middleware. `$route->computedMiddleware` is equal to ```Router::uniqueMiddleware(array_merge($route->middleware(), $route->controllerMiddleware()));```. So basically the same result as before, but with the controllerMiddleware added. I have added a test, which should cover this use case.