### PR TITLE
Fixes RedisCluster constants deprecation in PHPRedis 6.

### DIFF
--- a/src/Bootstrappers/RedisTenancyBootstrapper.php
+++ b/src/Bootstrappers/RedisTenancyBootstrapper.php
@@ -28,8 +28,8 @@ class RedisTenancyBootstrapper implements TenancyBootstrapper
             $prefix = $this->config['tenancy.redis.prefix_base'] . $tenant->getTenantKey();
             $client = Redis::connection($connection)->client();
 
-            $this->originalPrefixes[$connection] = $client->getOption($client::OPT_PREFIX);
-            $client->setOption($client::OPT_PREFIX, $prefix);
+            $this->originalPrefixes[$connection] = $client->getOption(\Redis::OPT_PREFIX);
+            $client->setOption(\Redis::OPT_PREFIX, $prefix);
         }
     }
 
@@ -38,7 +38,7 @@ class RedisTenancyBootstrapper implements TenancyBootstrapper
         foreach ($this->prefixedConnections() as $connection) {
             $client = Redis::connection($connection)->client();
 
-            $client->setOption($client::OPT_PREFIX, $this->originalPrefixes[$connection]);
+            $client->setOption(\Redis::OPT_PREFIX, $this->originalPrefixes[$connection]);
         }
 
         $this->originalPrefixes = [];


### PR DESCRIPTION
When deploying a project which uses Tenancy for Laravel to Laravel Vapor using PHP 8.3 runtime (which uses PHPRedis 6) and a Redis cluster, the following error occurs:

`Undefined constant RedisCluster::OPT_PREFIX`


As detailed in this Laravel merged PR:

https://github.com/laravel/framework/pull/48362

> The PHPRedis library removed `RedisCluster::` constants since 6.0.0.  (...)
> 
> The author of PHPREDIS recommends not using the constants of RedisCluster anymore but using the constants in Redis instead (...)


This PR changes the use of `$client::` (which can lead to the mentioned error when working with PHPRedis 6 and a Redis cluster) for constants to `\Redis::`.

Also, as stated in the Laravel PR mentioned above:

> This is backward compatible since the underlying values of these constants are the same, so it will still work for older phpredis versions
