### PR TITLE
chore: mysql version in docker compose updated to v8

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
         stdin_open: true
         tty: true
     mysql:
-        image: mysql:5.7
+        image: mysql:8
         environment:
             MYSQL_ROOT_PASSWORD: password
             MYSQL_DATABASE: main
@@ -46,7 +46,7 @@ services:
         tmpfs:
             - /var/lib/mysql
     mysql2:
-        image: mysql:5.7
+        image: mysql:8
         environment:
             MYSQL_ROOT_PASSWORD: password
             MYSQL_DATABASE: main


### PR DESCRIPTION
#### Description
When contributing to the package, I faced several challenges on my MacBook Pro M3 chip due to ARM architecture limitations.

#### Why this should be added
MySQL 5.7 has been EOL already since Oct 2023 and has no supported ARM tags. We should upgrade the MySQL version to 8.

MySQL 8 does have ARM support.

I was able to run the tests successfully on the said docker image.
