### PR TITLE
[4.x] Fix `tenants:run` argument parsing

### DIFF
--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -21,7 +21,10 @@ class Run extends Command
 
     public function handle(): int
     {
-        $stringInput = (new StringInput($this->argument('commandname')));
+        /** @var string $commandName */
+        $commandName = $this->argument('commandname');
+
+        $stringInput = (new StringInput($commandName));
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($stringInput) {
             $this->components->info("Tenant: {$tenant->getTenantKey()}");

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -24,7 +24,7 @@ class Run extends Command
         /** @var string $commandName */
         $commandName = $this->argument('commandname');
 
-        $stringInput = (new StringInput($commandName));
+        $stringInput = new StringInput($commandName);
 
         tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($stringInput) {
             $this->components->info("Tenant: {$tenant->getTenantKey()}");

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -7,8 +7,8 @@ namespace Stancl\Tenancy\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
 use Stancl\Tenancy\Concerns\HasTenantOptions;
-use Symfony\Component\Console\Output\ConsoleOutput;
 use Symfony\Component\Console\Input\StringInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
 
 class Run extends Command
 {

--- a/src/Commands/Run.php
+++ b/src/Commands/Run.php
@@ -7,8 +7,8 @@ namespace Stancl\Tenancy\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Contracts\Console\Kernel;
 use Stancl\Tenancy\Concerns\HasTenantOptions;
-use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Input\StringInput;
 
 class Run extends Command
 {
@@ -21,30 +21,16 @@ class Run extends Command
 
     public function handle(): int
     {
-        $argvInput = $this->argvInput();
+        $stringInput = (new StringInput($this->argument('commandname')));
 
-        tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($argvInput) {
+        tenancy()->runForMultiple($this->getTenants(), function ($tenant) use ($stringInput) {
             $this->components->info("Tenant: {$tenant->getTenantKey()}");
 
             $this->getLaravel()
                 ->make(Kernel::class)
-                ->handle($argvInput, new ConsoleOutput);
+                ->handle($stringInput, new ConsoleOutput);
         });
 
         return 0;
-    }
-
-    protected function argvInput(): ArgvInput
-    {
-        /** @var string $commandName */
-        $commandName = $this->argument('commandname');
-
-        // Convert string command to array
-        $subCommand = explode(' ', $commandName);
-
-        // Add "artisan" as first parameter because ArgvInput expects "artisan" as first parameter and later removes it
-        array_unshift($subCommand, 'artisan');
-
-        return new ArgvInput($subCommand);
     }
 }

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -389,6 +389,21 @@ test('run command works when sub command asks questions and accepts arguments', 
     expect($user->email)->toBe('email@localhost');
 });
 
+test('run command accepts arguments and options correctly', function() {
+    $tenant = Tenant::create();
+    $id = $tenant->getTenantKey();
+
+    // Use unquoted single-word arguments and quoted arguments with spaces
+    pest()->artisan("tenants:run \"bar username 'email@localhost' adsfg123 'some Arg' --option='some option'\" --tenants=$id")
+        ->expectsOutputToContain("Tenant: $id.")
+        ->expectsOutput("Name: username")
+        ->expectsOutput("Email: email@localhost")
+        ->expectsOutput("Password: adsfg123")
+        ->expectsOutput("Argument: some Arg")
+        ->expectsOutput("Option: some option")
+        ->assertExitCode(0);
+});
+
 test('migrate fresh command only deletes tenant databases if drop_tenant_databases_on_migrate_fresh is true', function (bool $dropTenantDBsOnMigrateFresh) {
     Event::listen(DeletingTenant::class,
         JobPipeline::make([DeleteDomains::class])->send(function (DeletingTenant $event) {

--- a/tests/Etc/Console/AnotherExampleCommand.php
+++ b/tests/Etc/Console/AnotherExampleCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Tests\Etc\Console;
+
+use Illuminate\Console\Command;
+
+class AnotherExampleCommand extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'bar {name} {email} {password} {arg} {--option=}';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $this->line('Name: ' . $this->argument('name'));
+        $this->line('Email: ' . $this->argument('email'));
+        $this->line('Password: ' . $this->argument('password'));
+        $this->line('Argument: ' . $this->argument('arg'));
+        $this->line('Option: ' . $this->option('option'));
+    }
+}

--- a/tests/Etc/Console/ConsoleKernel.php
+++ b/tests/Etc/Console/ConsoleKernel.php
@@ -10,6 +10,7 @@ class ConsoleKernel extends Kernel
 {
     protected $commands = [
         ExampleCommand::class,
+        AnotherExampleCommand::class,
         ExampleQuestionCommand::class,
         AddUserCommand::class,
     ];


### PR DESCRIPTION
The `tenants:run` command wasn't parsing quoted arguments with spaces correctly. E.g. when running `php artisan tenants:run "make:company-plugin-resource user 'change email request'"`, the args would get parsed like this:
```php
array:5 [
  0 => "make:company-plugin-resource"
  1 => "user"
  2 => "'change"
  3 => "email"
  4 => "request'"
]
```

when they should get parsed like this:
```php
array:5 [
  0 => "make:company-plugin-resource"
  1 => "user"
  2 => "change email request"
]
```

This issue was caused by our `argvInput()` method, where we divided the args by spaces.

Luckily, there's the StringInput class that allows us to just pass the commandname argument in `tenants:run`, and the class parses the arguments correctly, as opposed to our previous manual approach combined with ArgvInput. Fixes #1279