### PR TITLE
Fix tenant_route without absolute

### DIFF
--- a/src/helpers.php
+++ b/src/helpers.php
@@ -61,7 +61,7 @@ if (! function_exists('tenant_route')) {
     {
         // replace first occurance of hostname fragment with $domain
         $url = route($route, $parameters, $absolute);
-        $hostname = parse_url($url, PHP_URL_HOST);
+        $hostname = parse_url($url, PHP_URL_HOST) ?? '';
         $position = strpos($url, $hostname);
 
         return substr_replace($url, $domain, $position, strlen($hostname));

--- a/tests/Features/RedirectTest.php
+++ b/tests/Features/RedirectTest.php
@@ -42,5 +42,6 @@ class RedirectTest extends TestCase
 
         $this->assertSame('http://foo.localhost/abcdef/as/df', tenant_route('foo.localhost', 'foo', ['a' => 'as', 'b' => 'df']));
         $this->assertSame('http://foo.localhost/abcdef', tenant_route('foo.localhost', 'foo', []));
+        $this->assertSame('foo.localhost/abcdef', tenant_route('foo.localhost', 'foo', [], false));
     }
 }


### PR DESCRIPTION
This PR aims to resolve the issue when trying to pass `Absolute: false` to the `tenant_route` helper

When we try to generate a route with the `tenant_route` helper, passing absolute as false, we receive the following error.
`tenant_route(): argument #1 ($domain) must be of type string, null provided, called on line 1.`