### PR TITLE
[3.x] Laravel 12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,12 +16,12 @@ jobs:
     strategy:
       matrix:
         include:
-        - laravel: 9
-          php: "8.0"
         - laravel: 10
           php: "8.1"
         - laravel: 11
           php: "8.3"
+        - laravel: 12
+          php: "8.4"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
         - laravel: 11
           php: "8.3"
         - laravel: 12
-          php: "8.4"
+          php: "8.3"
+          # Ideally we'd run at least one of these on PHP 8.4, however the Dockerfile seems to require some changes for that
 
     steps:
     - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/support": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
         "facade/ignition-contracts": "^1.0.2",
         "ramsey/uuid": "^4.7.3",
-        "stancl/jobpipeline": "^1.6.2",
-        "stancl/virtualcolumn": "^1.3.1"
+        "stancl/jobpipeline": "^1.8.0",
+        "stancl/virtualcolumn": "^1.5.0"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "doctrine/dbal": "^3.6.0",
         "spatie/valuestore": "^1.3.2"

--- a/composer.json
+++ b/composer.json
@@ -12,15 +12,15 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/support": "^9.0|^10.0|^11.0|^12.0",
+        "illuminate/support": "^10.0|^11.0|^12.0",
         "facade/ignition-contracts": "^1.0.2",
         "ramsey/uuid": "^4.7.3",
         "stancl/jobpipeline": "^1.8.0",
         "stancl/virtualcolumn": "^1.5.0"
     },
     "require-dev": {
-        "laravel/framework": "^9.0|^10.0|^11.0|^12.0",
-        "orchestra/testbench": "^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "^10.0|^11.0|^12.0",
+        "orchestra/testbench": "^8.0|^9.0|^10.0",
         "league/flysystem-aws-s3-v3": "^3.12.2",
         "doctrine/dbal": "^3.6.0",
         "spatie/valuestore": "^1.3.2"


### PR DESCRIPTION
This PR adds Laravel 12 supports and drops Laravel 9 support.

The only thing I'd like to improve here would be running at least one set of tests on PHP 8.4, however the Dockerfile would require some changes and it's out of sync with the Dockerfile in master (v4). This can be updated later.