### PR TITLE
Feature: Base TestCase for Tenant-Aware Testing

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -196,4 +196,6 @@ return [
         '--class' => 'DatabaseSeeder', // root seeder class
         // '--force' => true, // This needs to be true to seed tenant databases in production
     ],
+
+    'test_tenant' => env('TEST_TENANT', 1),
 ];

--- a/src/Testing/TenantAwareTestCase.php
+++ b/src/Testing/TenantAwareTestCase.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Stancl\Tenancy\Testing;
+
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TenantAwareTestCase extends BaseTestCase
+{
+    use CreatesApplication;
+
+    /**
+     * Set this to true in child classes to enable tenancy.
+     *
+     * @var bool
+     */
+    protected bool $tenancy = true;
+
+    /**
+     * Tenant instance used in the test.
+     *
+     * @var \App\Models\Tenant|null
+     */
+    protected ?Tenant $tenant = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if ($this->tenancy) {
+            $this->initializeTenancy();
+        }
+    }
+
+    /**
+     * Initialize tenancy for a specific tenant.
+     *
+     * @param string|int|null $tenantIdentifier
+     * @return void
+     */
+    protected function initializeTenancy(string|int|null $tenantIdentifier = null): void
+    {
+        $identifier = $tenantIdentifier ?? config('tenancy.test_tenant');
+
+        $this->tenant = Tenant::find($identifier);
+
+        if (! $this->tenant) {
+            $this->fail("Tenant [{$identifier}] not found. Please ensure TEST_TENANT is set correctly in .env.testing or config('tenancy.test_tenant').");
+        }
+
+        tenancy()->initialize($this->tenant);
+    }
+
+    /**
+     * Run assertions or actions in central context.
+     */
+    protected function runInCentralContext(callable $callback): mixed
+    {
+        $tenant = $this->tenant ?? tenancy()->tenant;
+
+        tenancy()->end();
+
+        try {
+            return $callback();
+        } finally {
+            if ($tenant) {
+                tenancy()->initialize($tenant);
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Summary
This PR introduces a `TenantAwareTestCase` base class under the `Stancl\Tenancy\Testing` namespace to help developers write cleaner, tenant-aware tests with minimal boilerplate.

This PR provides an abstract base class that:

- Automatically initializes tenancy before each test (via TEST_TENANT)
- Allows easy switching to the central context using runInCentralContext()
- It is fully optional and does not affect existing behavior

# Usage
```
use Stancl\Tenancy\Testing\TenantAwareTestCase;

class OrdersTest extends TenantAwareTestCase
{
    public function test_orders_are_isolated_by_tenant()
    {
        $this->get('/api/orders')->assertStatus(200);
    }

    public function test_central_logic()
    {
        $this->runInCentralContext(function () {
            $this->assertDatabaseHas('users', ['email' => 'admin@example.com']);
        });
    }
}
```

# Features
1. Auto tenancy setup using .env.testing
5. $tenancy = false toggle for opt-out
6. Central DB testing support
7. 100% backward compatible
8. Fully optional — users can ignore it if not needed

Happy to rename, restructure, or adapt the PR based on your feedback or project goals. 😀