### PR TITLE
Fix Duplicate Primary Key Error During Tenant to Central Database Synchronization

### DIFF
--- a/src/Contracts/BaseSyncable.php
+++ b/src/Contracts/BaseSyncable.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Contracts;
+
+interface BaseSyncable
+{
+    public function getGlobalIdentifierKeyName(): string;
+
+    public function getGlobalIdentifierKey();
+
+    public function getCentralModelName(): string;
+
+    public function getSyncedAttributeNames(): array;
+
+    public function triggerSyncEvent();
+}

--- a/src/Contracts/SyncMaster.php
+++ b/src/Contracts/SyncMaster.php
@@ -10,9 +10,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 /**
  * @property-read Tenant[]|Collection $tenants
  */
-interface SyncMaster extends Syncable
+interface SyncMaster extends BaseSyncable
 {
     public function tenants(): BelongsToMany;
 
     public function getTenantModelName(): string;
+
+    public function getTenantModelFillable(): array;
 }

--- a/src/Contracts/Syncable.php
+++ b/src/Contracts/Syncable.php
@@ -4,15 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Contracts;
 
-interface Syncable
+interface Syncable extends BaseSyncable
 {
-    public function getGlobalIdentifierKeyName(): string;
-
-    public function getGlobalIdentifierKey();
-
-    public function getCentralModelName(): string;
-
-    public function getSyncedAttributeNames(): array;
-
-    public function triggerSyncEvent();
+    public function getCentralModelFillable(): array;
 }

--- a/src/Listeners/UpdateSyncedResource.php
+++ b/src/Listeners/UpdateSyncedResource.php
@@ -60,7 +60,7 @@ class UpdateSyncedResource extends QueueableListener
             } else {
                 // If the resource doesn't exist at all in the central DB,we create
                 // the record with all attributes, not just the synced ones.
-                $centralModel = $event->model->getCentralModelName()::create($event->model->getAttributes());
+                $centralModel = $event->model->getCentralModelName()::create($event->model->only($event->model->getCentralModelFillable()));
                 event(new SyncedResourceChangedInForeignDatabase($event->model, null));
             }
         });
@@ -113,7 +113,7 @@ class UpdateSyncedResource extends QueueableListener
                     $localModel->update($syncedAttributes);
                 } else {
                     // When creating, we use all columns, not just the synced ones.
-                    $localModel = $localModelClass::create($eventModel->getAttributes());
+                    $localModel = $localModelClass::create($eventModel->only($eventModel->getTenantModelFillable()));
                 }
 
                 event(new SyncedResourceChangedInForeignDatabase($localModel, $tenant));

--- a/tests/ResourceSyncingTest.php
+++ b/tests/ResourceSyncingTest.php
@@ -603,6 +603,11 @@ class CentralUser extends Model implements SyncMaster
         return ResourceUser::class;
     }
 
+    public function getTenantModelFillable(): array
+    {
+        return (new ResourceUser)->getFillable();
+    }
+
     public function getGlobalIdentifierKey()
     {
         return $this->getAttribute($this->getGlobalIdentifierKeyName());
@@ -649,6 +654,11 @@ class ResourceUser extends Model implements Syncable
     public function getCentralModelName(): string
     {
         return CentralUser::class;
+    }
+
+    public function getCentralModelFillable(): array
+    {
+        return (new CentralUser)->getFillable();
     }
 
     public function getSyncedAttributeNames(): array


### PR DESCRIPTION
Resolved an issue where creating records in the central database from a tenant context could result in duplicate primary key errors due to conflicting `id` values. Introduced `getCentralModelFillable` in the `Syncable` interface and `getTenantModelFillable` in the `SyncMaster` interface to ensure that only fillable attributes are synced during resource creation. This fix prevents `id` conflicts by excluding it from the synced attributes, allowing for seamless synchronization without primary key collisions.