### PR TITLE
Fix connection config template array_merge parameter order

### DIFF
--- a/src/DatabaseConfig.php
+++ b/src/DatabaseConfig.php
@@ -113,7 +113,7 @@ class DatabaseConfig
         $templateConnection = config("database.connections.{$template}");
 
         return $this->manager()->makeConnectionConfig(
-            array_merge($templateConnection, $this->tenantConfig()), $this->getName()
+            array_merge($this->tenantConfig(), $templateConnection), $this->getName()
         );
     }
 


### PR DESCRIPTION
I think this `array_merge($templateConnection, $this->tenantConfig())` is not merging the config correctly, it should merge it in reverse so it preserves the template config.