### PR TITLE
 Improved Storage Path Handling for Tenant UUIDs and Friendly Names

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -17,6 +17,9 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     /** @var array */
     public $originalPaths = [];
 
+    /** @var callable */
+    protected static $tenantKeyResolver;
+
     public function __construct(Application $app)
     {
         $this->app = $app;
@@ -33,9 +36,16 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         });
     }
 
+    public static function resolveTenantKeyUsing(callable $tenantKeyResolver): void
+    {
+        static::$tenantKeyResolver = $tenantKeyResolver;
+    }
+
     public function bootstrap(Tenant $tenant)
     {
-        $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenant->getTenantKey();
+        $tenantKey = static::$tenantKeyResolver ? (static::$tenantKeyResolver)($tenant) : $tenant->getTenantKey();
+
+        $suffix = $this->app['config']['tenancy.filesystem.suffix_base'] . $tenantKey;
 
         // storage_path()
         if ($this->app['config']['tenancy.filesystem.suffix_storage_path'] ?? true) {


### PR DESCRIPTION
This pull request addresses an issue with storage path generation for tenants where the tenant ID is an UUID. Previously, the path generation logic would become confused when dealing with UUIDs.

This implementation introduces the ability to set a friendly name based on the tenant mode. This provides a more descriptive and user-friendly approach to storage path generation, improving clarity and organization.