### PR TITLE
[4.x] TableRLSManager refactor, comment constraints

### DIFF
--- a/src/Exceptions/RLSCommentConstraintException.php
+++ b/src/Exceptions/RLSCommentConstraintException.php
@@ -10,6 +10,6 @@ class RLSCommentConstraintException extends Exception
 {
     public function __construct(string|null $message = null)
     {
-        parent::__construct($message ?? "Invalid comment constraint.");
+        parent::__construct($message ?? 'Invalid comment constraint.');
     }
 }

--- a/src/Exceptions/RLSCommentConstraintException.php
+++ b/src/Exceptions/RLSCommentConstraintException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Exceptions;
+
+use Exception;
+
+class RLSCommentConstraintException extends Exception
+{
+    public function __construct(string|null $message = null)
+    {
+        parent::__construct($message ?? "Invalid comment constraint.");
+    }
+}

--- a/src/RLS/Exceptions/RLSCommentConstraintException.php
+++ b/src/RLS/Exceptions/RLSCommentConstraintException.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Stancl\Tenancy\Exceptions;
+namespace Stancl\Tenancy\RLS\Exceptions;
 
 use Exception;
 

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -379,7 +379,7 @@ class TableRLSManager implements RLSPolicyManager
         }
 
         // Explicit scoping
-        if (Str::is($comment, 'rls')) {
+        if ($comment === 'rls') {
             return false;
         }
 

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -416,8 +416,7 @@ class TableRLSManager implements RLSPolicyManager
         array $foreignKeys,
         array &$cachedPaths,
         array $visitedTables
-    ): array
-    {
+    ): array {
         $visitedTables = [...$visitedTables, $table];
         $shortestPath = [];
         $hasRecursiveRelationships = false;

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\RLS\PolicyManagers;
 
 use Illuminate\Database\DatabaseManager;
-use Stancl\Tenancy\Database\Exceptions\RecursiveRelationshipException;
 use Illuminate\Support\Str;
+use Stancl\Tenancy\Database\Exceptions\RecursiveRelationshipException;
 
 // todo@samuel logical + structural refactor. the tree generation could use some dynamic programming optimizations
 class TableRLSManager implements RLSPolicyManager

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -489,26 +489,26 @@ class TableRLSManager implements RLSPolicyManager
     }
 
     /**
-     * Determine if the passed path is better than the current shortest path.
+     * Determine if the passed path is preferred to the current shortest path.
      *
-     * Non-nullable paths are preferred over nullable paths.
+     * Non-nullable paths are preferred to nullable paths.
      * From paths of the same nullability, the shorter will be preferred.
      */
