### PR TITLE
[4.x] Route cloning refactor

### DIFF
--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -22,7 +22,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * The default for $cloneRoutesWithMiddleware is ['clone'].
  * If $routesToClone is empty, all routes with any middleware specified in $cloneRoutesWithMiddleware will be cloned.
  * You may customize $cloneRoutesWithMiddleware using cloneRoutesWithMiddleware() to make any middleware of your choice trigger cloning.
- * By providing a callback to shouldClone(), you can change how it's determined if a route should be cloned.
+ * By providing a callback to shouldClone(), you can change how it's determined if a route should be cloned if you don't want to use middleware flags.
  *
  * Cloned routes are prefixed with '/{tenant}', flagged with 'tenant' middleware, and have their names prefixed with 'tenant.'.
  * The parameter name and prefix can be changed e.g. to `/{team}` and `team.` by configuring the path resolver (tenantParameterName and tenantRouteNamePrefix).
@@ -34,7 +34,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * Middleware groups are preserved as-is, even if they contain cloning middleware.
  *
  * Routes that already contain the tenant parameter or have names with the tenant prefix
- * will not be cloned. This is to prevent infinite cloning loops.
+ * will not be cloned.
  *
  * Example usage:
  * ```

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -32,7 +32,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
 class CloneRoutesAsTenant
 {
     protected array $routesToClone = [];
-    protected Closure|null $cloneUsing = null;
+    protected Closure|null $cloneUsing = null; // The callback should accept Route instance or the route name (string)
     protected Closure|null $shouldBeCloned = null;
     protected array $cloneRoutesWithMiddleware = ['clone'];
 
@@ -57,6 +57,11 @@ class CloneRoutesAsTenant
                 ($this->cloneUsing)($route);
 
                 continue;
+            }
+
+            if (is_string($route)) {
+                $this->router->getRoutes()->refreshNameLookups();
+                $route = $this->router->getRoutes()->getByName($route);
             }
 
             $this->copyMiscRouteProperties($route, $this->createNewRoute($route));
@@ -86,7 +91,7 @@ class CloneRoutesAsTenant
         return $this;
     }
 
-    public function cloneRoute(Route $route): static
+    public function cloneRoute(Route|string $route): static
     {
         $this->routesToClone[] = $route;
 

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -9,38 +9,32 @@ use Illuminate\Routing\Route;
 use Illuminate\Routing\Router;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
-use Stancl\Tenancy\Enums\RouteMode;
 use Stancl\Tenancy\Resolvers\PathTenantResolver;
 
 /**
- * The CloneRoutesAsTenant action clones
- * routes flagged with the 'universal' middleware,
- * all routes without a flag if the default route mode is universal,
- * and routes that directly use the InitializeTenancyByPath middleware.
+ * Clones routes manually added to $routesToClone, or if $routesToClone is empty,
+ * clones all existing routes for which shouldBeCloned returns true (by default, this means all routes
+ * with any middleware that's present in $cloneRoutesWithMiddleware).
+ * Cloned routes are prefixed with '/{tenant}', flagged with 'tenant' middleware,
+ * and have their names prefixed with 'tenant.'.
  *
  * The main purpose of this action is to make the integration
  * of packages (e.g., Jetstream or Livewire) easier with path-based tenant identification.
  *
- * By default, universal routes are cloned as tenant routes (= they get flagged with the 'tenant' middleware)
- * and prefixed with the '/{tenant}' path prefix. Their name also gets prefixed with the tenant name prefix.
- *
- * Routes with the path identification middleware get cloned similarly, but only if they're not universal at the same time.
- * Unlike universal routes, these routes don't get the tenant flag,
- * because they don't need it (they're not universal, and they have the identification MW, so they're already considered tenant).
- *
- * You can use the `cloneUsing()` hook to customize the route definitions,
- * and the `skipRoute()` method to skip cloning of specific routes.
- * You can also use the $tenantParameterName and $tenantRouteNamePrefix
- * static properties to customize the tenant parameter name or the route name prefix.
+ * Customization:
+ * - Use cloneRoutesWithMiddleware() to change the middleware in $cloneRoutesWithMiddleware
+ * - Use shouldClone() to change which routes should be cloned
+ * - Use cloneUsing() to customize route definitions
+ * - Adjust PathTenantResolver's $tenantParameterName and $tenantRouteNamePrefix as needed
  *
  * Note that routes already containing the tenant parameter or prefix won't be cloned.
  */
 class CloneRoutesAsTenant
 {
-    protected array $cloneRouteUsing = [];
-    protected array $skippedRoutes = [
-        'stancl.tenancy.asset',
-    ];
+    protected array $routesToClone = [];
+    protected Closure|null $cloneUsing = null;
+    protected Closure|null $shouldBeCloned = null;
+    protected array $cloneRoutesWithMiddleware = ['clone'];
 
     public function __construct(
         protected Router $router,
@@ -48,100 +42,69 @@ class CloneRoutesAsTenant
 
     public function handle(): void
     {
-        $this->getRoutesToClone()->each(fn (Route $route) => $this->cloneRoute($route));
+        // If no routes were specified using cloneRoute(), get all routes that should be cloned
+        if (! $this->routesToClone) {
+            $this->routesToClone = collect($this->router->getRoutes()->get())
+                ->filter(fn (Route $route) => $this->shouldBeCloned($route))
+                ->all();
+        }
+
+        foreach ($this->routesToClone as $route) {
+            // If the cloneUsing callback is set,
+            // use the callback to clone the route instead of the default
+            if ($this->cloneUsing) {
+                ($this->cloneUsing)($route);
+
+                continue;
+            }
+
+            $this->copyMiscRouteProperties($route, $this->createNewRoute($route));
+        }
 
         $this->router->getRoutes()->refreshNameLookups();
     }
 
-    /**
-     * Make the action clone a specific route using the provided callback instead of the default one.
-     */
-    public function cloneUsing(string $routeName, Closure $callback): static
+    public function cloneUsing(Closure|null $cloneUsing): static
     {
-        $this->cloneRouteUsing[$routeName] = $callback;
+        $this->cloneUsing = $cloneUsing;
 
         return $this;
     }
 
-    /**
-     * Skip a route's cloning.
-     */
-    public function skipRoute(string $routeName): static
+    public function cloneRoutesWithMiddleware(array $middleware): static
     {
-        $this->skippedRoutes[] = $routeName;
+        $this->cloneRoutesWithMiddleware = $middleware;
 
         return $this;
     }
 
-    /**
-     * @return Collection<int, Route>
-     */
-    protected function getRoutesToClone(): Collection
+    public function shouldClone(Closure|null $shouldClone): static
     {
-        $tenantParameterName = PathTenantResolver::tenantParameterName();
+        $this->shouldBeCloned = $shouldClone;
 
-        /**
-         * Clone all routes that:
-         * - don't have the tenant parameter
-         * - aren't in the $skippedRoutes array
-         * - are using path identification (kernel or route-level).
-         *
-         * Non-universal cloned routes will only be available in the tenant context,
-         * universal routes will be available in both contexts.
-         */
-        return collect($this->router->getRoutes()->get())->filter(function (Route $route) use ($tenantParameterName) {
-            if (
-                tenancy()->routeHasMiddleware($route, 'tenant') ||
-                in_array($route->getName(), $this->skippedRoutes, true) ||
-                in_array($tenantParameterName, $route->parameterNames(), true)
-            ) {
-                return false;
-            }
-
-            $pathIdentificationMiddleware = config('tenancy.identification.path_identification_middleware');
-            $routeHasPathIdentificationMiddleware = tenancy()->routeHasMiddleware($route, $pathIdentificationMiddleware);
-            $routeHasNonPathIdentificationMiddleware = tenancy()->routeHasIdentificationMiddleware($route) && ! $routeHasPathIdentificationMiddleware;
-            $pathIdentificationMiddlewareInGlobalStack = tenancy()->globalStackHasMiddleware($pathIdentificationMiddleware);
-
-            /**
-             * The route should get cloned if:
-             * - it has route-level path identification middleware, OR
-             * - it uses kernel path identification (it doesn't have any route-level identification middleware) and the route is tenant or universal.
-             *
-             * The route is considered tenant if:
-             * - it's flagged as tenant, OR
-             * - it's not flagged as tenant or universal, but it has the identification middleware
-             *
-             * The route is considered universal if it's flagged as universal, and it doesn't have the tenant flag
-             * (it's still considered universal if it has route-level path identification middleware + the universal flag).
-             *
-             * If the route isn't flagged, the context is determined using the default route mode.
-             */
-            $pathIdentificationUsed = (! $routeHasNonPathIdentificationMiddleware) &&
-                ($routeHasPathIdentificationMiddleware || $pathIdentificationMiddlewareInGlobalStack);
-
-            return $pathIdentificationUsed &&
-                (tenancy()->getRouteMode($route) === RouteMode::UNIVERSAL || tenancy()->routeHasMiddleware($route, 'clone'));
-        });
+        return $this;
     }
 
-    /**
-     * Clone a route using a callback specified in the $cloneRouteUsing property (using the cloneUsing method).
-     * If there's no callback specified for the route, use the default way of cloning routes.
-     */
-    protected function cloneRoute(Route $route): void
+    public function cloneRoute(Route $route): static
     {
-        $routeName = $route->getName();
+        $this->routesToClone[] = $route;
 
-        // If the route's cloning callback exists
-        // Use the callback to clone the route instead of the default way of cloning routes
-        if ($routeName && $customRouteCallback = data_get($this->cloneRouteUsing, $routeName)) {
-            $customRouteCallback($route);
+        return $this;
+    }
 
-            return;
+    // todo@rename
+    protected function shouldBeCloned(Route $route): bool
+    {
+        if ($this->shouldBeCloned) {
+            return ($this->shouldBeCloned)($route);
         }
 
-        $this->copyMiscRouteProperties($route, $this->createNewRoute($route));
+        if (Str::startsWith($route->getName(), PathTenantResolver::tenantRouteNamePrefix())) {
+            // The route already has the tenant route name prefix, so we don't need to clone it
+            return false;
+        }
+
+        return tenancy()->routeHasMiddleware($route, $this->cloneRoutesWithMiddleware);
     }
 
     protected function createNewRoute(Route $route): Route
@@ -156,21 +119,21 @@ class CloneRoutesAsTenant
 
             // Make the new route have the same middleware as the original route
             // Add the 'tenant' middleware to the new route
-            // Exclude `universal` and `clone` middleware from the new route (it should only be flagged as tenant)
+            // Exclude $this->cloneRoutesWithMiddleware MW from the new route (it should only be flagged as tenant)
             $newRouteMiddleware = collect($routeMiddleware)
                 ->merge(['tenant']) // Add 'tenant' flag
-                ->filter(fn (string $middleware) => ! in_array($middleware, ['universal', 'clone']))
+                ->filter(fn (string $middleware) => ! in_array($middleware, $this->cloneRoutesWithMiddleware))
                 ->toArray();
 
             $tenantRouteNamePrefix = PathTenantResolver::tenantRouteNamePrefix();
 
             // Make sure the route name has the tenant route name prefix
-            $newRouteNamePrefix = $route->getName()
+            $newRouteName = $route->getName()
                 ? $tenantRouteNamePrefix . Str::after($route->getName(), $tenantRouteNamePrefix)
                 : null;
 
             return $action
-                ->put('as', $newRouteNamePrefix)
+                ->put('as', $newRouteName)
                 ->put('middleware', $newRouteMiddleware)
                 ->put('prefix', $prefix . '/{' . PathTenantResolver::tenantParameterName() . '}');
         })->toArray();

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -142,17 +142,13 @@ class CloneRoutesAsTenant
         // Add the 'tenant' middleware to the new route
         // Exclude $this->cloneRoutesWithMiddleware MW from the new route (it should only be flagged as tenant)
 
-        /** @var array $middleware */
-        $middleware = $action->get('middleware') ?? [];
-        $middleware = $this->processMiddlewareForCloning($middleware);
-        $name = $route->getName();
+        $middleware = $this->processMiddlewareForCloning($action->get('middleware') ?? []);
 
-        if ($name) {
-            $name = PathTenantResolver::tenantRouteNamePrefix() . $name;
+        if ($name = $route->getName()) {
+            $action->put('as', PathTenantResolver::tenantRouteNamePrefix() . $name);
         }
 
         $action
-            ->put('as', $name)
             ->put('middleware', $middleware)
             ->put('prefix', $prefix . '/{' . PathTenantResolver::tenantParameterName() . '}');
 
@@ -177,11 +173,10 @@ class CloneRoutesAsTenant
     }
 
     /** Removes top-level cloneRoutesWithMiddleware and adds 'tenant' middleware. */
-    protected function processMiddlewareForCloning(array $middlewares): array
+    protected function processMiddlewareForCloning(array $middleware): array
     {
-        // Filter out top-level cloneRoutesWithMiddleware and add the 'tenant' flag
         $processedMiddleware = array_filter(
-            $middlewares,
+            $middleware,
             fn ($mw) => ! in_array($mw, $this->cloneRoutesWithMiddleware)
         );
 

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -42,7 +42,8 @@ class CloneRoutesAsTenant
 
     public function handle(): void
     {
-        // If no routes were specified using cloneRoute(), get all routes that should be cloned
+        // If no routes were specified using cloneRoute(), get all routes
+        // and for each, determine if it should be cloned
         if (! $this->routesToClone) {
             $this->routesToClone = collect($this->router->getRoutes()->get())
                 ->filter(fn (Route $route) => $this->shouldBeCloned($route))

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -13,14 +13,20 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
 /**
  * Clones either all existing routes for which shouldBeCloned() returns true
  * (by default, all routes with any middleware present in $cloneRoutesWithMiddleware),
- * or if any routes were manually added to $routesToClone (using $action->cloneRoute($route)),
- * clone just the routes in $routesToClone.
+ * or if any routes were manually added to $routesToClone using $action->cloneRoute($route),
+ * clone just the routes in $routesToClone. This means that only the routes specified
+ * by cloneRoute() (which can be chained infinitely -- you can specify as many routes as you want)
+ * will be cloned.
  *
  * The main purpose of this action is to make the integration of packages
  * (e.g., Jetstream or Livewire) easier with path-based tenant identification.
  *
  * The default for $cloneRoutesWithMiddleware is ['clone'].
  * If $routesToClone is empty, all routes with any middleware specified in $cloneRoutesWithMiddleware will be cloned.
+ * The middleware can be in a group, nested as deep as you want
+ * (e.g. if a route has a 'bar' middleware, the 'bar' is actually a middleware group with the
+ * 'foo' middleware group, and 'foo' has the 'clone' middleware, the route will be cloned).
+ *
  * You may customize $cloneRoutesWithMiddleware using cloneRoutesWithMiddleware() to make any middleware of your choice trigger cloning.
  * By providing a callback to shouldClone(), you can change how it's determined if a route should be cloned if you don't want to use middleware flags.
  *
@@ -30,7 +36,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * The cloneUsing() method allows you to completely override the default behavior and customize how the cloned routes will be defined.
  *
  * After cloning, only top-level middleware in $cloneRoutesWithMiddleware will be removed
- * from the new route (so in the default case, 'clone' will be stripped from the MW list).
+ * from the new route (so by default, 'clone' will be omitted from the new route's MW).
  * Middleware groups are preserved as-is, even if they contain cloning middleware.
  *
  * Routes that already contain the tenant parameter or have names with the tenant prefix

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -129,7 +129,11 @@ class CloneRoutesAsTenant
         // Make the new route have the same middleware as the original route
         // Add the 'tenant' middleware to the new route
         // Exclude $this->cloneRoutesWithMiddleware MW from the new route (it should only be flagged as tenant)
-        $middleware = collect($action->get('middleware') ?? [])
+
+        /** @var array $middleware */
+        $middleware = $action->get('middleware') ?? [];
+
+        $middleware = collect($middleware)
             ->merge(['tenant']) // Add 'tenant' flag
             // todo0 what if 'clone' is within some middleware group - not top level? this should be handled similarly
             // to tenancy()->routeHasMiddleware() - use the same traversal depth. only issue is that in such a case, we

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -61,6 +61,11 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * $cloneAction->cloneRoute('baz')->handle();
  * ```
  *
