### PR TITLE
[4.x] Make RouteMode a backed enum

### DIFF
--- a/src/Enums/RouteMode.php
+++ b/src/Enums/RouteMode.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Enums;
 
-enum RouteMode
+enum RouteMode: string
 {
-    case TENANT;
-    case CENTRAL;
-    case UNIVERSAL;
+    case TENANT = 'tenant';
+    case CENTRAL = 'central';
+    case UNIVERSAL = 'universal';
 }


### PR DESCRIPTION
Laravel's official VSCode extension [tries to encode all config values to JSON](https://github.com/laravel/vs-code-extension/blob/821442f3698a2f3e3da3797fb6783115a40c4873/php-templates/configs.php#L146).

In Tenancy's config, `RouteMode` is present as the value of the `default_route_mode` key.

JSON encoding fails with the message: `Non-backed enums have no default serialization`.

This PR makes RouteMode a backed enum to mitigate this problem.