### PR TITLE
[4.x] Make TableRLSManager skip foreign keys with 'no-rls' comment right away

### DIFF
--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -108,6 +108,12 @@ class TableRLSManager implements RLSPolicyManager
 
     protected function generatePaths(string $table, array $foreign, array &$paths, array $currentPath = []): void
     {
+        // If the foreign key has a comment of 'no-rls', we skip it
+        // Also skip the foreign key if implicit scoping is off and the foreign key has no comment
+        if ($foreign['comment'] === 'no-rls' || (! static::$scopeByDefault && $foreign['comment'] === null)) {
+            return;
+        }
+
         if (in_array($foreign['foreignTable'], array_column($currentPath, 'foreignTable'))) {
             throw new RecursiveRelationshipException;
         }
@@ -115,15 +121,7 @@ class TableRLSManager implements RLSPolicyManager
         $currentPath[] = $foreign;
 
         if ($foreign['foreignTable'] === tenancy()->model()->getTable()) {
-            $comments = array_column($currentPath, 'comment');
-            $pathCanUseRls = static::$scopeByDefault ?
-                ! in_array('no-rls', $comments) :
-                ! in_array('no-rls', $comments) && ! in_array(null, $comments);
-
-            if ($pathCanUseRls) {
-                // If the foreign table is the tenants table, add the current path to $paths
-                $paths[] = $currentPath;
-            }
+            $paths[] = $currentPath;
         } else {
             // If not, recursively generate paths for the foreign table
             foreach ($this->database->getSchemaBuilder()->getForeignKeys($foreign['foreignTable']) as $nextConstraint) {

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -503,7 +503,7 @@ test('table rls manager generates relationship trees with tables related to the 
 
     // Add non-nullable comment_id foreign key
     Schema::table('ratings', function (Blueprint $table) {
-        $table->foreignId('comment_id')->onUpdate('cascade')->onDelete('cascade')->comment('rls')->constrained('comments');
+        $table->foreignId('comment_id')->comment('rls')->constrained('comments')->onUpdate('cascade')->onDelete('cascade');
     });
 
     // Non-nullable paths are preferred over nullable paths
@@ -640,11 +640,11 @@ test('table rls manager generates queries correctly', function() {
 test('table manager throws an exception when encountering a recursive relationship', function() {
     Schema::create('recursive_posts', function (Blueprint $table) {
         $table->id();
-        $table->foreignId('highlighted_comment_id')->constrained('comments')->nullable()->comment('rls');
+        $table->foreignId('highlighted_comment_id')->nullable()->comment('rls')->constrained('comments');
     });
 
     Schema::table('comments', function (Blueprint $table) {
-        $table->foreignId('recursive_post_id')->constrained('recursive_posts')->comment('rls');
+        $table->foreignId('recursive_post_id')->comment('rls')->constrained('recursive_posts');
     });
 
     expect(fn () => app(TableRLSManager::class)->generateTrees())->toThrow(RecursiveRelationshipException::class);

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -650,6 +650,19 @@ test('table manager throws an exception when encountering a recursive relationsh
     expect(fn () => app(TableRLSManager::class)->generateTrees())->toThrow(RecursiveRelationshipException::class);
 });
 
+test('table manager ignores recursive relationship if the foreign key responsible for the recursion has no-rls comment', function() {
+    Schema::create('recursive_posts', function (Blueprint $table) {
+        $table->id();
+        $table->foreignId('highlighted_comment_id')->nullable()->comment('no-rls')->constrained('comments');
+    });
+
+    Schema::table('comments', function (Blueprint $table) {
+        $table->foreignId('recursive_post_id')->comment('rls')->constrained('recursive_posts');
+    });
+
+    expect(fn () => app(TableRLSManager::class)->generateTrees())->not()->toThrow(RecursiveRelationshipException::class);
+});
+
 class Post extends Model
 {
     protected $guarded = [];


### PR DESCRIPTION
Until now, TableRLSManager generated paths leading to the tenants table through any foreign key, even when the foreign key had the 'no-rls' comment. The paths were "thrown away" if they had 'no-rls' only after they were fully generated, and that's too late, namely because of how recursive relationships are handled.

The RecursiveRelationshipException gets thrown after the same table name has been added to the path twice. This would happen before the code could check the foreign key's comment, so generating RLS policies with relationships like this:
```php
Schema::create('posts', function (Blueprint $table) {
        $table->id();
        $table->foreignId('highlighted_comment_id')->nullable()->comment('no-rls')->constrained();
    });


Schema::create('comments', function (Blueprint $table) {
        $table->id();
        $table->foreignId('post_id')->comment('rls')->constrained();
});
```

wouldn't work. Note the 'no-rls' comment -- it should prevent RecursiveRelationshipException, but until now, it didn't.

After the change introduced in this PR, the foreign key's comment is read right at the start of `generatePaths()` and the path generation is interrupted if the comment is 'no-rls', or if `static::$scopeByDefault` is `false` and the comment is null. So now, it's possible to handle recursive relationships as mentioned above.

Also fixed the column definitions in TableManagerTest's migrations.