+ * Calling handle() will also clear the $routesToClone array, so that subsequent handle() calls aren't broken.
+ * This means that $action->cloneRoute('foo')->handle() will clone the 'foo' route, but subsequent calls to handle() will behave
+ * as if cloneRoute() wasn't called at all ($routesToClone will be empty).
+ * Note that calling handle() does not reset the other properties.
+ *
  * @see Stancl\Tenancy\Resolvers\PathTenantResolver
  */
 class CloneRoutesAsTenant

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -24,8 +24,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * The default for $cloneRoutesWithMiddleware is ['clone'].
  * If $routesToClone is empty, all routes with any middleware specified in $cloneRoutesWithMiddleware will be cloned.
  * The middleware can be in a group, nested as deep as you want
- * (e.g. if a route has a 'bar' middleware, the 'bar' is actually a middleware group with the
- * 'foo' middleware group, and 'foo' has the 'clone' middleware, the route will be cloned).
+ * (e.g. if a route has a 'foo' middleware which is a group containing the 'clone' middleware, the route will be cloned).
  *
  * You may customize $cloneRoutesWithMiddleware using cloneRoutesWithMiddleware() to make any middleware of your choice trigger cloning.
  * By providing a callback to shouldClone(), you can change how it's determined if a route should be cloned if you don't want to use middleware flags.
