### PR TITLE
Fix: Seed Job Failing To Run Due to `confirmToProceed` Condition In Seed Command

### DIFF
--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -33,6 +33,7 @@ class SeedDatabase implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--force' => true,
         ]);
     }
 }


### PR DESCRIPTION
During our work with the package, we were attempting to create a new tenant via a artisan command we created.  We noticed that when we shifted to production it would hang and never complete, but only while the environment was set to `production`.  While digging into this, we noticed that it was getting caught here:

https://github.com/archtechx/tenancy/blob/3.x/src/Commands/Seed.php#L49

To resolve this, we added the force option when invoking the seed command from the job that AFAIK is only run upon standing up a tenant.  Not really sure when or why this behavior changed considering the blame says it's unchanged for years, so I can only assume it was a change in Laravel because we've used this package for years now without encountering this issue.

Side note, thanks for all the work you do on this!
