### PR TITLE
[4.x] Fix: drop tenant databases on migrate fresh without domains

### DIFF
--- a/src/Jobs/DeleteDomains.php
+++ b/src/Jobs/DeleteDomains.php
@@ -21,6 +21,6 @@ class DeleteDomains
 
     public function handle(): void
     {
-        $this->tenant->domains->each->delete();
+        $this->tenant->domains?->each->delete();
     }
 }


### PR DESCRIPTION
When running `php artisan migrate:fresh` in a tenacy setup without domains in combination with `'drop_tenant_databases_on_migrate_fresh' => true,` an ErrorException is thrown

```bash
  ErrorException 

  Attempt to read property "each" on null

  at vendor/stancl/tenancy/src/Jobs/DeleteDomains.php:24
     20▕     ) {}
     21▕ 
     22▕     public function handle(): void
     23▕     {
  ➜  24▕         $this->tenant->domains->each->delete();
     25▕     }
     26▕ }
     27▕ 
```

This PR resolves the issue by setting the domains to be optional on the DeleteDomain job