### PR TITLE
fix: not using template/tenant hostname while creating database users

### DIFF
--- a/src/TenantDatabaseManagers/PermissionControlledMySQLDatabaseManager.php
+++ b/src/TenantDatabaseManagers/PermissionControlledMySQLDatabaseManager.php
@@ -25,14 +25,14 @@ class PermissionControlledMySQLDatabaseManager extends MySQLDatabaseManager impl
         $hostname = $databaseConfig->connection()['host'];
         $password = $databaseConfig->getPassword();
 
-        $this->database()->statement("CREATE USER `{$username}`@`%` IDENTIFIED BY '{$password}'");
+        $this->database()->statement("CREATE USER `{$username}`@`{$hostname}` IDENTIFIED BY '{$password}'");
 
         $grants = implode(', ', static::$grants);
 
         if ($this->isVersion8()) { // MySQL 8+
-            $grantQuery = "GRANT $grants ON `$database`.* TO `$username`@`%`";
+            $grantQuery = "GRANT $grants ON `$database`.* TO `$username`@`{$hostname}`";
         } else { // MySQL 5.7
-            $grantQuery = "GRANT $grants ON `$database`.* TO `$username`@`%` IDENTIFIED BY '$password'";
+            $grantQuery = "GRANT $grants ON `$database`.* TO `$username`@`{$hostname}` IDENTIFIED BY '$password'";
         }
 
         return $this->database()->statement($grantQuery);


### PR DESCRIPTION
the `$hostname` variable was defined but never used while creating new database user in the PermissionControlledMySQLDatabaseManager and a default hostname of % was used which caused permission issues like database user can't access mysql using password on localhost 
closes #1309 