### PR TITLE
[4.x] Improve id generators

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -33,6 +33,7 @@ return [
          *
          * @see \Stancl\Tenancy\UniqueIdentifierGenerators\UUIDGenerator
          * @see \Stancl\Tenancy\UniqueIdentifierGenerators\RandomHexGenerator
+         * @see \Stancl\Tenancy\UniqueIdentifierGenerators\RandomIntGenerator
          * @see \Stancl\Tenancy\UniqueIdentifierGenerators\RandomStringGenerator
          */
         'id_generator' => UniqueIdentifierGenerators\UUIDGenerator::class,

--- a/src/Contracts/UniqueIdentifierGenerator.php
+++ b/src/Contracts/UniqueIdentifierGenerator.php
@@ -11,5 +11,5 @@ interface UniqueIdentifierGenerator
     /**
      * Generate a unique identifier for a model.
      */
-    public static function generate(Model $model): string;
+    public static function generate(Model $model): string|int;
 }

--- a/src/UniqueIdentifierGenerators/RandomHexGenerator.php
+++ b/src/UniqueIdentifierGenerators/RandomHexGenerator.php
@@ -18,7 +18,7 @@ class RandomHexGenerator implements UniqueIdentifierGenerator
 {
     public static int $bytes = 6;
 
-    public static function generate(Model $model): string
+    public static function generate(Model $model): string|int
     {
         return bin2hex(random_bytes(static::$bytes));
     }

--- a/src/UniqueIdentifierGenerators/RandomIntGenerator.php
+++ b/src/UniqueIdentifierGenerators/RandomIntGenerator.php
@@ -5,16 +5,17 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\UniqueIdentifierGenerators;
 
 use Illuminate\Database\Eloquent\Model;
-use Ramsey\Uuid\Uuid;
 use Stancl\Tenancy\Contracts\UniqueIdentifierGenerator;
 
 /**
- * Generates a UUID for the tenant key.
+ * Generates a cryptographically secure random integer for the tenant key.
+ *
+ * The integer is generated in range (0, PHP_INT_MAX).
  */
-class UUIDGenerator implements UniqueIdentifierGenerator
+class RandomIntGenerator implements UniqueIdentifierGenerator
 {
     public static function generate(Model $model): string|int
     {
-        return Uuid::uuid4()->toString();
+        return random_int(0, PHP_INT_MAX);
     }
 }

--- a/src/UniqueIdentifierGenerators/RandomIntGenerator.php
+++ b/src/UniqueIdentifierGenerators/RandomIntGenerator.php
@@ -9,13 +9,14 @@ use Stancl\Tenancy\Contracts\UniqueIdentifierGenerator;
 
 /**
  * Generates a cryptographically secure random integer for the tenant key.
- *
- * The integer is generated in range (0, PHP_INT_MAX).
  */
 class RandomIntGenerator implements UniqueIdentifierGenerator
 {
+    public static int $min = 0;
+    public static int $max = PHP_INT_MAX;
+
     public static function generate(Model $model): string|int
     {
-        return random_int(0, PHP_INT_MAX);
+        return random_int(static::$min, static::$max);
     }
 }

--- a/src/UniqueIdentifierGenerators/RandomStringGenerator.php
+++ b/src/UniqueIdentifierGenerators/RandomStringGenerator.php
@@ -18,7 +18,7 @@ class RandomStringGenerator implements UniqueIdentifierGenerator
 {
     public static int $length = 8;
 
-    public static function generate(Model $model): string
+    public static function generate(Model $model): string|int
     {
         return Str::random(static::$length);
     }

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -95,12 +95,10 @@ test('random ints are supported', function () {
     // should statistically be above 1 billion.
     try {
         $tenant1 = Tenant::create();
-        expect($tenant1->id)->toBeString();
         assert((int) $tenant1->id > 10**9);
     } catch (\AssertionError) {
         // retry
         $tenant1 = Tenant::create();
-        expect($tenant1->id)->toBeString();
         assert((int) $tenant1->id > 10**9);
     }
 });

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -23,6 +23,11 @@ use Stancl\Tenancy\UniqueIdentifierGenerators\RandomHexGenerator;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomIntGenerator;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomStringGenerator;
 
+afterEach(function () {
+    RandomIntGenerator::$min = 0;
+    RandomIntGenerator::$max = PHP_INT_MAX;
+});
+
 test('created event is dispatched', function () {
     Event::fake([TenantCreated::class]);
 
@@ -90,17 +95,12 @@ test('hex ids are supported', function () {
 
 test('random ints are supported', function () {
     app()->bind(UniqueIdentifierGenerator::class, RandomIntGenerator::class);
+    RandomIntGenerator::$min = 200;
+    RandomIntGenerator::$max = 1000;
 
-    // No good way to test this besides asserting that at least one of two ids
-    // should statistically be above 1 billion.
-    try {
-        $tenant1 = Tenant::create();
-        assert((int) $tenant1->id > 10**9);
-    } catch (\AssertionError) {
-        // retry
-        $tenant1 = Tenant::create();
-        assert((int) $tenant1->id > 10**9);
-    }
+    $tenant1 = Tenant::create();
+    expect($tenant1->id >= 200)->toBeTrue();
+    expect($tenant1->id <= 1000)->toBeTrue();
 });
 
 test('random string ids are supported', function () {

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -20,6 +20,7 @@ use Stancl\Tenancy\Tests\Etc\Tenant;
 use Stancl\Tenancy\UniqueIdentifierGenerators\UUIDGenerator;
 use Stancl\Tenancy\Exceptions\TenancyNotInitializedException;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomHexGenerator;
+use Stancl\Tenancy\UniqueIdentifierGenerators\RandomIntGenerator;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomStringGenerator;
 
 test('created event is dispatched', function () {
@@ -85,6 +86,23 @@ test('hex ids are supported', function () {
     expect(strlen($tenant2->id))->toBe(16);
 
     RandomHexGenerator::$bytes = 6; // reset
+});
+
+test('random ints are supported', function () {
+    app()->bind(UniqueIdentifierGenerator::class, RandomIntGenerator::class);
+
+    // No good way to test this besides asserting that at least one of two ids
+    // should statistically be above 1 billion.
+    try {
+        $tenant1 = Tenant::create();
+        expect($tenant1->id)->toBeString();
+        assert((int) $tenant1->id > 10**9);
+    } catch (\AssertionError) {
+        // retry
+        $tenant1 = Tenant::create();
+        expect($tenant1->id)->toBeString();
+        assert((int) $tenant1->id > 10**9);
+    }
 });
 
 test('random string ids are supported', function () {


### PR DESCRIPTION
- [x] Add bigint generator
- [x] ~~Add an option to store hex bytes as raw bytes? Figure out how casts and queries would work here. UUIDs have a `uuid()` string type (in migration syntax) but are used as strings, I'm not sure if we could do the same with an arbitrary binary column~~
- [x] ~~Consider a snowflake generator~~