### PR TITLE
feat: Add getTenantName method to Tenant model and update migration c…

### DIFF
--- a/src/Commands/Migrate.php
+++ b/src/Commands/Migrate.php
@@ -49,7 +49,7 @@ class Migrate extends MigrateCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->line("Tenant: {$tenant->getTenantName()}");
 
             event(new MigratingDatabase($tenant));
 

--- a/src/Commands/Rollback.php
+++ b/src/Commands/Rollback.php
@@ -58,7 +58,7 @@ class Rollback extends RollbackCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->line("Tenant: {$tenant->getTenantName()}");
 
             event(new RollingBackDatabase($tenant));
 

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -33,7 +33,7 @@ class Run extends Command
     public function handle()
     {
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->line("Tenant: {$tenant->getTenantName()}");
 
             $callback = function ($prefix = '') {
                 return function ($arguments, $argument) use ($prefix) {

--- a/src/Commands/Seed.php
+++ b/src/Commands/Seed.php
@@ -51,7 +51,7 @@ class Seed extends SeedCommand
         }
 
         tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
-            $this->line("Tenant: {$tenant->getTenantKey()}");
+            $this->line("Tenant: {$tenant->getTenantName()}");
 
             event(new SeedingDatabase($tenant));
 

--- a/src/Commands/TenantList.php
+++ b/src/Commands/TenantList.php
@@ -36,9 +36,9 @@ class TenantList extends Command
             ->cursor()
             ->each(function (Tenant $tenant) {
                 if ($tenant->domains) {
-                    $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
+                    $this->line("[{$tenant->getTenantName()}] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()} @ " . implode('; ', $tenant->domains->pluck('domain')->toArray() ?? []));
                 } else {
-                    $this->line("[Tenant] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}");
+                    $this->line("[{$tenant->getTenantName()}] {$tenant->getTenantKeyName()}: {$tenant->getTenantKey()}");
                 }
             });
     }

--- a/src/Contracts/Tenant.php
+++ b/src/Contracts/Tenant.php
@@ -27,4 +27,7 @@ interface Tenant
 
     /** Run a callback in this tenant's environment. */
     public function run(callable $callback);
+	
+    /** Get the human readable name of the tenant. */
+    public function getTenantName(): string;
 }

--- a/src/Database/Models/Tenant.php
+++ b/src/Database/Models/Tenant.php
@@ -48,7 +48,12 @@ class Tenant extends Model implements Contracts\Tenant
     {
         return new TenantCollection($models);
     }
-
+	
+    public function getTenantName(): string
+    {
+        return $this->getAttribute('name') ?? $this->getTenantKey();
+    }
+	
     protected $dispatchesEvents = [
         'saving' => Events\SavingTenant::class,
         'saved' => Events\TenantSaved::class,


### PR DESCRIPTION
### Summary

This pull request introduces a new method, `getTenantName`, to the Tenant model, which returns the human-readable name of the tenant. The commands has been updated to use this new method instead of `getTenantKey`.

### Benefits

- Improves clarity by using a human-readable tenant name in migration logs.
- Provides a more intuitive and meaningful identifier for tenants during migrations.

### Testing

- Verified that migrations run correctly and display the tenant's human-readable name.
- Ensured that the new `getTenantName` method functions as expected without affecting other functionalities.
