### PR TITLE
[4.x] Make RemoveStorageSymlinksAction able to delete broken symlinks

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -53,6 +53,7 @@ class TenancyServiceProvider extends ServiceProvider
             Events\DeletingTenant::class => [
                 JobPipeline::make([
                     Jobs\DeleteDomains::class,
+                    // Jobs\RemoveStorageSymlinks::class,
                 ])->send(function (Events\DeletingTenant $event) {
                     return $event->tenant;
                 })->shouldBeQueued(false),
@@ -62,7 +63,6 @@ class TenancyServiceProvider extends ServiceProvider
             Events\TenantDeleted::class => [
                 JobPipeline::make([
                     Jobs\DeleteDatabase::class,
-                    // Jobs\RemoveStorageSymlinks::class,
                 ])->send(function (Events\TenantDeleted $event) {
                     return $event->tenant;
                 })->shouldBeQueued(false), // `false` by default, but you probably want to make this `true` for production.

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -56,6 +56,6 @@ trait DealsWithTenantSymlinks
     /** Determine if the provided path is an existing symlink. */
     protected function symlinkExists(string $link): bool
     {
-        return file_exists($link) && is_link($link);
+        return is_link($link);
     }
 }

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -77,7 +77,7 @@ test('remove storage symlinks action works', function() {
     expect(file_exists($publicPath))->toBeFalse();
 });
 
-test('removing the tenant symlinks works even if the symlinks are invalid', function() {
+test('removing tenant symlinks works even if the symlinks are invalid', function() {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -11,6 +11,7 @@ use Stancl\Tenancy\Listeners\RevertToCentralContext;
 use Stancl\Tenancy\Actions\CreateStorageSymlinksAction;
 use Stancl\Tenancy\Actions\RemoveStorageSymlinksAction;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
+use Illuminate\Support\Facades\File;
 
 beforeEach(function () {
     Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
@@ -66,4 +67,40 @@ test('remove storage symlinks action works', function() {
     (new RemoveStorageSymlinksAction)($tenant);
 
     $this->assertDirectoryDoesNotExist($publicPath);
+});
+
+test('removing the tenant symlinks works even if the symlinks are invalid', function() {
+    // todo0 For this test to pass, delete the file_exists($link) check from symlinkExists() in DealsWithTenantSymlinks
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.suffix_base' => 'tenant-',
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%'
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+    $tenantKey = $tenant->getTenantKey();
+
+    tenancy()->initialize($tenant);
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    // The symlink exists and is valid
+    expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeTrue();
+    expect(file_exists($publicPath))->toBeTrue();
+
+    // Make the symlink invalid by deleting the tenant storage directory
+    $storagePath = storage_path();
+    File::deleteDirectory($storagePath);
+
+    // The symlink still exists, but isn't valid
+    expect(is_link($publicPath))->toBeTrue();
+    expect(file_exists($publicPath))->toBeFalse();
+
+    (new RemoveStorageSymlinksAction)($tenant);
+
+    expect(is_link($publicPath))->toBeFalse();
 });

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -70,7 +70,6 @@ test('remove storage symlinks action works', function() {
 });
 
 test('removing the tenant symlinks works even if the symlinks are invalid', function() {
-    // todo0 For this test to pass, delete the file_exists($link) check from symlinkExists() in DealsWithTenantSymlinks
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -36,11 +36,15 @@ test('create storage symlinks action works', function() {
 
     tenancy()->initialize($tenant);
 
-    $this->assertDirectoryDoesNotExist($publicPath = public_path("public-$tenantKey"));
+    // The symlink doesn't exist
+    expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeFalse();
+    expect(file_exists($publicPath))->toBeFalse();
 
     (new CreateStorageSymlinksAction)($tenant);
 
-    $this->assertDirectoryExists($publicPath);
+    // The symlink exists and is valid
+    expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeTrue();
+    expect(file_exists($publicPath))->toBeTrue();
     $this->assertEquals(storage_path("app/public/"), readlink($publicPath));
 });
 
@@ -62,11 +66,15 @@ test('remove storage symlinks action works', function() {
 
     (new CreateStorageSymlinksAction)($tenant);
 
-    $this->assertDirectoryExists($publicPath = public_path("public-$tenantKey"));
+    // The symlink exists and is valid
+    expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeTrue();
+    expect(file_exists($publicPath))->toBeTrue();
 
     (new RemoveStorageSymlinksAction)($tenant);
 
-    $this->assertDirectoryDoesNotExist($publicPath);
+    // The symlink doesn't exist
+    expect(is_link($publicPath))->toBeFalse();
+    expect(file_exists($publicPath))->toBeFalse();
 });
 
 test('removing the tenant symlinks works even if the symlinks are invalid', function() {


### PR DESCRIPTION
I noticed that RemoveStorageSymlinksAction only deletes symlinks if they're not broken (= if they're pointing to an existing directory). To verify this:

```php
config([
    'tenancy.bootstrappers' => [
        FilesystemTenancyBootstrapper::class,
    ],
    'tenancy.filesystem.suffix_base' => 'tenant-',
]);

$tenant = Tenant::create();
$tenantKey = $tenant->getTenantKey();

tenancy()->initialize($tenant);

(new CreateStorageSymlinksAction)($tenant);

file_exists($publicPath); // true

// Make the symlink invalid by deleting the tenant storage directory
File::deleteDirectory(storage_path());

(new RemoveStorageSymlinksAction)($tenant);

$publicPath = public_path("public-$tenantKey");

file_exists($publicPath); // false
is_link($publicPath); // true, the broken symlink still exists
```

This PR changes the `symlinkExists()` function in DealsWithTenantSymlinks to return `is_link($link)` instead of `file_exists($link) && is_link($link)` (check if the link exists instead of checking if it exists _ands is valid_). This change makes RemoveStorageSymlinksAction able to delete broken symlinks. Added a regression test for that ('removing the tenant symlinks works even if the symlinks are invalid' in ActionTest).

This PR also moves the commented RemoveStorageSymlinks job in the TenancyServiceProvider stub from the TenantDeleted event's job pipeline to DeletingTenant -- before the commented RemoveTenantStorage listener. This is a bit better default, since deleting the symlinks before deleting the tenant storage makes more sense (though with the `symlinkExists()` change, the order shouldn't really matter).

Note: **Either** change would've fixed the bug, but they both make sense together as well.