### PR TITLE
Check if the database exists.

### DIFF
--- a/src/DatabaseConfig.php
+++ b/src/DatabaseConfig.php
@@ -163,4 +163,14 @@ class DatabaseConfig
 
         return $databaseManager;
     }
+
+    /**
+     * Check if the database exists.
+     *
+     * @return bool Returns true if the database exists, otherwise false.
+     */
+    public function exists(): bool
+    {
+        return $this->manager()->databaseExists($this->getName());
+    }
 }


### PR DESCRIPTION
This update introduces a method to verify whether a tenant's database exists.  

#### Usage:  
```php
$tenant->database()->exists();
```
Returns `true` if the tenant's database exists, otherwise `false`.  

#### Why is this necessary?  
In some cases, a tenant's database may be missing due to system migrations or failures.  
Attempting to access `$tenant->database` when the database doesn't exist results in an error:  

> `Modules\Tenancy\App\Models\Tenant::database must return a relationship instance.`  

This makes it difficult to perform conditional checks or debug issues effectively.