### PR TITLE
[4.x] Test that route model binding works correctly with path identification

### DIFF
--- a/tests/PathIdentificationTest.php
+++ b/tests/PathIdentificationTest.php
@@ -258,7 +258,7 @@ test('any extra model column needs to be whitelisted', function () {
     pest()->get('/acme/foo')->assertSee($tenant->getTenantKey());
 });
 
-test('route model binding works with closure-based routes', function() {
+test('route model binding works with path identification', function() {
     config(['tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class]]);
 
     Event::listen(TenancyInitialized::class, BootstrapTenancy::class);

--- a/tests/PathIdentificationTest.php
+++ b/tests/PathIdentificationTest.php
@@ -19,7 +19,6 @@ use Stancl\Tenancy\Jobs\MigrateDatabase;
 use Stancl\JobPipeline\JobPipeline;
 use Stancl\Tenancy\Events\TenancyInitialized;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
-use Stancl\Tenancy\Events\TenancyEnded;
 use Stancl\Tenancy\Listeners\RevertToCentralContext;
 use Stancl\Tenancy\Tests\Etc\User;
 use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;


### PR DESCRIPTION
This PR adds a test for checking if route model binding works with routes using path identification.

For example: `Route::get('/{tenant}/{user}', fn (User $user) => $user->name)->middleware([InitializeTenancyByPath::class, 'web']);`

In this route, tenancy will be initialized first, and then, the user will be resolved in the tenant context.