-    protected function determineBetterPath(array $path, array $currentBestPath): bool
+    protected function determineBetterPath(array $path, array $shortestPath): bool
     {
-        if (! $currentBestPath) {
+        if (! $shortestPath) {
             return true;
         }
 
         $pathIsNullable = $this->isPathNullable($path['steps']);
-        $bestPathIsNullable = $this->isPathNullable($currentBestPath['steps']);
+        $shortestPathIsNullable = $this->isPathNullable($shortestPath['steps']);
 
         // Prefer non-nullable
-        if ($pathIsNullable !== $bestPathIsNullable) {
+        if ($pathIsNullable !== $shortestPathIsNullable) {
             return ! $pathIsNullable;
         }
 
         // Prefer shorter
-        return count($path['steps']) < count($currentBestPath['steps']);
+        return count($path['steps']) < count($shortestPath['steps']);
     }
 }

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -382,7 +382,7 @@ class TableRLSManager implements RLSPolicyManager
         $validConstraints = [];
 
         foreach ($formattedConstraints as $constraint) {
-            if (! $this->shouldSkipPathLeadingThrough($constraint)) {
+            if (! $this->shouldSkipPathLeadingThroughConstraint($constraint)) {
                 $validConstraints[] = $constraint;
             }
         }
@@ -400,7 +400,7 @@ class TableRLSManager implements RLSPolicyManager
      *
      * @param array $constraint Formatted constraint
      */
-    protected function shouldSkipPathLeadingThrough(array $constraint): bool
+    protected function shouldSkipPathLeadingThroughConstraint(array $constraint): bool
     {
         $comment = $constraint['comment'] ?? null;
 

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -142,7 +142,10 @@ class TableRLSManager implements RLSPolicyManager
         $pathExplicitlySkipped = $foreignKey['comment'] === 'no-rls';
         $pathImplicitlySkipped = ! static::$scopeByDefault && (
             ! isset($foreignKey['comment']) ||
-            (is_string($foreignKey['comment']) && ! Str::startsWith($foreignKey['comment'], 'rls'))
+            (is_string($foreignKey['comment']) && ! (
+                Str::is($foreignKey['comment'], 'rls') || // Explicit RLS
+                Str::startsWith($foreignKey['comment'], 'rls ') // Comment constraint
+            ))
         );
 
         return $pathExplicitlySkipped || $pathImplicitlySkipped;
@@ -169,7 +172,7 @@ class TableRLSManager implements RLSPolicyManager
 
             // Validate comment constraint format
             if (count($constraint) !== 2 || empty($constraint[0]) || empty($constraint[1])) {
-                throw new RLSCommentConstraintException("Incorrectly formatted comment constraint on {$tableName}.{$column['name']}: '{$column['comment']}'");
+                throw new RLSCommentConstraintException("Malformed comment constraint on {$tableName}.{$column['name']}: '{$column['comment']}'");
             }
 
             $foreignTable = $constraint[0];

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -265,7 +265,7 @@ class TableRLSManager implements RLSPolicyManager
          * If there's no valid path in the end, and the table has recursive relationships,
          * an appropriate exception is thrown.
          *
-         * At the end, it return the shortest non-nullable path if available,
+         * At the end, it returns the shortest non-nullable path if available,
          * fall back to the overall shortest path.
          */
         $visitedTables = [...$visitedTables, $table];

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -126,12 +126,11 @@ class TableRLSManager implements RLSPolicyManager
      */
     public function shortestPaths(): array
     {
-        $cachedPaths = [];
         $shortestPaths = [];
 
         foreach ($this->getTableNames() as $tableName) {
             // Generate the shortest path from table named $tableName to the tenants table
-            $shortestPath = $this->shortestPathToTenantsTable($tableName, $cachedPaths);
+            $shortestPath = $this->shortestPathToTenantsTable($tableName);
 
             if ($this->isValidPath($shortestPath)) {
                 // Format path steps to a more readable format (keep only the needed data)
@@ -252,7 +251,7 @@ class TableRLSManager implements RLSPolicyManager
      */
     protected function shortestPathToTenantsTable(
         string $table,
-        array &$cachedPaths,
+        array &$cachedPaths = [],
         array $visitedTables = []
     ): array {
         // Return the shortest path for this table if it was already found and cached
@@ -262,6 +261,9 @@ class TableRLSManager implements RLSPolicyManager
 
         // Reached tenants table (last step)
         if ($table === tenancy()->model()->getTable()) {
+            // This pretty much just means we set $cachedPaths['tenants'] to an
+            // empty path. The significance of an empty path is that this class
+            // considers it to mean "you are at the tenants table".
             $cachedPaths[$table] = $this->buildPath();
 
             return $cachedPaths[$table];

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -263,7 +263,7 @@ class TableRLSManager implements RLSPolicyManager
     protected function isColumnNullable(string $table, string $column): bool
     {
         $result = $this->database->selectOne(
-            "SELECT is_nullable FROM information_schema.columns WHERE table_name = ? AND column_name = ?",
+            'SELECT is_nullable FROM information_schema.columns WHERE table_name = ? AND column_name = ?',
             [$table, $column]
         );
 
@@ -452,7 +452,7 @@ class TableRLSManager implements RLSPolicyManager
                 $path = [
                     'dead_end' => false,
                     'recursion' => false,
-                    'steps' => array_merge([$foreign], $foreignPath['steps'])
+                    'steps' => array_merge([$foreign], $foreignPath['steps']),
                 ];
 
                 if ($this->determineBetterPath($path, $shortestPath)) {

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -64,7 +64,7 @@ class TableRLSManager implements RLSPolicyManager
 {
     /**
      * When true, all valid constraints are considered while generating paths for RLS policies,
-     * unless explicitly marked with 'no-rls' comment.
+     * unless explicitly marked with a 'no-rls' comment.
      *
      * When false, only columns explicitly marked with 'rls' or 'rls table.column' comments are considered.
      */
@@ -82,7 +82,7 @@ class TableRLSManager implements RLSPolicyManager
      * The passed paths should be formatted like this:
      * [
      *     'table_name' => [...$stepsLeadingToTenantsTable]
-     * ].
+     * ]
      */
     public function generateQueries(array $paths = []): array
     {
@@ -392,7 +392,7 @@ class TableRLSManager implements RLSPolicyManager
     }
 
     /**
-     * Retrieve table's comment constraints.
+     * Retrieve a table's comment constraints.
      *
      * Comment constraints are columns with comments
      * formatted like "rls <foreign_table>.<foreign_column>".

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -212,7 +212,7 @@ class TableRLSManager implements RLSPolicyManager
      * Retrieve table's comment-based constraints. These are columns with comments
      * formatted like "rls <foreign_table>.<foreign_column>".
      *
-     * Returns the constraints as unformatted foreign key arrays, ready to be passed to $this->formatForeignKey().
+     * Returns the constraints as unformatted foreign key arrays, ready to be formatted by formatForeignKey().
      */
     protected function getCommentConstraints(string $tableName): array
     {

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -7,7 +7,7 @@ namespace Stancl\Tenancy\RLS\PolicyManagers;
 use Illuminate\Database\DatabaseManager;
 use Illuminate\Support\Str;
 use Stancl\Tenancy\Database\Exceptions\RecursiveRelationshipException;
-use Stancl\Tenancy\Exceptions\RLSCommentConstraintException;
+use Stancl\Tenancy\RLS\Exceptions\RLSCommentConstraintException;
 
 /**
  * Generates queries for creating RLS policies

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -455,7 +455,7 @@ class TableRLSManager implements RLSPolicyManager
                     'steps' => array_merge([$foreign], $foreignPath['steps']),
                 ];
 
-                if ($this->determineBetterPath($path, $shortestPath)) {
+                if ($this->isPathPreferable($path, $shortestPath)) {
                     $shortestPath = $path;
                 }
             }
@@ -494,7 +494,7 @@ class TableRLSManager implements RLSPolicyManager
      * Non-nullable paths are preferred to nullable paths.
      * From paths of the same nullability, the shorter will be preferred.
      */
-    protected function determineBetterPath(array $path, array $shortestPath): bool
+    protected function isPathPreferable(array $path, array $shortestPath): bool
     {
         if (! $shortestPath) {
             return true;

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -204,7 +204,7 @@ class TableRLSManager implements RLSPolicyManager
             return $cachedPaths[$table];
         }
 
-        return $this->determineShortestPath($table, $constraints, $cachedPaths, $visitedTables);
+        return $this->findShortestPath($table, $constraints, $cachedPaths, $visitedTables);
     }
 
     /**
@@ -240,7 +240,7 @@ class TableRLSManager implements RLSPolicyManager
      * If static::$scopeByDefault is true, only skip paths leading through constraints flagged with the 'no-rls' comment.
      * If static::$scopeByDefault is false, skip paths leading through any constraint, unless the key has explicit 'rls' or 'rls table.column' comments.
      *
-     * @param array $constraint Formatted constraint (has to have the 'comment' key)
+     * @param array $constraint Formatted constraint
      */
     protected function shouldSkipPathLeadingThrough(array $constraint): bool
     {
@@ -398,9 +398,7 @@ class TableRLSManager implements RLSPolicyManager
      * Find the optimal path from a table to the tenants table.
      *
      * Gathers table's constraints (both foreign key constraints and comment constraints)
-     * and recursively finds paths through each constraint while tracking both
-     * the overall shortest path and the shortest non-nullable
-     * path (non-nullable paths are preferred for reliability).
+     * and recursively finds shortest paths through each constraint (non-nullable paths are preferred for reliability).
      *
      * Handles recursive relationships by skipping paths that would create loops.
      * If there's no valid path in the end, and the table has recursive relationships,
@@ -415,7 +413,7 @@ class TableRLSManager implements RLSPolicyManager
      * @param array $visitedTables Tables already visited in this path (used for detecting recursion)
      * @return array Path with 'steps' array, 'dead_end' flag, and 'recursive_relationship' flag
      */
-    protected function determineShortestPath(
+    protected function findShortestPath(
         string $table,
         array $constraints,
         array &$cachedPaths,

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -110,8 +110,6 @@ class TableRLSManager implements RLSPolicyManager
 
     protected function generatePaths(string $table, array $foreign, array &$paths, array $currentPath = []): void
     {
-        // If the foreign key has a comment of 'no-rls', we skip it
-        // Also skip the foreign key if implicit scoping is off and the foreign key has no comment
         if ($this->shouldSkipPathLeadingThrough($foreign)) {
             return;
         }
@@ -137,8 +135,9 @@ class TableRLSManager implements RLSPolicyManager
 
     protected function shouldSkipPathLeadingThrough(array $foreignKey): bool
     {
-        // If the foreign key has a comment of 'no-rls', we skip it
-        // Also skip the foreign key if implicit scoping is off and the foreign key has no comment
+        // If the column has a comment of 'no-rls', we skip it.
+        // Also skip the column if implicit scoping is off and the column
+        // has no 'rls' comment or is not recognized as a comment constraint (its comment doesn't begin with 'rls ').
         $pathExplicitlySkipped = $foreignKey['comment'] === 'no-rls';
         $pathImplicitlySkipped = ! static::$scopeByDefault && (
             ! isset($foreignKey['comment']) ||

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -87,7 +87,7 @@ class TableRLSManager implements RLSPolicyManager
                 $shortestPaths[$tableName] = array_map(fn (array $step) => [
                     'foreignKey' => $step['foreignKey'],
                     'foreignTable' => $step['foreignTable'],
-                    'foreignId' => $step['foreignId']
+                    'foreignId' => $step['foreignId'],
                 ], $shortestPath['steps']);
             }
 

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -371,7 +371,6 @@ class TableRLSManager implements RLSPolicyManager
      *
      * The comment constraints are retrieved using getFormattedCommentConstraints().
      * These constraints are formatted in the method itself.
-     *
      */
     protected function getConstraints(string $table): array
     {

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -78,8 +78,7 @@ class TableRLSManager implements RLSPolicyManager
         string $table,
         array &$cachedPaths,
         array $visitedTables = []
-    ): array
-    {
+    ): array {
         if (isset($cachedPaths[$table])) {
             return $cachedPaths[$table];
         }
@@ -89,7 +88,7 @@ class TableRLSManager implements RLSPolicyManager
             $cachedPaths[$table] = [
                 'dead_end' => false,
                 'recursion' => false,
-                'steps' => []
+                'steps' => [],
             ];
 
             return $cachedPaths[$table];
@@ -102,7 +101,7 @@ class TableRLSManager implements RLSPolicyManager
             $cachedPaths[$table] = [
                 'dead_end' => true,
                 'recursion' => false,
-                'steps' => []
+                'steps' => [],
             ];
 
             return $cachedPaths[$table];
@@ -352,8 +351,7 @@ class TableRLSManager implements RLSPolicyManager
         array $foreignKeys,
         array &$cachedPaths,
         array $visitedTables
-    ): array
-    {
+    ): array {
         $visitedTables = [...$visitedTables, $table];
         // Initialize the length variables with maximum values
         $shortestLength = PHP_INT_MAX;
@@ -408,7 +406,7 @@ class TableRLSManager implements RLSPolicyManager
             $finalPath = [
                 'dead_end' => false,
                 'recursion' => true,
-                'steps' => []
+                'steps' => [],
             ];
 
             // Don't cache recursive paths -- return right away.
@@ -422,7 +420,7 @@ class TableRLSManager implements RLSPolicyManager
             $finalPath = $shortestNonNullablePath ?? $shortestPath ?? [
                 'dead_end' => true,
                 'recursion' => false,
-                'steps' => []
+                'steps' => [],
             ];
         }
 
@@ -447,7 +445,7 @@ class TableRLSManager implements RLSPolicyManager
         return [
             'dead_end' => false,
             'recursion' => false,
-            'steps' => array_merge([$constraint], $foreignPath['steps'])
+            'steps' => array_merge([$constraint], $foreignPath['steps']),
         ];
     }
 }

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -43,14 +43,14 @@ use Stancl\Tenancy\RLS\Exceptions\RLSCommentConstraintException;
  * //     'foo_table' => [...$stepsLeadingToTenantsTable],
  * //     'bar_table' => [
  * //         [
- * //             'foreignKey' => 'post_id',
+ * //             'localColumn' => 'post_id',
  * //             'foreignTable' => 'posts',
- * //             'foreignId' => 'id'
+ * //             'foreignColumn' => 'id'
  * //         ],
  * //         [
- * //             'foreignKey' => 'tenant_id',
+ * //             'localColumn' => 'tenant_id',
  * //             'foreignTable' => 'tenants',
- * //             'foreignId' => 'id'
+ * //             'foreignColumn' => 'id'
  * //         ],
  * //     ],
  * // This is used in the CreateUserWithRLSPolicies command.
@@ -103,21 +103,21 @@ class TableRLSManager implements RLSPolicyManager
      *
      * 'posts' => [
      *     [
-     *         'foreignKey' => 'tenant_id',
+     *         'localColumn' => 'tenant_id',
      *         'foreignTable' => 'tenants',
-     *         'foreignId' => 'id'
+     *         'foreignColumn' => 'id'
      *     ],
      * ],
      * 'comments' => [
      *     [
-     *         'foreignKey' => 'post_id',
+     *         'localColumn' => 'post_id',
      *         'foreignTable' => 'posts',
-     *         'foreignId' => 'id'
+     *         'foreignColumn' => 'id'
      *     ],
      *     [
-     *         'foreignKey' => 'tenant_id',
+     *         'localColumn' => 'tenant_id',
      *         'foreignTable' => 'tenants',
-     *         'foreignId' => 'id'
+     *         'foreignColumn' => 'id'
      *     ],
      * ],
      *
@@ -136,9 +136,9 @@ class TableRLSManager implements RLSPolicyManager
             if ($this->isValidPath($shortestPath)) {
                 // Format path steps to a more readable format (keep only the needed data)
                 $shortestPaths[$tableName] = array_map(fn (array $step) => [
-                    'foreignKey' => $step['foreignKey'],
+                    'localColumn' => $step['localColumn'],
                     'foreignTable' => $step['foreignTable'],
-                    'foreignId' => $step['foreignId'],
+                    'foreignColumn' => $step['foreignColumn'],
                 ], $shortestPath['steps']);
             }
 
@@ -187,9 +187,9 @@ class TableRLSManager implements RLSPolicyManager
      * before returning the shortest paths in shortestPath().
      *
      * [
-     *    'foreignKey' => 'tenant_id',
+     *    'localColumn' => 'tenant_id',
      *    'foreignTable' => 'tenants',
-     *    'foreignId' => 'id',
+     *    'foreignColumn' => 'id',
      *    'comment' => 'no-rls', // Used to explicitly enable/disable RLS or to create a comment constraint (internal metadata)
      *    'nullable' => false, // Used to determine if the constraint is nullable (internal metadata)
      * ].
@@ -229,9 +229,9 @@ class TableRLSManager implements RLSPolicyManager
         bool $nullable
     ): array {
         return [
-            'foreignKey' => $foreignKey,
+            'localColumn' => $foreignKey,
             'foreignTable' => $foreignTable,
-            'foreignId' => $foreignId,
+            'foreignColumn' => $foreignId,
             // Internal metadata omitted in shortestPaths()
             'comment' => $comment,
             'nullable' => $nullable,
@@ -362,9 +362,9 @@ class TableRLSManager implements RLSPolicyManager
      * and that method uses formatConstraint(), which serves as a single source of truth
      * for our constraint formatting. A formatted constraint looks like this:
      * [
-     *     'foreignKey' => 'tenant_id',
+     *     'localColumn' => 'tenant_id',
      *     'foreignTable' => 'tenants',
-     *     'foreignId' => 'id',
+     *     'foreignColumn' => 'id',
      *     'comment' => 'no-rls',
      *     'nullable' => false
      * ]
@@ -505,9 +505,9 @@ class TableRLSManager implements RLSPolicyManager
         $sessionTenantKey = config('tenancy.rls.session_variable_name');
 
         foreach ($path as $index => $relation) {
-            $column = $relation['foreignKey'];
+            $column = $relation['localColumn'];
             $table = $relation['foreignTable'];
-            $foreignKey = $relation['foreignId'];
+            $foreignKey = $relation['foreignColumn'];
 
             $indentation = str_repeat(' ', ($index + 1) * 4);
 

--- a/src/RLS/PolicyManagers/TableRLSManager.php
+++ b/src/RLS/PolicyManagers/TableRLSManager.php
@@ -462,7 +462,7 @@ class TableRLSManager implements RLSPolicyManager
             // Example:
             // - posts table has highlighted_comment_id that leads to the comments table
             // - comments table has recursive_post_id that leads to the posts table (recursive relationship),
-            // - comments table also has tenant_id which leadds to the tenants table (a valid path).
+            // - comments table also has tenant_id which leads to the tenants table (a valid path).
             // If the recursive path got cached first, the path leading directly through tenants would never be found.
             return $this->buildPath(recursive: true);
         } else {

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -323,7 +323,7 @@ test('queries are correctly scoped using RLS', function() {
         ->toThrow(QueryException::class);
 });
 
-test('table rls manager generates relationship trees with tables related to the tenants table', function (bool $scopeByDefault) {
+test('table rls manager generates shortest paths that lead to the tenants table correctly', function (bool $scopeByDefault) {
     TableRLSManager::$scopeByDefault = $scopeByDefault;
 
     /** @var TableRLSManager $manager */
@@ -378,7 +378,7 @@ test('table rls manager generates relationship trees with tables related to the 
         $table->unsignedBigInteger('post_id')->nullable()->comment('rls');
         $table->foreign('post_id')->references('id')->on('posts')->onUpdate('cascade')->onDelete('cascade');
 
-        // No 'rls' comment – should get excluded from full trees when using explicit scoping
+        // No 'rls' comment – should get excluded from path generation when using explicit scoping
         $table->string('tenant_id')->nullable();
         $table->foreign('tenant_id')->references('id')->on('tenants')->onUpdate('cascade')->onDelete('cascade');
 
@@ -625,7 +625,7 @@ test('table manager can generate paths leading through comment constraint column
     /** @var TableRLSManager $manager */
     $manager = app(TableRLSManager::class);
 
-    $expectedTrees = [
+    $expectedPaths = [
         'non_constrained_posts' => [
             [
                 'foreignKey' => 'author_id',
@@ -647,7 +647,7 @@ test('table manager can generate paths leading through comment constraint column
         ],
     ];
 
-    expect($manager->shortestPaths())->toEqual($expectedTrees);
+    expect($manager->shortestPaths())->toEqual($expectedPaths);
 });
 
 test('table manager throws an exception when comment constraint is incorrect', function(string $comment, string $exceptionMessage) {

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -428,9 +428,15 @@ test('table rls manager generates shortest paths that lead to the tenants table 
 
     expect($manager->shortestPaths())->toEqual($expectedShortestPaths);
 
-    // Add non-nullable comment_id foreign key
+    // Add non-nullable comment_id comment constraint
     Schema::table('ratings', function (Blueprint $table) {
-        $table->foreignId('comment_id')->comment('rls')->constrained('comments')->onUpdate('cascade')->onDelete('cascade');
+        $table->string('comment_id')->comment('rls comments.id');
+
+        // Nullable constraint with a non-RLS comment.
+        // Skipped when scopeByDefault is false,
+        // not ignored when scopeByDefault is true, but still,
+        // not preferred since comment_id is valid and non-nullable.
+        $table->foreignId('author_id')->nullable()->comment('random comment')->constrained('authors');
     });
 
     // Non-nullable paths are preferred over nullable paths

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -196,9 +196,9 @@ test('queries are correctly scoped using RLS', function (
 
     $post1 = Post::create([
         'text' => 'first post',
-        'tenant_id' => $tenant1->getTenantKey(),
-        'author_id' => Author::create(['name' => 'author1', 'tenant_id' => $tenant1->getTenantKey()])->id,
-        'category_id' => Category::create(['name' => 'category1', 'tenant_id' => $tenant1->getTenantKey()])->id,
+        'tenant_id' => $tenant1->id,
+        'author_id' => Author::create(['name' => 'author1', 'tenant_id' => $tenant1->id])->id,
+        'category_id' => Category::create(['name' => 'category1', 'tenant_id' => $tenant1->id])->id,
     ]);
 
     $post1Comment = Comment::create(['text' => 'first comment', 'post_id' => $post1->id]);
@@ -209,9 +209,9 @@ test('queries are correctly scoped using RLS', function (
 
     $post2 = Post::create([
         'text' => 'second post',
-        'tenant_id' => $tenant2->getTenantKey(),
-        'author_id' => Author::create(['name' => 'author2', 'tenant_id' => $tenant2->getTenantKey()])->id,
-        'category_id' => Category::create(['name' => 'category2', 'tenant_id' => $tenant2->getTenantKey()])->id
+        'tenant_id' => $tenant2->id,
+        'author_id' => Author::create(['name' => 'author2', 'tenant_id' => $tenant2->id])->id,
+        'category_id' => Category::create(['name' => 'category2', 'tenant_id' => $tenant2->id])->id
     ]);
 
     $post2Comment = Comment::create(['text' => 'second comment', 'post_id' => $post2->id]);
@@ -327,7 +327,7 @@ test('queries are correctly scoped using RLS', function (
     expect(Note::count())->toBe(1);
 
     // Directly inserting records to other tenant's tables should fail (insufficient privilege error – new row violates row-level security policy)
-    expect(fn () => DB::statement("INSERT INTO posts (text, author_id, category_id, tenant_id) VALUES ('third post', 1, 1, '{$tenant1->getTenantKey()}')"))
+    expect(fn () => DB::statement("INSERT INTO posts (text, author_id, category_id, tenant_id) VALUES ('third post', 1, 1, '{$tenant1->id}')"))
         ->toThrow(QueryException::class);
 
     expect(fn () => DB::statement("INSERT INTO comments (text, post_id) VALUES ('third comment', {$post1->id})"))
@@ -496,7 +496,7 @@ test('forceRls prevents even the table owner from querying his own tables if he 
     // Create RLS policy for the orders table
     pest()->artisan('tenants:rls');
 
-    $tenant1->run(fn () => Order::create(['name' => 'order1', 'tenant_id' => $tenant1->getTenantKey()]));
+    $tenant1->run(fn () => Order::create(['name' => 'order1', 'tenant_id' => $tenant1->id]));
 
     // We are still using the 'administrator' user - owner of the orders table
 
@@ -543,7 +543,7 @@ test('users with BYPASSRLS privilege can bypass RLS regardless of forceRls setti
     // Create RLS policy for the orders table
     pest()->artisan('tenants:rls');
 
-    $tenant1->run(fn () => Order::create(['name' => 'order1', 'tenant_id' => $tenant1->getTenantKey()]));
+    $tenant1->run(fn () => Order::create(['name' => 'order1', 'tenant_id' => $tenant1->id]));
 
     // We are still using the 'administrator' user
 

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -703,8 +703,6 @@ test('table manager can generate paths leading through non-constrained foreign k
             ],
         ],
         'non_constrained_users' => [
-            // Category tree gets excluded because the category table is related to the tenant table
-            // only through a column with the 'no-rls' comment
             'tenant_id' => [
                 [
                     [

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -20,7 +20,7 @@ use Stancl\Tenancy\RLS\PolicyManagers\TableRLSManager;
 use Stancl\Tenancy\Bootstrappers\PostgresRLSBootstrapper;
 use Stancl\Tenancy\Database\Exceptions\RecursiveRelationshipException;
 use function Stancl\Tenancy\Tests\pest;
-use Stancl\Tenancy\Exceptions\RLSCommentConstraintException;
+use Stancl\Tenancy\RLS\Exceptions\RLSCommentConstraintException;
 
 beforeEach(function () {
     CreateUserWithRLSPolicies::$forceRls = true;

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -664,6 +664,12 @@ test('table manager ignores recursive relationship if the foreign key responsibl
 });
 
 test('table manager can generate paths leading through non-constrained foreign keys', function() {
+    // Drop extra tables
+    Schema::dropIfExists('reactions');
+    Schema::dropIfExists('comments');
+    Schema::dropIfExists('posts');
+    Schema::dropIfExists('authors');
+
     Schema::create('non_constrained_users', function (Blueprint $table) {
         $table->id();
         $table->string('tenant_id')->comment('rls tenants.id'); // "fake" constraint
@@ -678,58 +684,6 @@ test('table manager can generate paths leading through non-constrained foreign k
     $manager = app(TableRLSManager::class);
 
     $expectedTrees = [
-        'authors' => [
-            // Directly related to tenants
-            'tenant_id' => [
-                [
-                    [
-                        'foreignKey' => 'tenant_id',
-                        'foreignTable' => 'tenants',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ]
-                ],
-            ],
-        ],
-        'comments' => [
-            // Tree starting from the post_id foreign key
-            'post_id' => [
-                [
-                    [
-                        'foreignKey' => 'post_id',
-                        'foreignTable' => 'posts',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ],
-                    [
-                        'foreignKey' => 'author_id',
-                        'foreignTable' => 'authors',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ],
-                    [
-                        'foreignKey' => 'tenant_id',
-                        'foreignTable' => 'tenants',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ],
-                ],
-                [
-                    [
-                        'foreignKey' => 'post_id',
-                        'foreignTable' => 'posts',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ],
-                    [
-                        'foreignKey' => 'tenant_id',
-                        'foreignTable' => 'tenants',
-                        'foreignId' => 'id',
-                        'nullable' => true,
-                    ],
-                ],
-            ],
-        ],
         'non_constrained_posts' => [
             'author_id' => [
                 [
@@ -758,34 +712,6 @@ test('table manager can generate paths leading through non-constrained foreign k
                         'foreignTable' => 'tenants',
                         'foreignId' => 'id',
                         'nullable' => false,
-                    ]
-                ]
-            ],
-        ],
-        'posts' => [
-            'author_id' => [
-                [
-                    [
-                        'foreignKey' => 'author_id',
-                        'foreignTable' => 'authors',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ],
-                    [
-                        'foreignKey' => 'tenant_id',
-                        'foreignTable' => 'tenants',
-                        'foreignId' => 'id',
-                        'nullable' => false,
-                    ]
-                ],
-            ],
-            'tenant_id' => [
-                [
-                    [
-                        'foreignKey' => 'tenant_id',
-                        'foreignTable' => 'tenants',
-                        'foreignId' => 'id',
-                        'nullable' => true,
                     ]
                 ]
             ],

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -336,7 +336,7 @@ test('queries are correctly scoped using RLS', function (
     expect(fn () => DB::statement("INSERT INTO notes (text, comment_id) VALUES ('baz', {$post1Comment->id})"))
         ->toThrow(QueryException::class);
 })->with(['forceRls is true' => true, 'forceRls is false' => false])
-    ->with(['comment constraint' => true, 'real constraint' => false]);
+    ->with(['comment constraint' => true, 'foreign key constraint' => false]);
 
 test('table rls manager generates shortest paths that lead to the tenants table correctly', function (bool $scopeByDefault) {
     TableRLSManager::$scopeByDefault = $scopeByDefault;
@@ -684,7 +684,7 @@ test('table manager throws an exception when the only generated paths lead throu
         // Add another recursive relationship to demonstrate a more complex case
         $table->foreignId('related_post_id')->comment('rls recursive_posts.id');
 
-        // Add a foreign key with constraint to the current table (= self-referencing constraint)
+        // Add a foreign key to the current table (= self-referencing constraint)
         $table->foreignId('parent_comment_id')->comment('rls recursive_comments.id');
 
         // Add tenant_id to break the recursion - RecursiveRelationshipException should not be thrown
@@ -736,12 +736,12 @@ test('table manager can generate paths leading through comment constraint column
 
     Schema::create('non_constrained_users', function (Blueprint $table) {
         $table->id();
-        $table->string('tenant_id')->comment('rls tenants.id'); // comment constraint
+        $table->string('tenant_id')->comment('rls tenants.id'); // Comment constraint
     });
 
     Schema::create('non_constrained_posts', function (Blueprint $table) {
         $table->id();
-        $table->foreignId('author_id')->comment('rls non_constrained_users.id'); // comment constraint
+        $table->foreignId('author_id')->comment('rls non_constrained_users.id'); // Comment constraint
     });
 
     /** @var TableRLSManager $manager */

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -453,6 +453,10 @@ test('table rls manager generates shortest paths that lead to the tenants table 
             'foreignId' => 'id',
         ],
         [
+            // Importantly, the best path goes through authors
+            // since ratings -> posts is nullable, as well as
+            // posts -> tenants directly (without going through
+            // authors first).
             'foreignKey' => 'author_id',
             'foreignTable' => 'authors',
             'foreignId' => 'id',

--- a/tests/RLS/TableManagerTest.php
+++ b/tests/RLS/TableManagerTest.php
@@ -361,38 +361,38 @@ test('table rls manager generates shortest paths that lead to the tenants table 
     $expectedShortestPaths = [
         'authors' => [
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         'posts' => [
             [
-                'foreignKey' => 'author_id',
+                'localColumn' => 'author_id',
                 'foreignTable' => 'authors',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         'comments' => [
             [
-                'foreignKey' => 'post_id',
+                'localColumn' => 'post_id',
                 'foreignTable' => 'posts',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'author_id',
+                'localColumn' => 'author_id',
                 'foreignTable' => 'authors',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         // When scoping by default is enabled (implicit scoping),
@@ -401,25 +401,25 @@ test('table rls manager generates shortest paths that lead to the tenants table 
         // the shortest path leads through post_id.
         'ratings' => $scopeByDefault ? [
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ] : [
             [
-                'foreignKey' => 'post_id',
+                'localColumn' => 'post_id',
                 'foreignTable' => 'posts',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'author_id',
+                'localColumn' => 'author_id',
                 'foreignTable' => 'authors',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         // Articles table is ignored because it's not related to the tenant table in any way
@@ -443,28 +443,28 @@ test('table rls manager generates shortest paths that lead to the tenants table 
     // Non-nullable paths are preferred over nullable paths
     $expectedShortestPaths['ratings'] = [
         [
-            'foreignKey' => 'comment_id',
+            'localColumn' => 'comment_id',
             'foreignTable' => 'comments',
-            'foreignId' => 'id',
+            'foreignColumn' => 'id',
         ],
         [
-            'foreignKey' => 'post_id',
+            'localColumn' => 'post_id',
             'foreignTable' => 'posts',
-            'foreignId' => 'id',
+            'foreignColumn' => 'id',
         ],
         [
             // Importantly, the best path goes through authors
             // since ratings -> posts is nullable, as well as
             // posts -> tenants directly (without going through
             // authors first).
-            'foreignKey' => 'author_id',
+            'localColumn' => 'author_id',
             'foreignTable' => 'authors',
-            'foreignId' => 'id',
+            'foreignColumn' => 'id',
         ],
         [
-            'foreignKey' => 'tenant_id',
+            'localColumn' => 'tenant_id',
             'foreignTable' => 'tenants',
-            'foreignId' => 'id',
+            'foreignColumn' => 'id',
         ],
     ];
 
@@ -613,38 +613,38 @@ test('table rls manager generates queries correctly', function() {
     $paths = [
         'primaries' => [
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         'secondaries' => [
             [
-                'foreignKey' => 'primary_id',
+                'localColumn' => 'primary_id',
                 'foreignTable' => 'primaries',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         'foo' => [
             [
-                'foreignKey' => 'secondary_id',
+                'localColumn' => 'secondary_id',
                 'foreignTable' => 'secondaries',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'primary_id',
+                'localColumn' => 'primary_id',
                 'foreignTable' => 'primaries',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
     ];
@@ -782,21 +782,21 @@ test('table manager can generate paths leading through comment constraint column
     $expectedPaths = [
         'non_constrained_posts' => [
             [
-                'foreignKey' => 'author_id',
+                'localColumn' => 'author_id',
                 'foreignTable' => 'non_constrained_users',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
         'non_constrained_users' => [
             [
-                'foreignKey' => 'tenant_id',
+                'localColumn' => 'tenant_id',
                 'foreignTable' => 'tenants',
-                'foreignId' => 'id',
+                'foreignColumn' => 'id',
             ],
         ],
     ];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
     {
         parent::setUp();
 
+        ini_set('memory_limit', '1G');
+
         Redis::connection('default')->flushdb();
         Redis::connection('cache')->flushdb();
         Artisan::call('cache:clear memcached'); // flush memcached


### PR DESCRIPTION
## TableRLSManager refactor
The structure of TableRLSManager got updated. Now, the only public methods are
- `shortestPaths()` (generates the shortest, valid, preferably non-nullable path from table X to the tenants table, used in tests)
- `generateQueries()` (used by the `tenants:rls` command to generate RLS policies for tables, uses `shortestPaths()`)

### Performance
The path generation logic now utilizes dynamic programming (recursion + caching), so generating the paths from tables to the tenants table (and so generating the RLS policies) is now significantly faster, especially in apps with larger/complex DB schemas.

Shortest paths from table X to the tenants table are now cached during path generation. This prevents repeatedly generating already generated paths.

Paths that don't lead to the tenants table ("dead ends") are also cached so that we don't unnecessarily try to build paths that don't lead to the tenants table.

### Other improvements
Recursive relationships now behave as described in the docs. The RecursiveRelationshipException is only thrown if a recursive relationship was detected on the table AND there's no valid path from that table to the tenants table.

Comment logic (the "rls"/"no-rls" explicit/implicit scoping behavior) got corrected, the behavior is also clearer from the code now.
- "no-rls" comment on a column = the column won't be considered while generating a path from table X to the tenants table
- While `$scopeByDefault` is `false`, foreign key columns have to have an "rls" comment for paths leading through them to the tenants table to be considered during path generation (previously, the comment just had to be non-null)

## Comment constraints
Before, the TableRLSManager would completely ignore columns without constraints from policy generation. This PR makes it possible to add "fake" constraints to columns using comments. The columns now don't need to have real constraints for them to be included in RLS policy generation.

### Usage
The comment constraint can be defined like this:
`$table->string('tablename_id')->comment('rls tablename.id')`

The comment has to be formatted like `rls <foreign_table>.<foreign_id>`. If you format the comment incorrectly, you'll receive an exception while attempting to generate the paths (in a real app, while running `tenants:rls`).

Note that in relationship paths, you can combine real and comment constraints in any way.

### Real-world example
A comment constraint is a "fake" foreign key constraint that only serves for generating the RLS policies. This is useful if some of your migrations don't use real constraints, either for performance reasons, or for handling constraint edge cases in a simpler way.

The Jetstream's teams table for example (which appears to be the latter case):

```php
// The teams table
Schema::create('teams', function (Blueprint $table) {
    $table->id();
    $table->foreignId('user_id')->index(); // bigInteger column without a real constraint
    // Other columns..
});

// The users table
Schema::create('users', function (Blueprint $table) {
    $table->id();
    $table->foreignId('current_team_id')->nullable(); // bigInteger column without a real constraint
    $table->string('tenant_id');
    $table->foreign('tenant_id')->references('id')->on('tenants')
        ->onUpdate('cascade')->onDelete('cascade'); // Column with a real constraint
 });
```

This example intentionally doesn't use real constraints (because of the "chicken and egg" problem described below), therefore, the teams table **will be skipped** while generating the RLS policies using `php artisan tenants:rls`, and the data won't be properly separated per-tenant using the RLS policies.

The `user_id` and `current_team_id` columns can't have a normal constraint. If they had normal constraints (= the foreignId columns would have the `->constrained()` call):
- the users table would have to be created before the teams table because the teams table references the users table
- we wouldn't be able to create the users table because it also references the teams table

So we'd need to modify the migrations in a complex way for the tables to have real constraints. That could also alter the default behavior (not inherently incorrect, but assume it is for the sake of this example).

The ideal way to deal with this and keep the default behavior intact would be to give the `user_id`and `current_team_id` columns info about the constraint (= foreign table and foreign id) using comments for the data separation to work using RLS policies without defining actual constraints:

```php
// The teams table
Schema::create('teams', function (Blueprint $table) {
    $table->id();
    $table->foreignId('user_id')->index()->comment('rls users.id'); // Column with a comment constraint
    // Other columns..
});
```

Now, running `tenants:rls` will generate a RLS policy for the teams table (sidenote: also the `team_invitations` table, which has a constraint to the teams table on the `team_id` column), ensuring proper data separation.