### PR TITLE
[3.x] Add MariaDB database manager config

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -60,6 +60,7 @@ return [
         'managers' => [
             'sqlite' => Stancl\Tenancy\TenantDatabaseManagers\SQLiteDatabaseManager::class,
             'mysql' => Stancl\Tenancy\TenantDatabaseManagers\MySQLDatabaseManager::class,
+            'mariadb' => Stancl\Tenancy\TenantDatabaseManagers\MySQLDatabaseManager::class,
             'pgsql' => Stancl\Tenancy\TenantDatabaseManagers\PostgreSQLDatabaseManager::class,
 
         /**


### PR DESCRIPTION
Laravel added a `mariadb` driver a while ago (see https://laravel.com/docs/11.x/upgrade#dedicated-mariadb-driver) and I noticed that there is no database manager registered out of the box.