### PR TITLE
[4.x] Add ULIDGenerator

### DIFF
--- a/src/UniqueIdentifierGenerators/ULIDGenerator.php
+++ b/src/UniqueIdentifierGenerators/ULIDGenerator.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\UniqueIdentifierGenerators;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+use Stancl\Tenancy\Contracts\UniqueIdentifierGenerator;
+
+/**
+ * Generates a UUID for the tenant key.
+ */
+class ULIDGenerator implements UniqueIdentifierGenerator
+{
+    public static function generate(Model $model): string|int
+    {
+        return Str::ulid()->toString();
+    }
+}

--- a/tests/TenantModelTest.php
+++ b/tests/TenantModelTest.php
@@ -22,6 +22,8 @@ use Stancl\Tenancy\Exceptions\TenancyNotInitializedException;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomHexGenerator;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomIntGenerator;
 use Stancl\Tenancy\UniqueIdentifierGenerators\RandomStringGenerator;
+use Stancl\Tenancy\UniqueIdentifierGenerators\ULIDGenerator;
+
 use function Stancl\Tenancy\Tests\pest;
 
 afterEach(function () {
@@ -76,6 +78,20 @@ test('autoincrement ids are supported', function () {
 
     expect($tenant1->id)->toBe(1);
     expect($tenant2->id)->toBe(2);
+});
+
+test('ulid ids are supported', function () {
+    app()->bind(UniqueIdentifierGenerator::class, ULIDGenerator::class);
+
+    $tenant1 = Tenant::create();
+    expect($tenant1->id)->toBeString();
+    expect(strlen($tenant1->id))->toBe(26);
+
+    $tenant2 = Tenant::create();
+    expect($tenant2->id)->toBeString();
+    expect(strlen($tenant2->id))->toBe(26);
+
+    expect($tenant2->id > $tenant1->id)->toBeTrue();
 });
 
 test('hex ids are supported', function () {


### PR DESCRIPTION
I didn't change the UUID implementation to just use the Str::uuid() , but that's also an option to remove the dependency on ramsey (and have it as an indirect via the laravel/support)