### PR TITLE
Fix ModelNotSyncMasterException message

### DIFF
--- a/src/Exceptions/ModelNotSyncMasterException.php
+++ b/src/Exceptions/ModelNotSyncMasterException.php
@@ -10,6 +10,6 @@ class ModelNotSyncMasterException extends Exception
 {
     public function __construct(string $class)
     {
-        parent::__construct("Model of $class class is not an SyncMaster model. Make sure you're using the central model to make changes to synced resources when you're in the central context");
+        parent::__construct("Model of $class class is not a SyncMaster model. Make sure you're using the central model to make changes to synced resources when you're in the central context.");
     }
 }


### PR DESCRIPTION
Fix the ModelNotSyncMasterException message by replacing "an" with "a" and adding a period at the end of the sentence to match the style of the other exceptions.