### PR TITLE
 Improved Storage Path Handling for Tenant UUIDs and Friendly Names

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -17,6 +17,9 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     /** @var array */
     public $originalPaths = [];
 
+    /** @var callable */
+    protected static $tenantKeyResolver;
+
     public function __construct(Application $app)
     {
         $this->app = $app;
@@ -33,9 +36,16 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         });
     }
 
+    public static function resolveTenantKeyUsing(callable $tenantKeyResolver): void
+    {
+        static::$tenantKeyResolver = $tenantKeyResolver;
+    }
+
     public function bootstrap(Tenant $tenant)
     {
-        $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenant->getTenantKey();
+        $tenantKey = static::$tenantKeyResolver ? (static::$tenantKeyResolver)($tenant) : $tenant->getTenantKey();
+
+        $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenantKey;
 
         // storage_path()
         if ($this->app['config']['tenancy.filesystem.suffix_storage_path'] ?? true) {

--- a/src/Contracts/Syncable.php
+++ b/src/Contracts/Syncable.php
@@ -15,4 +15,6 @@ interface Syncable
     public function getSyncedAttributeNames(): array;
 
     public function triggerSyncEvent();
+
+    public function isSyncEnabled();
 }

--- a/src/Contracts/Syncable.php
+++ b/src/Contracts/Syncable.php
@@ -16,5 +16,5 @@ interface Syncable
 
     public function triggerSyncEvent();
 
-    public function isSyncEnabled();
+    public function shouldSync(): bool;
 }

--- a/src/Database/Concerns/ResourceSyncing.php
+++ b/src/Database/Concerns/ResourceSyncing.php
@@ -20,10 +20,10 @@ trait ResourceSyncing
         });
 
         static::creating(function (self $model) {
-            $key = $model->getGlobalIdentifierKeyName();
+            $keyName = $model->getGlobalIdentifierKeyName();
 
-            if (! $model->getAttribute($key) && app()->bound(UniqueIdentifierGenerator::class) && $model->isSyncEnabled()) {
-                $model->setAttribute($key, app(UniqueIdentifierGenerator::class)->generate($model));
+            if (! $model->getAttribute($keyName) && app()->bound(UniqueIdentifierGenerator::class)) {
+                $model->setAttribute($keyName, app(UniqueIdentifierGenerator::class)->generate($model));
             }
         });
     }

--- a/src/Database/Concerns/ResourceSyncing.php
+++ b/src/Database/Concerns/ResourceSyncing.php
@@ -14,7 +14,7 @@ trait ResourceSyncing
     {
         static::saved(function (Syncable $model) {
             /** @var ResourceSyncing $model */
-            if ($model->isSyncEnabled()) {
+            if ($model->shouldSync()) {
                 $model->triggerSyncEvent();
             }
         });
@@ -34,7 +34,7 @@ trait ResourceSyncing
         event(new SyncedResourceSaved($this, tenant()));
     }
 
-    public function isSyncEnabled()
+    public function shouldSync(): bool
     {
         return true;
     }

--- a/src/Database/Models/TenantPivot.php
+++ b/src/Database/Models/TenantPivot.php
@@ -16,7 +16,7 @@ class TenantPivot extends Pivot
         static::saved(function (self $pivot) {
             $parent = $pivot->pivotParent;
 
-            if ($parent instanceof Syncable) {
+            if ($parent instanceof Syncable && $parent->isSyncEnabled()) {
                 $parent->triggerSyncEvent();
             }
         });

--- a/src/Database/Models/TenantPivot.php
+++ b/src/Database/Models/TenantPivot.php
@@ -16,7 +16,7 @@ class TenantPivot extends Pivot
         static::saved(function (self $pivot) {
             $parent = $pivot->pivotParent;
 
-            if ($parent instanceof Syncable && $parent->isSyncEnabled()) {
+            if ($parent instanceof Syncable && $parent->shouldSync()) {
                 $parent->triggerSyncEvent();
             }
         });

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -682,7 +682,7 @@ class CentralUser extends Model implements SyncMaster
         ];
     }
 
-    public function isSyncEnabled()
+    public function shouldSync()
     {
         return $this->role !== 'not_sync';
     }
@@ -720,7 +720,7 @@ class ResourceUser extends Model implements Syncable
         ];
     }
 
-    public function isSyncEnabled()
+    public function shouldSync()
     {
         return $this->role !== 'not_sync';
     }


### PR DESCRIPTION
This pull request addresses an issue with storage path generation for tenants where the tenant ID is an UUID. Previously, the path generation logic would become confused when dealing with UUIDs.

This implementation introduces the ability to set a friendly name based on the tenant mode. This provides a more descriptive and user-friendly approach to storage path generation, improving clarity and organization.