### PR TITLE
nitpick: make the default tenant database name a bit more readable

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -186,7 +186,7 @@ return [
          * Tenant database names are created like this:
          * prefix + tenant_id + suffix.
          */
-        'prefix' => 'tenant',
+        'prefix' => 'tenant_',
         'suffix' => '',
 
         /**


### PR DESCRIPTION
Right now databases on a fresh install are setup like 

```tenanta0f50601-87fb-4f8e-bb18-3fb0b39a69bc```

added `_` just to make it a bit tidier 😅