### PR TITLE
Enhance Cache Methods to Handle Tag Support with Different Drivers

### DIFF
--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -32,6 +32,10 @@ class CacheManager extends BaseCacheManager
             return $this->store()->tags(array_merge($tags, $names));
         }
 
-        return $this->store()->tags($tags)->$method(...$parameters);
+        if ($this->store()->supportsTags()) {
+            return $this->store()->tags($tags)->$method(...$parameters);
+        }
+
+        return $this->store()->$method(...$parameters);
     }
 }


### PR DESCRIPTION
Enhance Cache Methods to Handle Tag Support with Different Drivers

This commit modifies the cache methods in Laravel to handle tag support differently based on the driver being used. When using a driver that supports tags, such as the array driver, the methods like Cache::put(), Cache::get(), etc., will utilize tagging functionality as expected. However, for drivers like the default database driver, which do not support tags, the methods will now fallback to direct cache operations without tagging. 

This enhancement ensures consistent behavior across different cache drivers, optimizing functionality for both tag-supported and non-tag-supported drivers.
