### PR TITLE
Allow overriding root URL in tests by default

### DIFF
--- a/src/Bootstrappers/RootUrlBootstrapper.php
+++ b/src/Bootstrappers/RootUrlBootstrapper.php
@@ -42,7 +42,7 @@ class RootUrlBootstrapper implements TenancyBootstrapper
      * that are generating URLs in things like mails, the bootstrapper should be used
      * just like in any queued job.
      */
-    public static bool $rootUrlOverrideInTests = false;
+    public static bool $rootUrlOverrideInTests = true;
 
     public function __construct(
         protected Repository $config,

--- a/src/Bootstrappers/RootUrlBootstrapper.php
+++ b/src/Bootstrappers/RootUrlBootstrapper.php
@@ -41,6 +41,8 @@ class RootUrlBootstrapper implements TenancyBootstrapper
      * due to an internal Livewire route, so you may want to disable it, while in tests
      * that are generating URLs in things like mails, the bootstrapper should be used
      * just like in any queued job.
+     *
+     * todo@revisit
      */
     public static bool $rootUrlOverrideInTests = true;
 


### PR DESCRIPTION
This PR allows overriding root URL in tests by default by changing the default value of `RootUrlBootstrapper::$rootUrlOverrideInTests` to `true`.