### PR TITLE
Allow suffix for prefixed Redis connections

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -149,6 +149,7 @@ return [
      */
     'redis' => [
         'prefix_base' => 'tenant', // Each key in Redis will be prepended by this prefix_base, followed by the tenant id.
+        'suffix' => '',
         'prefixed_connections' => [ // Redis connections whose keys are prefixed, to separate one tenant's keys from another.
             // 'default',
         ],

--- a/src/Bootstrappers/RedisTenancyBootstrapper.php
+++ b/src/Bootstrappers/RedisTenancyBootstrapper.php
@@ -26,10 +26,11 @@ class RedisTenancyBootstrapper implements TenancyBootstrapper
     {
         foreach ($this->prefixedConnections() as $connection) {
             $prefix = $this->config['tenancy.redis.prefix_base'] . $tenant->getTenantKey();
+            $suffix = $this->config['tenancy.redis.suffix'] ?? '_';
             $client = Redis::connection($connection)->client();
 
             $this->originalPrefixes[$connection] = $client->getOption($client::OPT_PREFIX);
-            $client->setOption($client::OPT_PREFIX, $prefix);
+            $client->setOption($client::OPT_PREFIX, $prefix.$suffix);
         }
     }
 


### PR DESCRIPTION
This will allow suffixing Redis tenant connections with a configured suffix or default to `_` for better readability.