### PR TITLE
[4.x] Make ScopeSessions usable on universal routes

### DIFF
--- a/src/Middleware/ScopeSessions.php
+++ b/src/Middleware/ScopeSessions.php
@@ -19,6 +19,12 @@ class ScopeSessions
     public function handle(Request $request, Closure $next): mixed
     {
         if (! tenancy()->initialized) {
+            $route = tenancy()->getRoute($request);
+
+            if (tenancy()->routeIsUniversal($route)) {
+                return $next($request);
+            }
+
             throw new TenancyNotInitializedException('Tenancy needs to be initialized before the session scoping middleware is executed');
         }
 

--- a/src/Middleware/ScopeSessions.php
+++ b/src/Middleware/ScopeSessions.php
@@ -19,9 +19,7 @@ class ScopeSessions
     public function handle(Request $request, Closure $next): mixed
     {
         if (! tenancy()->initialized) {
-            $route = tenancy()->getRoute($request);
-
-            if (tenancy()->routeIsUniversal($route)) {
+            if (tenancy()->routeIsUniversal(tenancy()->getRoute($request))) {
                 return $next($request);
             }
 

--- a/tests/ScopeSessionsTest.php
+++ b/tests/ScopeSessionsTest.php
@@ -55,3 +55,15 @@ test('an exception is thrown when the middleware is executed before tenancy is i
     pest()->expectException(TenancyNotInitializedException::class);
     $this->withoutExceptionHandling()->get('http://acme.localhost/bar');
 });
+
+test('scope sessions mw can be used on universal routes', function() {
+    Route::get('/universal', function () {
+        return true;
+    })->middleware(['universal', InitializeTenancyBySubdomain::class, ScopeSessions::class]);
+
+    Tenant::create([
+        'id' => 'acme',
+    ])->createDomain('acme');
+
+    pest()->withoutExceptionHandling()->get('http://localhost/universal')->assertSuccessful();
+});


### PR DESCRIPTION
The ScopeSessions middleware always throws TenancyNotInitializedException when in central context, even when the route is universal. This PR solves that by skipping the middleware when it's used on a universal route and the route gets visited in central context.