@@ -61,7 +60,7 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * $cloneAction->cloneRoute('baz')->handle();
  * ```
  *
- * Calling handle() will also clear the $routesToClone array, so that subsequent handle() calls aren't broken.
+ * Calling handle() will also clear the $routesToClone array.
  * This means that $action->cloneRoute('foo')->handle() will clone the 'foo' route, but subsequent calls to handle() will behave
  * as if cloneRoute() wasn't called at all ($routesToClone will be empty).
  * Note that calling handle() does not reset the other properties.

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -92,16 +92,10 @@ class CloneRoutesAsTenant
         return $this;
     }
 
-    // todo@rename
     protected function shouldBeCloned(Route $route): bool
     {
         if ($this->shouldBeCloned) {
             return ($this->shouldBeCloned)($route);
-        }
-
-        if (Str::startsWith($route->getName(), PathTenantResolver::tenantRouteNamePrefix())) {
-            // The route already has the tenant route name prefix, so we don't need to clone it
-            return false;
         }
 
         return tenancy()->routeHasMiddleware($route, $this->cloneRoutesWithMiddleware);

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -249,9 +249,9 @@ test('clone middleware within middleware groups is properly handled during cloni
     expect($clonedNestedRoute)->not()->toBeNull();
 
     $nestedRouteMiddleware = tenancy()->getRouteMiddleware($clonedNestedRoute);
+
     expect($nestedRouteMiddleware)
         ->toContain('web', 'auth', 'tenant')
-        ->not()->toContain('clone')
-        // Should not contain any group names - middleware should be extracted
-        ->not()->toContain('nested-group', 'level-2-group', 'level-3-group');
+        // Shouldn't contain 'clone' or any nested group names
+        ->not()->toContain('clone', 'nested-group', 'level-2-group', 'level-3-group');
 });

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -113,7 +113,7 @@ test('custom callbacks can be used for customizing the creation of the cloned ro
     pest()->get(route('cloned.bar'))->assertSee('cloned route');
 });
 
-test('the clone action can clone specific routes', function() {
+test('the clone action can clone specific routes', function(bool $cloneRouteByName) {
     RouteFacade::get('/foo', fn () => true)->name('foo');
     $barRoute = RouteFacade::get('/bar', fn () => true)->name('bar');
     RouteFacade::get('/baz', fn () => true)->name('baz');
@@ -124,13 +124,17 @@ test('the clone action can clone specific routes', function() {
     /** @var CloneRoutesAsTenant $cloneRoutesAction */
     $cloneRoutesAction = app(CloneRoutesAsTenant::class);
 
-    $cloneRoutesAction->cloneRoute($barRoute)->handle();
+    // A route instance or a route name can be passed to cloneRoute()
+    $cloneRoutesAction->cloneRoute($cloneRouteByName ? $barRoute->getName() : $barRoute)->handle();
 
     // Exactly one route should be cloned
     expect($currentRouteCount())->toEqual($initialRouteCount + 1);
 
     expect(RouteFacade::getRoutes()->getByName('tenant.bar'))->not()->toBeNull();
-});
+})->with([
+    true,
+    false,
+]);
 
 test('the clone action prefixes already prefixed routes correctly', function () {
     $routes = [

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -1,270 +1,121 @@
 <?php
 
 use Illuminate\Routing\Route;
-use Stancl\Tenancy\Enums\RouteMode;
 use Stancl\Tenancy\Tests\Etc\Tenant;
-use Illuminate\Contracts\Http\Kernel;
 use Stancl\Tenancy\Actions\CloneRoutesAsTenant;
 use Stancl\Tenancy\Resolvers\PathTenantResolver;
 use Illuminate\Support\Facades\Route as RouteFacade;
-use Stancl\Tenancy\Tests\Etc\HasMiddlewareController;
-use Stancl\Tenancy\Middleware\InitializeTenancyByPath;
-use Stancl\Tenancy\Middleware\InitializeTenancyByDomain;
 use function Stancl\Tenancy\Tests\pest;
 
-test('a route can be universal using path identification', function (array $routeMiddleware, array $globalMiddleware) {
-    foreach ($globalMiddleware as $middleware) {
-        if ($middleware === 'universal') {
-            config(['tenancy.default_route_mode' => RouteMode::UNIVERSAL]);
-        } else {
-            app(Kernel::class)->pushMiddleware($middleware);
-        }
-    }
-
-    RouteFacade::get('/foo', function () {
-        return tenancy()->initialized
-            ? 'Tenancy is initialized.'
-            : 'Tenancy is not initialized.';
-    })->middleware($routeMiddleware);
-
-    config(['tenancy._tests.static_identification_middleware' => $routeMiddleware]);
-
-    RouteFacade::get('/bar', [HasMiddlewareController::class, 'index']);
-
-    /** @var CloneRoutesAsTenant $cloneRoutesAction */
-    $cloneRoutesAction = app(CloneRoutesAsTenant::class);
-
-    $cloneRoutesAction->handle();
-
-    $tenantKey = Tenant::create()->getTenantKey();
-
-    pest()->get("http://localhost/foo")
-        ->assertSuccessful()
-        ->assertSee('Tenancy is not initialized.');
-
-    pest()->get("http://localhost/{$tenantKey}/foo")
-        ->assertSuccessful()
-        ->assertSee('Tenancy is initialized.');
-
-    tenancy()->end();
-
-    pest()->get("http://localhost/bar")
-        ->assertSuccessful()
-        ->assertSee('Tenancy is not initialized.');
-
-    pest()->get("http://localhost/{$tenantKey}/bar")
-        ->assertSuccessful()
-        ->assertSee('Tenancy is initialized.');
-})->with('path identification types');
-
-test('CloneRoutesAsTenant registers prefixed duplicates of universal routes correctly', function (bool $kernelIdentification, bool $useController, string $tenantMiddleware) {
-    $routeMiddleware = ['universal'];
-    config(['tenancy.identification.path_identification_middleware' => [$tenantMiddleware]]);
-
-    if ($kernelIdentification) {
-        app(Kernel::class)->pushMiddleware($tenantMiddleware);
-    } else {
-        $routeMiddleware[] = $tenantMiddleware;
-    }
-
+test('CloneRoutesAsTenant registers prefixed duplicates of routes correctly', function () {
     config(['tenancy.identification.resolvers.' . PathTenantResolver::class . '.tenant_parameter_name' => $tenantParameterName = 'team']);
     config(['tenancy.identification.resolvers.' . PathTenantResolver::class . '.tenant_route_name_prefix' => $tenantRouteNamePrefix = 'team-route.']);
 
     // Test that routes with controllers as well as routes with closure actions get cloned correctly
-    $universalRoute = RouteFacade::get('/home', $useController ? Controller::class : fn () => tenant() ? 'Tenancy is initialized.' : 'Tenancy is not initialized.')->middleware($routeMiddleware)->name('home');
-    $centralRoute = RouteFacade::get('/central', fn () => true)->name('central');
+    $route = RouteFacade::get('/home', fn () => true)->middleware(['clone'])->name('home');
 
-    config(['tenancy._tests.static_identification_middleware' => $routeMiddleware]);
-
-    $universalRoute2 = RouteFacade::get('/bar', [HasMiddlewareController::class, 'index'])->name('second-home');
-
-    expect($routes = RouteFacade::getRoutes()->get())->toContain($universalRoute)
-        ->toContain($universalRoute2)
-        ->toContain($centralRoute);
+    expect($routes = RouteFacade::getRoutes()->get())->toContain($route);
 
     /** @var CloneRoutesAsTenant $cloneRoutesAction */
     $cloneRoutesAction = app(CloneRoutesAsTenant::class);
 
     $cloneRoutesAction->handle();
 
-    expect($routesAfterRegisteringDuplicates = RouteFacade::getRoutes()->get())
-        ->toContain($universalRoute)
-        ->toContain($centralRoute);
+    $newRoutes = collect(RouteFacade::getRoutes()->get())->filter(fn ($route) => ! in_array($route, $routes));
 
-    $newRoutes = collect($routesAfterRegisteringDuplicates)->filter(fn ($route) => ! in_array($route, $routes));
+    expect($newRoutes->first()->uri())->toBe('{' . $tenantParameterName . '}' . '/' . $route->uri());
 
-    expect($newRoutes->first()->uri())->toBe('{' . $tenantParameterName . '}' . '/' . $universalRoute->uri());
-    expect($newRoutes->last()->uri())->toBe('{' . $tenantParameterName . '}' . '/' . $universalRoute2->uri());
-
-    // Universal flag is excluded from the route middleware
+    // The 'clone' flag is excluded from the route middleware
     expect(tenancy()->getRouteMiddleware($newRoutes->first()))
         ->toEqualCanonicalizing(
-            array_values(array_filter(array_merge(tenancy()->getRouteMiddleware($universalRoute), ['tenant']),
-            fn($middleware) => $middleware !== 'universal'))
-        );
-
-    // Universal flag is provided statically in the route's controller, so we cannot exclude it
-    expect(tenancy()->getRouteMiddleware($newRoutes->last()))
-        ->toEqualCanonicalizing(
-            array_values(array_merge(tenancy()->getRouteMiddleware($universalRoute2), ['tenant']))
+            array_values(array_filter(array_merge(tenancy()->getRouteMiddleware($route), ['tenant']),
+            fn($middleware) => $middleware !== 'clone'))
         );
 
     $tenant = Tenant::create();
 
-    pest()->get(route($centralRouteName = $universalRoute->getName()))->assertSee('Tenancy is not initialized.');
-    pest()->get(route($centralRouteName2 = $universalRoute2->getName()))->assertSee('Tenancy is not initialized.');
-    pest()->get(route($tenantRouteName = $newRoutes->first()->getName(), [$tenantParameterName => $tenant->getTenantKey()]))->assertSee('Tenancy is initialized.');
-    tenancy()->end();
-    pest()->get(route($tenantRouteName2 = $newRoutes->last()->getName(), [$tenantParameterName => $tenant->getTenantKey()]))->assertSee('Tenancy is initialized.');
+    pest()->get(route($tenantRouteName = $newRoutes->first()->getName(), [$tenantParameterName => $tenant->getTenantKey()]))->assertOk();
 
-    expect($tenantRouteName)->toBe($tenantRouteNamePrefix . $universalRoute->getName());
-    expect($tenantRouteName2)->toBe($tenantRouteNamePrefix . $universalRoute2->getName());
-    expect($centralRouteName)->toBe($universalRoute->getName());
-    expect($centralRouteName2)->toBe($universalRoute2->getName());
-})->with([
-    'kernel identification' => true,
-    'route-level identification' => false,
-// Creates a matrix (multiple with())
-])->with([
-    'use controller' => true,
-    'use closure' => false
-])->with([
-    'path identification middleware' => InitializeTenancyByPath::class,
-    'custom path identification middleware' => CustomInitializeTenancyByPath::class,
-]);
-
-test('CloneRoutesAsTenant only clones routes with path identification by default', function () {
-    app(Kernel::class)->pushMiddleware(InitializeTenancyByPath::class);
-
-    $currentRouteCount = fn () => count(RouteFacade::getRoutes()->get());
-
-    $initialRouteCount = $currentRouteCount();
-
-    // Path identification is used globally, and this route doesn't use a specific identification middleware, meaning path identification is used and the route should get cloned
-    RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')->middleware('universal')->name('home');
-    // The route uses a specific identification middleware other than InitializeTenancyByPath – the route shouldn't get cloned
-    RouteFacade::get('/home-domain-id', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')->middleware(['universal', InitializeTenancyByDomain::class])->name('home-domain-id');
-
-    expect($currentRouteCount())->toBe($newRouteCount = $initialRouteCount + 2);
-
-    /** @var CloneRoutesAsTenant $cloneRoutesAction */
-    $cloneRoutesAction = app(CloneRoutesAsTenant::class);
-
-    $cloneRoutesAction->handle();
-
-    // Only one of the two routes gets cloned
-    expect($currentRouteCount())->toBe($newRouteCount + 1);
+    expect($tenantRouteName)->toBe($tenantRouteNamePrefix . $route->getName());
 });
 
-test('custom callbacks can be used for cloning universal routes', function () {
-    RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')->middleware(['universal', InitializeTenancyByPath::class])->name($routeName = 'home');
+test('custom callback can be used for determining if a route should be cloned', function () {
+    RouteFacade::get('/home', fn () => true)->name('home');
 
     /** @var CloneRoutesAsTenant $cloneRoutesAction */
     $cloneRoutesAction = app(CloneRoutesAsTenant::class);
     $currentRouteCount = fn () => count(RouteFacade::getRoutes()->get());
     $initialRouteCount = $currentRouteCount();
 
-    $cloneRoutesAction;
+    // No routes should be cloned
+    $cloneRoutesAction
+        ->shouldClone(fn (Route $route) => false)
+        ->handle();
 
-    // Skip cloning the 'home' route
-    $cloneRoutesAction->cloneUsing($routeName, function (Route $route) {
-        return;
-    })->handle();
-
-    // Expect route count to stay the same because the 'home' route cloning gets skipped
+    // Expect route count to stay the same because cloning essentially gets turned off
     expect($initialRouteCount)->toEqual($currentRouteCount());
 
-    // Modify the 'home' route cloning so that a different route is cloned
-    $cloneRoutesAction->cloneUsing($routeName, function (Route $route) {
-        RouteFacade::get('/cloned-route', fn () => true)->name('new.home');
-    })->handle();
+    // Only the 'home' route should be cloned
+    $cloneRoutesAction
+        ->shouldClone(fn (Route $route) => $route->getName() === 'home')
+        ->handle();
 
     expect($currentRouteCount())->toEqual($initialRouteCount + 1);
 });
 
-test('cloning of specific routes can get skipped', function () {
-    RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')->middleware('universal')->name($routeName = 'home');
+test('custom callbacks can be used for customizing the creation of the cloned routes', function () {
+    RouteFacade::get('/foo', fn () => true)->name('foo')->middleware(['clone']);
+    RouteFacade::get('/bar', fn () => true)->name('bar')->middleware(['clone']);
 
     /** @var CloneRoutesAsTenant $cloneRoutesAction */
     $cloneRoutesAction = app(CloneRoutesAsTenant::class);
+
+    $cloneRoutesAction
+        ->cloneUsing(function (Route $route) {
+            RouteFacade::get('/cloned/' . $route->uri(), fn () => 'cloned route')->name('cloned.' . $route->getName());
+        })->handle();
+
+    pest()->get(route('cloned.foo'))->assertSee('cloned route');
+    pest()->get(route('cloned.bar'))->assertSee('cloned route');
+});
+
+test('the clone action can clone specific routes', function() {
+    RouteFacade::get('/foo', fn () => true)->name('foo')->middleware(['clone']);
+    $barRoute = RouteFacade::get('/bar', fn () => true)->name('bar')->middleware(['clone']);
+
     $currentRouteCount = fn () => count(RouteFacade::getRoutes()->get());
     $initialRouteCount = $currentRouteCount();
 
-    // Skip cloning the 'home' route
-    $cloneRoutesAction->skipRoute($routeName);
+    /** @var CloneRoutesAsTenant $cloneRoutesAction */
+    $cloneRoutesAction = app(CloneRoutesAsTenant::class);
 
-    $cloneRoutesAction->handle();
+    $cloneRoutesAction->cloneRoute($barRoute)->handle();
 
-    // Expect route count to stay the same because the 'home' route cloning gets skipped
-    expect($initialRouteCount)->toEqual($currentRouteCount());
+    // Exactly one route should be cloned
+    expect($currentRouteCount())->toEqual($initialRouteCount + 1);
+
+    expect(RouteFacade::getRoutes()->getByName('tenant.bar'))->not()->toBeNull();
 });
-
-test('routes except nonuniversal routes with path id mw are given the tenant flag after cloning', function (array $routeMiddleware, array $globalMiddleware) {
-    foreach ($globalMiddleware as $middleware) {
-        if ($middleware === 'universal') {
-            config(['tenancy.default_route_mode' => RouteMode::UNIVERSAL]);
-        } else {
-            app(Kernel::class)->pushMiddleware($middleware);
-        }
-    }
-
-    $route = RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-        ->middleware($routeMiddleware)
-        ->name($routeName = 'home');
-
-    app(CloneRoutesAsTenant::class)->handle();
-
-    $clonedRoute = RouteFacade::getRoutes()->getByName('tenant.' . $routeName);
-
-    // Non-universal routes with identification middleware are already considered tenant, so they don't get the tenant flag
-    if (! tenancy()->routeIsUniversal($route) && tenancy()->routeHasIdentificationMiddleware($clonedRoute)) {
-        expect($clonedRoute->middleware())->not()->toContain('tenant');
-    } else {
-        expect($clonedRoute->middleware())->toContain('tenant');
-    }
-})->with('path identification types');
-
-test('routes with the clone flag get cloned without making the routes universal', function ($identificationMiddleware) {
-    config(['tenancy.identification.path_identification_middleware' => [$identificationMiddleware]]);
-
-    RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-        ->middleware(['clone', $identificationMiddleware])
-        ->name($routeName = 'home');
-
-    $tenant = Tenant::create();
-
-    app(CloneRoutesAsTenant::class)->handle();
-
-    $clonedRoute = RouteFacade::getRoutes()->getByName('tenant.' . $routeName);
-
-    expect(array_values($clonedRoute->middleware()))->toEqualCanonicalizing(['tenant', $identificationMiddleware]);
-
-    // The original route is not accessible
-    pest()->get(route($routeName))->assertServerError();
-    pest()->get(route($routeName, ['tenant' => $tenant]))->assertServerError();
-    // The cloned route is a tenant route
-    pest()->get(route('tenant.' . $routeName, ['tenant' => $tenant]))->assertSee('Tenancy initialized.');
-})->with([InitializeTenancyByPath::class, CustomInitializeTenancyByPath::class]);
 
 test('the clone action prefixes already prefixed routes correctly', function () {
     $routes = [
-        RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-            ->middleware(['universal', InitializeTenancyByPath::class])
+        RouteFacade::get('/home', fn () => true)
+            ->middleware(['clone'])
             ->name('home')
             ->prefix('prefix'),
 
-        RouteFacade::get('/leadingAndTrailingSlash', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-            ->middleware(['universal', InitializeTenancyByPath::class])
+        RouteFacade::get('/leadingAndTrailingSlash', fn () => true)
+            ->middleware(['clone'])
             ->name('leadingAndTrailingSlash')
             ->prefix('/prefix/'),
 
-        RouteFacade::get('/leadingSlash', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-            ->middleware(['universal', InitializeTenancyByPath::class])
+        RouteFacade::get('/leadingSlash', fn () => true)
+            ->middleware(['clone'])
             ->name('leadingSlash')
             ->prefix('/prefix'),
 
-        RouteFacade::get('/trailingSlash', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-            ->middleware(['universal', InitializeTenancyByPath::class])
+        RouteFacade::get('/trailingSlash', fn () => true)
+            ->middleware(['clone'])
             ->name('trailingSlash')
             ->prefix('prefix/'),
     ];
@@ -293,7 +144,7 @@ test('the clone action prefixes already prefixed routes correctly', function () 
             ->toBe("http://localhost/prefix/{$tenant->getTenantKey()}/{$routes[$key]->getName()}");
 
         // The cloned route is accessible
-        pest()->get($clonedRouteUrl)->assertSee('Tenancy initialized.');
+        pest()->get($clonedRouteUrl)->assertOk();
     }
 });
 
@@ -301,12 +152,12 @@ test('clone action trims trailing slashes from prefixes given to nested route gr
     RouteFacade::prefix('prefix')->group(function () {
         RouteFacade::prefix('')->group(function () {
             // This issue seems to only happen when there's a group with a prefix, then a group with an empty prefix, and then a / route
-            RouteFacade::get('/', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-                ->middleware(['universal', InitializeTenancyByPath::class])
+            RouteFacade::get('/', fn () => true)
+                ->middleware(['clone'])
                 ->name('landing');
 
-            RouteFacade::get('/home', fn () => tenant() ? 'Tenancy initialized.' : 'Tenancy not initialized.')
-                ->middleware(['universal', InitializeTenancyByPath::class])
+            RouteFacade::get('/home', fn () => true)
+                ->middleware(['clone'])
                 ->name('home');
         });
     });
@@ -324,27 +175,3 @@ test('clone action trims trailing slashes from prefixes given to nested route gr
         ->not()->toContain("prefix//")
         ->toBe("http://localhost/prefix/{$tenant->getTenantKey()}/home");
 });
-
-class CustomInitializeTenancyByPath extends InitializeTenancyByPath
-{
-
-}
-
-dataset('path identification types', [
-    'kernel identification' => [
-        ['universal'], // Route middleware
-        [InitializeTenancyByPath::class], // Global Global middleware
-    ],
-    'route-level identification' => [
-        ['universal', InitializeTenancyByPath::class], // Route middleware
-        [], // Global middleware
-    ],
-    'kernel identification + defaulting to universal routes' => [
-        [], // Route middleware
-        ['universal', InitializeTenancyByPath::class], // Global middleware
-    ],
-    'route-level identification + defaulting to universal routes' => [
-        [InitializeTenancyByPath::class],  // Route middleware
-        ['universal'], // Global middleware
-    ],
-]);

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -48,7 +48,7 @@ test('CloneRoutesAsTenant action clones routes correctly', function (Route|null 
     }
 })->with([
     null, // Clone all routes for which shouldBeCloned returns true
-    fn () => RouteFacade::get('/home', fn () => true)->name('home'), // THe only route that should be cloned
+    fn () => RouteFacade::get('/home', fn () => true)->name('home'), // The only route that should be cloned
 ]);
 
 test('all routes with any of the middleware specified in cloneRoutesWithMiddleware will be cloned by default', function(array $cloneRoutesWithMiddleware) {

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -97,7 +97,7 @@ test('all routes with any of the middleware specified in cloneRoutesWithMiddlewa
         ->cloneRoutesWithMiddleware($cloneRoutesWithMiddleware)
         ->handle();
 
-    // Each middleware is only used on a single route so we assert that the count new routes matches the count of used middleware flags
+    // Each middleware is only used on a single route so we assert that the count of new routes matches the count of used middleware flags
     expect($currentRouteCount())->toEqual($initialRouteCount + count($cloneRoutesWithMiddleware));
 })->with([
     [[]],

--- a/tests/EarlyIdentificationTest.php
+++ b/tests/EarlyIdentificationTest.php
@@ -344,9 +344,9 @@ test('the tenant parameter is only removed from tenant routes when using path id
             ->middleware('tenant')
             ->name('tenant-route');
 
-        RouteFacade::get($pathIdentification ? '/universal-route' : '/universal-route/{tenant?}', [ControllerWithMiddleware::class, 'routeHasTenantParameter'])
-            ->middleware('universal')
-            ->name('universal-route');
+        RouteFacade::get($pathIdentification ? '/cloned-route' : '/cloned-route/{tenant?}', [ControllerWithMiddleware::class, 'routeHasTenantParameter'])
+            ->middleware('clone')
+            ->name('cloned-route');
 
         /** @var CloneRoutesAsTenant */
         $cloneRoutesAction = app(CloneRoutesAsTenant::class);
@@ -364,8 +364,8 @@ test('the tenant parameter is only removed from tenant routes when using path id
             $response = pest()->get($tenantKey . '/tenant-route')->assertOk();
             expect((bool) $response->getContent())->toBeFalse();
 
-            // The tenant parameter gets removed from the cloned universal route
-            $response = pest()->get($tenantKey . '/universal-route')->assertOk();
+            // The tenant parameter gets removed from the cloned route
+            $response = pest()->get($tenantKey . '/cloned-route')->assertOk();
             expect((bool) $response->getContent())->toBeFalse();
         } else {
             // Tenant parameter is not removed from tenant routes using other kernel identification MW
@@ -374,12 +374,12 @@ test('the tenant parameter is only removed from tenant routes when using path id
             $response = pest()->get("http://{$domain}/{$tenantKey}/tenant-route")->assertOk();
             expect((bool) $response->getContent())->toBeTrue();
 
-            // The tenant parameter does not get removed from the universal route when accessing it through the central domain
-            $response = pest()->get("http://localhost/universal-route/$tenantKey")->assertOk();
+            // The tenant parameter does not get removed from the cloned route when accessing it through the central domain
+            $response = pest()->get("http://localhost/cloned-route/$tenantKey")->assertOk();
             expect((bool) $response->getContent())->toBeTrue();
 
-            // The tenant parameter gets removed from the universal route when accessing it through the tenant domain
-            $response = pest()->get("http://{$domain}/universal-route")->assertOk();
+            // The tenant parameter gets removed from the cloned route when accessing it through the tenant domain
+            $response = pest()->get("http://{$domain}/cloned-route")->assertOk();
             expect((bool) $response->getContent())->toBeFalse();
         }
     } else {


### PR DESCRIPTION
> Note: "Route cloning" means recreating a route as a tenant route. A tenant route has the '/{tenant}' prefix ('tenant' is customizable -- `PathTenantResolver::tenantParameterName()`), flagged with 'tenant' middleware, and a name prefixed with 'tenant.' (customizable -- `PathTenantResolver::tenantRouteNamePrefix()`). Cloning is intended to be used with path identification, and serves primarily for better integration of packages.

This PR refactors and simplifies route cloning. The CloneRoutesAsTenant action is now much simpler because the code is completely decoupled from identification middleware and universal routes.

The CloneRoutesAsTenant action now clones all routes for which `shouldBeCloned()` returns `true` (by default, this means all routes with any of the middleware specified in `CloneRoutesAsTenant::$cloneRoutesWithMiddleware` -- this array contains the 'clone' middleware by default), or clones only the routes specified using `cloneRoute()` (`cloneRoute()` accepts either a route instance or a route name -- if you pass a name of a nonexistent route, you'll get an exception). 

The described behavior can be completely customized using the public methods. How the cloned routes will be defined can be overriden using the `cloneUsing()` method. To change how it's decided if a route should be cloned, use the `shouldClone()` method. And to change the middleware with which the routes are supposed to be cloned (using the default shouldBeCloned logic), use the `cloneRoutesWithMiddleware()` method.

`cloneUsing()` should be used with caution. Take inspiration from the default behavior in the `handle()` method.