### PR TITLE
Invalidate the resolver cache when a tenant or related model is deleted

### DIFF
--- a/src/Database/Concerns/InvalidatesResolverCache.php
+++ b/src/Database/Concerns/InvalidatesResolverCache.php
@@ -19,7 +19,7 @@ trait InvalidatesResolverCache
     public static function bootInvalidatesResolverCache()
     {
         static::saved(fn(Tenant $tenant) => static::invalidateTenantCache($tenant));
-        static::deleted(fn(Tenant $tenant) => static::invalidateTenantCache($tenant));
+        static::deleting(fn(Tenant $tenant) => static::invalidateTenantCache($tenant));
     }
 
     private static function invalidateTenantCache(Tenant $tenant): void

--- a/src/Database/Concerns/InvalidatesResolverCache.php
+++ b/src/Database/Concerns/InvalidatesResolverCache.php
@@ -18,13 +18,17 @@ trait InvalidatesResolverCache
 
     public static function bootInvalidatesResolverCache()
     {
-        static::saved(function (Tenant $tenant) {
-            foreach (static::$resolvers as $resolver) {
-                /** @var CachedTenantResolver $resolver */
-                $resolver = app($resolver);
+        static::saved(fn(Tenant $tenant) => static::invalidateTenantCache($tenant));
+        static::deleted(fn(Tenant $tenant) => static::invalidateTenantCache($tenant));
+    }
 
-                $resolver->invalidateCache($tenant);
-            }
-        });
+    private static function invalidateTenantCache(Tenant $tenant): void
+    {
+        foreach (static::$resolvers as $resolver) {
+            /** @var CachedTenantResolver $resolver */
+            $resolver = app($resolver);
+
+            $resolver->invalidateCache($tenant);
+        }
     }
 }

--- a/src/Database/Concerns/InvalidatesTenantsResolverCache.php
+++ b/src/Database/Concerns/InvalidatesTenantsResolverCache.php
@@ -21,13 +21,17 @@ trait InvalidatesTenantsResolverCache
 
     public static function bootInvalidatesTenantsResolverCache()
     {
-        static::saved(function (Model $model) {
-            foreach (static::$resolvers as $resolver) {
-                /** @var CachedTenantResolver $resolver */
-                $resolver = app($resolver);
+        static::saved(fn(Model $model) => static::invalidateTenantCache($model));
+        static::deleted(fn(Model $model) => static::invalidateTenantCache($model));
+    }
 
-                $resolver->invalidateCache($model->tenant);
-            }
-        });
+    private static function invalidateTenantCache(Model $model): void
+    {
+        foreach (static::$resolvers as $resolver) {
+            /** @var CachedTenantResolver $resolver */
+            $resolver = app($resolver);
+
+            $resolver->invalidateCache($model->tenant);
+        }
     }
 }

--- a/src/Database/Concerns/InvalidatesTenantsResolverCache.php
+++ b/src/Database/Concerns/InvalidatesTenantsResolverCache.php
@@ -22,7 +22,7 @@ trait InvalidatesTenantsResolverCache
     public static function bootInvalidatesTenantsResolverCache()
     {
         static::saved(fn(Model $model) => static::invalidateTenantCache($model));
-        static::deleted(fn(Model $model) => static::invalidateTenantCache($model));
+        static::deleting(fn(Model $model) => static::invalidateTenantCache($model));
     }
 
     private static function invalidateTenantCache(Model $model): void


### PR DESCRIPTION
Currently, whenever `$shouldCache` in a `CachedTenantResolver` is set to `true`, the cache is only invalidated on the `saved` event of the model. As a result, whenever a `Domain` or a `Tenant` is deleted, the cache is not invalidated and the domains are still accessible (i. e. not falling back to the `$onFail` logic or throwing the `TenantCouldNotBeIdentifiedException`) which may lead to unhandled errors (no database permissions etc.).

This PR makes sure the invalidation is also performed on a `delete` event of `Tenant` or the related models like `Domain`.