### PR TITLE
add early exit for 'runForMultiple' method

### DIFF
--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -158,7 +158,7 @@ class Tenancy
 
             $this->initialize($tenant);
 
-            if (! $callback($tenant)) {
+            if ($callback($tenant) === false) {
                 break;
             };
         }

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -157,7 +157,10 @@ class Tenancy
             }
 
             $this->initialize($tenant);
-            $callback($tenant);
+
+            if (! $callback($tenant)) {
+                break;
+            };
         }
 
         if ($originalTenant) {


### PR DESCRIPTION
This PR adds the ability to stop processing further tenants in the 'runForMultiple' method by returning false from the passed callback function. This behaviour is similar to that of Laravel's EnumerableValues trait's 'each' method early exit.

This feature could be particularly useful when a developer needs to check whether a value is unique across tenant databases, allowing them to exit early once a match is found.