### PR TITLE
Bring back assetPathResolver closure if set in Tenancy Vite Facade

### DIFF
--- a/src/Vite.php
+++ b/src/Vite.php
@@ -15,6 +15,6 @@ class Vite extends BaseVite // todo move to a different directory in v4
      */
     protected function assetPath($path, $secure = null)
     {
-        return global_asset($path);
+        return $this->assetPathResolver ? ($this->assetPathResolver)($path, $secure) : global_asset($path);
     }
 }


### PR DESCRIPTION
The original Vite Facade uses the assetPathResolver closure (if set) to generate assets with a custom URL. This is needed when for example assets are cached on a CDN, or if you need assets from a central URL while in Tenant context.

This updates the Tenancy version of the Vite-Facade to bring back the assetPathResolver logic.

Example usage from [Laravel](https://laravel.com/docs/11.x/vite#advanced-customization) docs:

```blade
{{
  Vite::withEntryPoints(['resources/js/app.js']) // Specify the entry points...
    ->createAssetPathsUsing(function (string $path, ?bool $secure) { // Customize the backend path generation for built assets...
        return "https://cdn.example.com/{$path}";
    })
    ->toHtml()
}}
```