### PR TITLE
Execute the bootstrappers in reverse order when reverting back to central

### DIFF
--- a/src/Listeners/RevertToCentralContext.php
+++ b/src/Listeners/RevertToCentralContext.php
@@ -14,7 +14,7 @@ class RevertToCentralContext
     {
         event(new RevertingToCentralContext($event->tenancy));
 
-        foreach ($event->tenancy->getBootstrappers() as $bootstrapper) {
+        foreach (array_reverse($event->tenancy->getBootstrappers()) as $bootstrapper) {
             $bootstrapper->revert();
         }
 


### PR DESCRIPTION
Bootstrappers order may be relevant in specific cases.
For example, when a custom bootstrapper queries the tenant database, it will be placed after the Database bootstrapper in the bootstrappers list and it must be reverted before the database connection is reverted back to central.