### PR TITLE
[4.x] Fix: no primary key on RLS views

### DIFF
--- a/src/Database/TenantDatabaseManagers/PermissionControlledPostgreSQLSchemaManager.php
+++ b/src/Database/TenantDatabaseManagers/PermissionControlledPostgreSQLSchemaManager.php
@@ -27,7 +27,7 @@ class PermissionControlledPostgreSQLSchemaManager extends PostgreSQLSchemaManage
         $this->connection()->statement("GRANT USAGE, CREATE ON SCHEMA \"{$schema}\" TO \"{$username}\"");
         $this->connection()->statement("GRANT USAGE ON ALL SEQUENCES IN SCHEMA \"{$schema}\" TO \"{$username}\"");
 
-        $tables = $this->connection()->select("SELECT table_name FROM information_schema.tables WHERE table_schema = '{$schema}'");
+        $tables = $this->connection()->select("SELECT table_name FROM information_schema.tables WHERE table_schema = '{$schema}' AND table_type = 'BASE TABLE'");
 
         // Grant permissions to any existing tables. This is used with RLS
         // todo@samuel refactor this along with the todo in TenantDatabaseManager

--- a/tests/RLS/PolicyTest.php
+++ b/tests/RLS/PolicyTest.php
@@ -78,7 +78,8 @@ beforeEach(function () {
     });
 });
 
-test('rls command succeeds when a view is in the database', function (string $manager) {
+// Regression test for https://github.com/archtechx/tenancy/pull/1280
+test('rls command doesnt fail when a view is in the database', function (string $manager) {
     DB::statement("
         CREATE VIEW post_comments AS
         SELECT
@@ -94,17 +95,12 @@ test('rls command succeeds when a view is in the database', function (string $ma
 
     config(['tenancy.rls.manager' => $manager]);
 
-    try {
-        pest()->artisan('tenants:rls');
-
-        pest()->assertTrue(true);
-    } catch (\Exception $e) {
-        pest()->assertTrue(false);
-    }
+    // throws an exception without the patch
+    pest()->artisan('tenants:rls');
 })->with([
     TableRLSManager::class,
     TraitRLSManager::class,
-]);
+])->throwsNoExceptions();
 
 test('postgres user gets created using the rls command', function(string $manager) {
     config(['tenancy.rls.manager' => $manager]);

--- a/tests/RLS/PolicyTest.php
+++ b/tests/RLS/PolicyTest.php
@@ -78,6 +78,34 @@ beforeEach(function () {
     });
 });
 
+test('rls command succeeds when a view is in the database', function (string $manager) {
+    DB::statement("
+        CREATE VIEW post_comments AS
+        SELECT
+            comments.id AS comment_id,
+            posts.id AS post_id
+        FROM comments
+        INNER JOIN posts
+            ON posts.id = comments.post_id
+    ");
+
+    // Inherit RLS rules from joined tables
+    DB::statement("ALTER VIEW post_comments SET (security_invoker = on)");
+
+    config(['tenancy.rls.manager' => $manager]);
+
+    try {
+        pest()->artisan('tenants:rls');
+
+        pest()->assertTrue(true);
+    } catch (\Exception $e) {
+        pest()->assertTrue(false);
+    }
+})->with([
+    TableRLSManager::class,
+    TraitRLSManager::class,
+]);
+
 test('postgres user gets created using the rls command', function(string $manager) {
     config(['tenancy.rls.manager' => $manager]);
 


### PR DESCRIPTION
When running `php artisan tenants:rls` with a Postgres view an exception is thrown:

```
Attempt to read property "column_name" on null

at vendor/stancl/tenancy/src/Database/TenantDatabaseManagers/PermissionControlledPostgreSQLSchemaManager.php:44
```

This PR attempts to fix this by granting RLS permissions to just BASE TABLEs and ignoring views.

To test, add a Postgres view, my use case is below but any view will do

```sql
CREATE VIEW friends AS
SELECT
    f1.follower_id AS user_id,
    f1.following_id AS friend_id
FROM followers f1
INNER JOIN followers f2
    ON f1.follower_id = f2.following_id
    AND f1.following_id = f2.follower_id
WHERE f1.accepted_at IS NOT NULL
AND f2.accepted_at IS NOT NULL
```

then run `php artisan tenants:rls`