### PR TITLE
[4.x] URL generation, request data identification improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Testing
 - `composer test` - Run tests without coverage using Docker
+- `./test tests/TestFile.php` - Run an entire test file
 - `./t 'test name'` - Run a specific test
 
 ### Code Quality

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `composer test` - Run tests without coverage using Docker
 - `./test tests/TestFile.php` - Run an entire test file
 - `./t 'test name'` - Run a specific test
+- You can append `-v` to get a full stack trace if a test fails due to an exception
 
 ### Code Quality
 - `composer phpstan` - Run PHPStan static analysis (level 8)

--- a/assets/config.php
+++ b/assets/config.php
@@ -119,7 +119,7 @@ return [
             Resolvers\PathTenantResolver::class => [
                 'tenant_parameter_name' => 'tenant', // todo0 test changing this
                 'tenant_model_column' => null, // null = tenant key
-                'tenant_route_name_prefix' => null, // null = 'tenant.'
+                'tenant_route_name_prefix' => 'tenant.',
                 'allowed_extra_model_columns' => [], // used with binding route fields
 
                 'cache' => false,
@@ -127,8 +127,9 @@ return [
                 'cache_store' => null, // null = default
             ],
             Resolvers\RequestDataTenantResolver::class => [
+                // Set any of these to null to disable that method of identification
                 'header' => 'X-Tenant',
-                'cookie' => 'tenant', // todo0 test in url generator
+                'cookie' => 'tenant',
                 'query_parameter' => 'tenant',
 
                 'cache' => false,

--- a/assets/config.php
+++ b/assets/config.php
@@ -132,6 +132,8 @@ return [
                 'cookie' => 'tenant',
                 'query_parameter' => 'tenant',
 
+                'tenant_model_column' => null, // null = tenant key
+
                 'cache' => false,
                 'cache_ttl' => 3600, // seconds
                 'cache_store' => null, // null = default

--- a/assets/config.php
+++ b/assets/config.php
@@ -117,7 +117,7 @@ return [
                 'cache_store' => null, // null = default
             ],
             Resolvers\PathTenantResolver::class => [
-                'tenant_parameter_name' => 'tenant',
+                'tenant_parameter_name' => 'tenant', // todo0 test changing this
                 'tenant_model_column' => null, // null = tenant key
                 'tenant_route_name_prefix' => null, // null = 'tenant.'
                 'allowed_extra_model_columns' => [], // used with binding route fields
@@ -127,6 +127,10 @@ return [
                 'cache_store' => null, // null = default
             ],
             Resolvers\RequestDataTenantResolver::class => [
+                'header' => 'X-Tenant',
+                'cookie' => 'tenant', // todo0 test in url generator
+                'query_parameter' => 'tenant',
+
                 'cache' => false,
                 'cache_ttl' => 3600, // seconds
                 'cache_store' => null, // null = default

--- a/assets/config.php
+++ b/assets/config.php
@@ -117,7 +117,7 @@ return [
                 'cache_store' => null, // null = default
             ],
             Resolvers\PathTenantResolver::class => [
-                'tenant_parameter_name' => 'tenant', // todo0 test changing this
+                'tenant_parameter_name' => 'tenant',
                 'tenant_model_column' => null, // null = tenant key
                 'tenant_route_name_prefix' => 'tenant.',
                 'allowed_extra_model_columns' => [], // used with binding route fields

--- a/src/Bootstrappers/UrlGeneratorBootstrapper.php
+++ b/src/Bootstrappers/UrlGeneratorBootstrapper.php
@@ -73,7 +73,6 @@ class UrlGeneratorBootstrapper implements TenancyBootstrapper
 
             foreach (PathTenantResolver::allowedExtraModelColumns() as $column) {
                 // todo0 should this be tenantParameterName() concatenated to :$column?
-                // add tests
                 $defaultParameters["tenant:$column"] = $tenant->getAttribute($column);
             }
         }

--- a/src/Bootstrappers/UrlGeneratorBootstrapper.php
+++ b/src/Bootstrappers/UrlGeneratorBootstrapper.php
@@ -67,13 +67,15 @@ class UrlGeneratorBootstrapper implements TenancyBootstrapper
         $defaultParameters = $this->originalUrlGenerator->getDefaultParameters();
 
         if (static::$addTenantParameterToDefaults) {
-            $defaultParameters = array_merge(
-                $defaultParameters,
-                [
-                    PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue($tenant), // path identification
-                    'tenant' => $tenant->getTenantKey(), // query string identification
-                ],
-            );
+            $defaultParameters = array_merge($defaultParameters, [
+                PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue($tenant),
+            ]);
+
+            foreach (PathTenantResolver::allowedExtraModelColumns() as $column) {
+                // todo0 should this be tenantParameterName() concatenated to :$column?
+                // add tests
+                $defaultParameters["tenant:$column"] = $tenant->getAttribute($column);
+            }
         }
 
         $newGenerator->defaults($defaultParameters);

--- a/src/Bootstrappers/UrlGeneratorBootstrapper.php
+++ b/src/Bootstrappers/UrlGeneratorBootstrapper.php
@@ -67,13 +67,14 @@ class UrlGeneratorBootstrapper implements TenancyBootstrapper
         $defaultParameters = $this->originalUrlGenerator->getDefaultParameters();
 
         if (static::$addTenantParameterToDefaults) {
+            $tenantParameterName = PathTenantResolver::tenantParameterName();
+
             $defaultParameters = array_merge($defaultParameters, [
-                PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue($tenant),
+                $tenantParameterName => PathTenantResolver::tenantParameterValue($tenant),
             ]);
 
             foreach (PathTenantResolver::allowedExtraModelColumns() as $column) {
-                // todo0 should this be tenantParameterName() concatenated to :$column?
-                $defaultParameters["tenant:$column"] = $tenant->getAttribute($column);
+                $defaultParameters["$tenantParameterName:$column"] = $tenant->getAttribute($column);
             }
         }
 

--- a/src/Overrides/TenancyUrlGenerator.php
+++ b/src/Overrides/TenancyUrlGenerator.php
@@ -192,6 +192,7 @@ class TenancyUrlGenerator extends UrlGenerator
                     return array_merge($parameters, [$queryParameterName => RequestDataTenantResolver::payloadValue(tenant())]);
                 }
             }
+
             return array_merge($parameters, [PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue(tenant())]);
         } else {
             return $parameters;

--- a/src/Overrides/TenancyUrlGenerator.php
+++ b/src/Overrides/TenancyUrlGenerator.php
@@ -9,6 +9,7 @@ use Illuminate\Routing\UrlGenerator;
 use Illuminate\Support\Arr;
 use InvalidArgumentException;
 use Stancl\Tenancy\Resolvers\PathTenantResolver;
+use Stancl\Tenancy\Resolvers\RequestDataTenantResolver;
 
 /**
  * This class is used in place of the default UrlGenerator when UrlGeneratorBootstrapper is enabled.
@@ -86,12 +87,22 @@ class TenancyUrlGenerator extends UrlGenerator
     public static array $overrides = [];
 
     /**
-     * Use default parameter names ('tenant' name and tenant key value) instead of the parameter name
-     * and column name configured in the path resolver config.
+     * Follow the query_parameter config instead of the tenant_parameter_name (path identification) config.
      *
-     * You want to enable this when using query string identification while having customized that config.
+     * This only has an effect when:
+     *   - $passTenantParameterToRoutes is enabled, and
+     *   - the tenant_parameter_name config for the path resolver differs from the query_parameter config for the request data resolver.
+     *
+     * In such a case, instead of adding ['tenant' => '...'] to the route parameters (or whatever your tenant_parameter_name is if not 'tenant'),
+     * the query_parameter will be passed instead, e.g. ['team' => '...'] if your query_parameter config is 'team'.
+     *
+     * This is enabled by default because typically you will not need $passTenantParameterToRoutes with path identification.
+     * UrlGeneratorBootstrapper::$addTenantParameterToDefaults is recommended instead when using path identification.
+     *
+     * On the other hand, when using request data identification (specifically query string) you WILL need to pass the parameter
+     * directly to route() calls, therefore you would use $passTenantParameterToRoutes to avoid having to do that manually.
      */
-    public static bool $defaultParameterNames = false;
+    public static bool $passQueryParameter = true;
 
     /**
      * Override the route() method so that the route name gets prefixed
@@ -175,9 +186,8 @@ class TenancyUrlGenerator extends UrlGenerator
     protected function addTenantParameter(array $parameters): array
     {
         if (tenant() && static::$passTenantParameterToRoutes) {
-            if (static::$defaultParameterNames) {
-                // todo0 this should be changed to something like static::$queryParameter and it should respect the configured tenant model column
-                return array_merge($parameters, ['tenant' => tenant()->getTenantKey()]);
+            if (static::$passQueryParameter) {
+                return array_merge($parameters, [RequestDataTenantResolver::queryParameterName() => RequestDataTenantResolver::payloadValue(tenant())]);
             } else {
                 return array_merge($parameters, [PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue(tenant())]);
             }

--- a/src/Overrides/TenancyUrlGenerator.php
+++ b/src/Overrides/TenancyUrlGenerator.php
@@ -176,6 +176,7 @@ class TenancyUrlGenerator extends UrlGenerator
     {
         if (tenant() && static::$passTenantParameterToRoutes) {
             if (static::$defaultParameterNames) {
+                // todo0 this should be changed to something like static::$queryParameter and it should respect the configured tenant model column
                 return array_merge($parameters, ['tenant' => tenant()->getTenantKey()]);
             } else {
                 return array_merge($parameters, [PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue(tenant())]);

--- a/src/Overrides/TenancyUrlGenerator.php
+++ b/src/Overrides/TenancyUrlGenerator.php
@@ -187,10 +187,12 @@ class TenancyUrlGenerator extends UrlGenerator
     {
         if (tenant() && static::$passTenantParameterToRoutes) {
             if (static::$passQueryParameter) {
-                return array_merge($parameters, [RequestDataTenantResolver::queryParameterName() => RequestDataTenantResolver::payloadValue(tenant())]);
-            } else {
-                return array_merge($parameters, [PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue(tenant())]);
+                $queryParameterName = RequestDataTenantResolver::queryParameterName();
+                if ($queryParameterName !== null) {
+                    return array_merge($parameters, [$queryParameterName => RequestDataTenantResolver::payloadValue(tenant())]);
+                }
             }
+            return array_merge($parameters, [PathTenantResolver::tenantParameterName() => PathTenantResolver::tenantParameterValue(tenant())]);
         } else {
             return $parameters;
         }

--- a/src/Resolvers/RequestDataTenantResolver.php
+++ b/src/Resolvers/RequestDataTenantResolver.php
@@ -20,7 +20,9 @@ class RequestDataTenantResolver extends Contracts\CachedTenantResolver
     {
         $payload = (string) $args[0];
 
-        if ($payload && $tenant = tenancy()->find($payload, withRelations: true)) {
+        $column = static::tenantModelColumn();
+
+        if ($payload && $tenant = tenancy()->find($payload, $column, withRelations: true)) {
             return $tenant;
         }
 
@@ -32,6 +34,11 @@ class RequestDataTenantResolver extends Contracts\CachedTenantResolver
         return [
             $this->formatCacheKey($tenant->getTenantKey()),
         ];
+    }
+
+    public static function tenantModelColumn(): string
+    {
+        return config('tenancy.identification.resolvers.' . static::class . '.tenant_model_column') ?? tenancy()->model()->getTenantKeyName();
     }
 
     /**

--- a/src/Resolvers/RequestDataTenantResolver.php
+++ b/src/Resolvers/RequestDataTenantResolver.php
@@ -33,4 +33,28 @@ class RequestDataTenantResolver extends Contracts\CachedTenantResolver
             $this->formatCacheKey($tenant->getTenantKey()),
         ];
     }
+
+    /**
+     * Returns the name of the header used for identification, or null if header identification is disabled.
+     */
+    public static function headerName(): string|null
+    {
+        return config('tenancy.identification.resolvers.' . static::class . '.header');
+    }
+
+    /**
+     * Returns the name of the query parameter used for identification, or null if query parameter identification is disabled.
+     */
+    public static function queryParameterName(): string|null
+    {
+        return config('tenancy.identification.resolvers.' . static::class . '.query_parameter');
+    }
+
+    /**
+     * Returns the name of the cookie used for identification, or null if cookie identification is disabled.
+     */
+    public static function cookieName(): string|null
+    {
+        return config('tenancy.identification.resolvers.' . static::class . '.cookie');
+    }
 }

--- a/src/Resolvers/RequestDataTenantResolver.php
+++ b/src/Resolvers/RequestDataTenantResolver.php
@@ -31,9 +31,15 @@ class RequestDataTenantResolver extends Contracts\CachedTenantResolver
 
     public function getPossibleCacheKeys(Tenant&Model $tenant): array
     {
+        // todo@tests
         return [
-            $this->formatCacheKey($tenant->getTenantKey()),
+            $this->formatCacheKey(static::payloadValue($tenant)),
         ];
+    }
+
+    public static function payloadValue(Tenant $tenant): string
+    {
+        return $tenant->getAttribute(static::tenantModelColumn());
     }
 
     public static function tenantModelColumn(): string

--- a/t
+++ b/t
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 if [[ "${CLAUDECODE}" != "1" ]]; then
-    COLOR_FLAG="--color=always"
+    COLOR_FLAG="--colors=always"
 else
-    COLOR_FLAG=""
+    COLOR_FLAG="--colors=never"
 fi
 
 docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest ${COLOR_FLAG} --no-coverage --filter "$@"

--- a/t
+++ b/t
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest --color=always --no-coverage --filter "$@"
+if [[ "${CLAUDECODE}" != "1" ]]; then
+    COLOR_FLAG="--color=always"
+else
+    COLOR_FLAG=""
+fi
+
+docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest ${COLOR_FLAG} --no-coverage --filter "$@"

--- a/test
+++ b/test
@@ -3,7 +3,7 @@
 if [[ "${CLAUDECODE}" != "1" ]]; then
     COLOR_FLAG="--colors=always"
 else
-    COLOR_FLAG=""
+    COLOR_FLAG="--colors=never"
 fi
 
 # --columns doesn't seem to work at the moment, so we're setting it using an environment variable

--- a/test
+++ b/test
@@ -1,10 +1,10 @@
 #!/bin/bash
 
-# --columns doesn't seem to work at the moment, so we're setting it using an environment variable
 if [[ "${CLAUDECODE}" != "1" ]]; then
     COLOR_FLAG="--colors=always"
 else
     COLOR_FLAG=""
 fi
 
+# --columns doesn't seem to work at the moment, so we're setting it using an environment variable
 docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest ${COLOR_FLAG} "$@"

--- a/test
+++ b/test
@@ -1,4 +1,10 @@
 #!/bin/bash
 
 # --columns doesn't seem to work at the moment, so we're setting it using an environment variable
-docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest --colors=always "$@"
+if [[ "${CLAUDECODE}" != "1" ]]; then
+    COLOR_FLAG="--colors=always"
+else
+    COLOR_FLAG=""
+fi
+
+docker compose exec -e COLUMNS=$(tput cols) -T test vendor/bin/pest ${COLOR_FLAG} "$@"

--- a/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
+++ b/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
@@ -20,7 +20,7 @@ afterEach(function () {
     FortifyRouteBootstrapper::$passTenantParameter = true;
     FortifyRouteBootstrapper::$fortifyRedirectMap = [];
     FortifyRouteBootstrapper::$fortifyHome = 'tenant.dashboard';
-    FortifyRouteBootstrapper::$defaultParameterNames = false;
+    FortifyRouteBootstrapper::$passQueryParameter = false;
 });
 
 test('fortify route tenancy bootstrapper updates fortify config correctly', function() {

--- a/tests/Bootstrappers/UrlGeneratorBootstrapperTest.php
+++ b/tests/Bootstrappers/UrlGeneratorBootstrapperTest.php
@@ -119,7 +119,7 @@ test('request data identification route helper behavior', function (bool $addTen
 
     tenancy()->initialize($tenant);
 
-    // todo0 test changing tenancy.identification.resolvers.<request data>.query_parameter
+    // todo0 test changing tenancy.identification.resolvers.<request data>.query_parameter and tenant_model_column
 
     if ($passTenantParameterToRoutes) {
         expect(route('tenant.home'))->toBe("{$appUrl}/tenant/home?tenant={$tenantKey}");

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -99,7 +99,7 @@ test('cookie identification works', function (string|null $tenantModelColumn) {
 
 // todo@tests encrypted cookie
 
-test('an exception is thrown when no tenant data is not provided in the request', function () {
+test('an exception is thrown when no tenant data is provided in the request', function () {
     pest()->expectException(TenantCouldNotBeIdentifiedByRequestDataException::class);
     $this->withoutExceptionHandling()->get('test');
 });

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Route;
 use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedByRequestDataException;
 use Stancl\Tenancy\Middleware\InitializeTenancyByRequestData;
@@ -21,50 +22,80 @@ beforeEach(function () {
     });
 });
 
-test('header identification works', function () {
-    $tenant = Tenant::create();
+test('header identification works', function (string|null $tenantModelColumn) {
+    if ($tenantModelColumn) {
+        Schema::table('tenants', function (Blueprint $table) use ($tenantModelColumn) {
+            $table->string($tenantModelColumn)->unique();
+        });
+        Tenant::$extraCustomColumns = [$tenantModelColumn];
+    }
+
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => $tenantModelColumn]);
+
+    $tenant = Tenant::create($tenantModelColumn ? [$tenantModelColumn => 'acme'] : []);
+    $payload = $tenantModelColumn ? 'acme' : $tenant->id;
 
     // Default header name
-    $this->withoutExceptionHandling()->withHeader('X-Tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->withHeader('X-Tenant', $payload)->get('test')->assertSee($tenant->id);
 
     // Custom header name
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.header' => 'X-Custom-Tenant']);
-    $this->withoutExceptionHandling()->withHeader('X-Custom-Tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->withHeader('X-Custom-Tenant', $payload)->get('test')->assertSee($tenant->id);
 
     // Setting the header to null disables header identification
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.header' => null]);
-    expect(fn () => $this->withoutExceptionHandling()->withHeader('X-Tenant', $tenant->id)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
-});
+    expect(fn () => $this->withoutExceptionHandling()->withHeader('X-Tenant', $payload)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
+})->with([null, 'slug']);
 
-test('query parameter identification works', function () {
-    $tenant = Tenant::create();
+test('query parameter identification works', function (string|null $tenantModelColumn) {
+    if ($tenantModelColumn) {
+        Schema::table('tenants', function (Blueprint $table) use ($tenantModelColumn) {
+            $table->string($tenantModelColumn)->unique();
+        });
+        Tenant::$extraCustomColumns = [$tenantModelColumn];
+    }
+
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => $tenantModelColumn]);
+
+    $tenant = Tenant::create($tenantModelColumn ? [$tenantModelColumn => 'acme'] : []);
+    $payload = $tenantModelColumn ? 'acme' : $tenant->id;
 
     // Default query parameter name
-    $this->withoutExceptionHandling()->get('test?tenant=' . $tenant->id)->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->get('test?tenant=' . $payload)->assertSee($tenant->id);
 
     // Custom query parameter name
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.query_parameter' => 'custom_tenant']);
-    $this->withoutExceptionHandling()->get('test?custom_tenant=' . $tenant->id)->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->get('test?custom_tenant=' . $payload)->assertSee($tenant->id);
 
     // Setting the query parameter to null disables query parameter identification
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.query_parameter' => null]);
-    expect(fn () => $this->withoutExceptionHandling()->get('test?tenant=' . $tenant->id))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
-});
+    expect(fn () => $this->withoutExceptionHandling()->get('test?tenant=' . $payload))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
+})->with([null, 'slug']);
 
-test('cookie identification works', function () {
-    $tenant = Tenant::create();
+test('cookie identification works', function (string|null $tenantModelColumn) {
+    if ($tenantModelColumn) {
+        Schema::table('tenants', function (Blueprint $table) use ($tenantModelColumn) {
+            $table->string($tenantModelColumn)->unique();
+        });
+        Tenant::$extraCustomColumns = [$tenantModelColumn];
+    }
+
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => $tenantModelColumn]);
+
+    $tenant = Tenant::create($tenantModelColumn ? [$tenantModelColumn => 'acme'] : []);
+    $payload = $tenantModelColumn ? 'acme' : $tenant->id;
 
     // Default cookie name
-    $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $payload)->get('test')->assertSee($tenant->id);
 
     // Custom cookie name
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.cookie' => 'custom_tenant_id']);
-    $this->withoutExceptionHandling()->withUnencryptedCookie('custom_tenant_id', $tenant->id)->get('test')->assertSee($tenant->id);
+    $this->withoutExceptionHandling()->withUnencryptedCookie('custom_tenant_id', $payload)->get('test')->assertSee($tenant->id);
 
     // Setting the cookie to null disables cookie identification
     config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.cookie' => null]);
-    expect(fn () => $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $tenant->id)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
-});
+    expect(fn () => $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $payload)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
+})->with([null, 'slug']);
 
 // todo@tests encrypted cookie
 

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -14,12 +14,9 @@ beforeEach(function () {
         'tenancy.identification.central_domains' => [
             'localhost',
         ],
-        'tenancy.identification.' . RequestDataTenantResolver::class . '.header' => 'X-Tenant',
-        'tenancy.identification.' . RequestDataTenantResolver::class . '.query_parameter' => 'tenant',
-        'tenancy.identification.' . RequestDataTenantResolver::class . '.cookie' => 'tenant',
     ]);
 
-    Route::middleware(['tenant', InitializeTenancyByRequestData::class])->get('/test', function () {
+    Route::middleware([InitializeTenancyByRequestData::class])->get('/test', function () {
         return 'Tenant id: ' . tenant('id');
     });
 });
@@ -27,35 +24,52 @@ beforeEach(function () {
 test('header identification works', function () {
     $tenant = Tenant::create();
 
-    $this
-        ->withoutExceptionHandling()
-        ->withHeader('X-Tenant', $tenant->id)
-        ->get('test')
-        ->assertSee($tenant->id);
+    // Default header name
+    $this->withoutExceptionHandling()->withHeader('X-Tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+
+    // Custom header name
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.header' => 'X-Custom-Tenant']);
+    $this->withoutExceptionHandling()->withHeader('X-Custom-Tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+
+    // Setting the header to null disables header identification
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.header' => null]);
+    expect(fn () => $this->withoutExceptionHandling()->withHeader('X-Tenant', $tenant->id)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
 });
 
 test('query parameter identification works', function () {
     $tenant = Tenant::create();
 
-    $this
-        ->withoutExceptionHandling()
-        ->get('test?tenant=' . $tenant->id)
-        ->assertSee($tenant->id);
+    // Default query parameter name
+    $this->withoutExceptionHandling()->get('test?tenant=' . $tenant->id)->assertSee($tenant->id);
+
+    // Custom query parameter name
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.query_parameter' => 'custom_tenant']);
+    $this->withoutExceptionHandling()->get('test?custom_tenant=' . $tenant->id)->assertSee($tenant->id);
+
+    // Setting the query parameter to null disables query parameter identification
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.query_parameter' => null]);
+    expect(fn () => $this->withoutExceptionHandling()->get('test?tenant=' . $tenant->id))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
 });
 
 test('cookie identification works', function () {
     $tenant = Tenant::create();
 
-    $this
-        ->withoutExceptionHandling()
-        ->withUnencryptedCookie('tenant', $tenant->id)
-        ->get('test')
-        ->assertSee($tenant->id);
+    // Default cookie name
+    $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $tenant->id)->get('test')->assertSee($tenant->id);
+
+    // Custom cookie name
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.cookie' => 'custom_tenant_id']);
+    $this->withoutExceptionHandling()->withUnencryptedCookie('custom_tenant_id', $tenant->id)->get('test')->assertSee($tenant->id);
+
+    // Setting the cookie to null disables cookie identification
+    config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.cookie' => null]);
+    expect(fn () => $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $tenant->id)->get('test'))->toThrow(TenantCouldNotBeIdentifiedByRequestDataException::class);
 });
 
 // todo@tests encrypted cookie
 
-test('middleware throws exception when tenant data is not provided in the request', function () {
+test('an exception is thrown when no tenant data is not provided in the request', function () {
     pest()->expectException(TenantCouldNotBeIdentifiedByRequestDataException::class);
     $this->withoutExceptionHandling()->get('test');
 });
+


### PR DESCRIPTION
- [x] Fix passing defaults to new `UrlGenerator`:
    - Pass defaults for all allowed *extra columns*
    - Remove `'tenant'` for request data identification; defaults don't matter with request data URL generation and the `'tenant'` key was interfering with a potentially changed `tenancy.resolvers.PathTenantResolver.tenant_model_column`
 - [x] Handle changes to `tenant_parameter_name` in URL generator bootstrapper
 - [x] Allow changing tenant model column with request data identification, to avoid leaking the tenant key
    - [x] Basic implementation
    - [x] Support in URL generation
 - [x] ~~Local diff~~ (path id + route model binding test) moved to a separate task
 - [x] Issues reported in Discord convo - should be resolved by removing the hardcoded `'tenant'` default (see above about interfering with potentially changed tenant_model_column)

## Breaking changes
- **Request data identification**: Moves static properties from `InitializeTenancyByRequestData` to the config file and adds static functions to `RequestDataResolver`. This is consistent with how the path identification code handles configuration
- `defaultParameterNames` -> `passQueryParameter`, also a change in default values