### PR TITLE
fix check isSubdomain

### DIFF
--- a/src/Middleware/InitializeTenancyByDomainOrSubdomain.php
+++ b/src/Middleware/InitializeTenancyByDomainOrSubdomain.php
@@ -27,6 +27,9 @@ class InitializeTenancyByDomainOrSubdomain
 
     protected function isSubdomain(string $hostname): bool
     {
-        return Str::endsWith($hostname, config('tenancy.central_domains'));
+        return Str::endsWith(
+            $hostname,
+            array_map(fn ($domain) => '.' . $domain, config('tenancy.central_domains'))
+        );
     }
 }


### PR DESCRIPTION
I think append the dot `.` before the central domain could avoid the case central domain is considered as sub domain