### PR TITLE
feat: write cache in separate method

### DIFF
--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -40,17 +40,17 @@ abstract class CachedTenantResolver implements TenantResolver
             return $tenant;
         }
 
-        $this->writeCache(...$args);
-
-        return $tenant;
+        return $this->writeCache(...$args);
     }
 
-    public function writeCache(...$args): void
+    public function writeCache(...$args): Tenant
     {
         $key = $this->getCacheKey(...$args);
         $tenant = $this->resolveWithoutCache(...$args);
 
         $this->cache->put($key, $tenant, static::$cacheTTL);
+
+        return $tenant;
     }
 
     public function invalidateCache(Tenant $tenant): void

--- a/src/Resolvers/Contracts/CachedTenantResolver.php
+++ b/src/Resolvers/Contracts/CachedTenantResolver.php
@@ -34,18 +34,23 @@ abstract class CachedTenantResolver implements TenantResolver
             return $this->resolveWithoutCache(...$args);
         }
 
-        $key = $this->getCacheKey(...$args);
-
-        if ($tenant = $this->cache->get($key)) {
+        if ($tenant = $this->cache->get($this->getCacheKey(...$args))) {
             $this->resolved($tenant, ...$args);
 
             return $tenant;
         }
 
-        $tenant = $this->resolveWithoutCache(...$args);
-        $this->cache->put($key, $tenant, static::$cacheTTL);
+        $this->writeCache(...$args);
 
         return $tenant;
+    }
+
+    public function writeCache(...$args): void
+    {
+        $key = $this->getCacheKey(...$args);
+        $tenant = $this->resolveWithoutCache(...$args);
+
+        $this->cache->put($key, $tenant, static::$cacheTTL);
     }
 
     public function invalidateCache(Tenant $tenant): void


### PR DESCRIPTION
I have a case when a lot of concurrent requests all try to connect at the same time to the central database to refresh the cache. This is not optimal because in my case it takes all the available connections (from RDS proxy) and no connections for the actual target database are free anymore. Hence, I would like to control myself when the cache is written and use a job instead. I could copy the logic to my custom job but it would be nicer if I could simply call the new `writeCache` method.