### PR TITLE
[4.x] Resolve testing todos

### DIFF
--- a/src/Bootstrappers/Integrations/FortifyRouteBootstrapper.php
+++ b/src/Bootstrappers/Integrations/FortifyRouteBootstrapper.php
@@ -86,7 +86,6 @@ class FortifyRouteBootstrapper implements TenancyBootstrapper
     protected function useTenantRoutesInFortify(Tenant $tenant): void
     {
         if (static::$passQueryParameter) {
-            // todo@tests
             $tenantParameterName = RequestDataTenantResolver::queryParameterName();
             $tenantParameterValue = RequestDataTenantResolver::payloadValue($tenant);
         } else {

--- a/src/Resolvers/RequestDataTenantResolver.php
+++ b/src/Resolvers/RequestDataTenantResolver.php
@@ -31,7 +31,6 @@ class RequestDataTenantResolver extends Contracts\CachedTenantResolver
 
     public function getPossibleCacheKeys(Tenant&Model $tenant): array
     {
-        // todo@tests
         return [
             $this->formatCacheKey(static::payloadValue($tenant)),
         ];

--- a/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
+++ b/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
@@ -27,9 +27,6 @@ afterEach(function () {
 test('fortify route tenancy bootstrapper updates fortify config correctly', function() {
     config(['tenancy.bootstrappers' => [FortifyRouteBootstrapper::class]]);
 
-    // The bootstrapper uses resolver config for generating Fortify route URLs.
-    // Config used for generating Fortify route URLs
-    // when FortifyRouteBootstrapper::$passQueryParameter is true (default)
     config([
         // Parameter name (RequestDataTenantResolver::queryParameterName())
         'tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.query_parameter' => 'team_query',
@@ -37,8 +34,6 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
         'tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => 'company',
     ]);
 
-    // Config used for generating Fortify route URLs
-    // when FortifyRouteBootstrapper::$passQueryParameter is false
     config([
         // Parameter name (PathTenantResolver::tenantParameterName())
         'tenancy.identification.resolvers.' . PathTenantResolver::class . '.tenant_parameter_name' => 'team_path',
@@ -59,11 +54,13 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
     expect(config('fortify.redirects'))->toBe($originalFortifyRedirects);
 
     /**
-     * When $passQueryParameter is true, use the RequestDataTenantResolver config
+     * When $passQueryParameter is true, the bootstrapper uses
+     * the RequestDataTenantResolver config for generating the Fortify URLs
      * - tenant parameter is 'team_query'
      * - parameter value is the tenant's company ('Acme')
      *
-     * When $passQueryParameter is false, use the PathTenantResolver config
+     * When $passQueryParameter is false, the bootstrapper uses
+     * the PathTenantResolver config for generating the Fortify URLs
      * - tenant parameter is 'team_path'
      * - parameter value is the tenant's name ('Foo')
      */
@@ -72,8 +69,9 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
         'name' => 'Foo',
     ]);
 
-    // The bootstrapper overrides the URLs in the Fortify config correctly (the URLs have the correct tenant parameter + parameter value)
-    // Bootstrapper should generate URLs using RequestDataTenantResolver
+    // The bootstrapper generates and overrides the URLs in the Fortify config correctly
+    // (= the generated URLs have the correct tenant parameter + parameter value)
+    // The bootstrapper should use RequestDataTenantResolver while generating the URLs (default)
     FortifyRouteBootstrapper::$passQueryParameter = true;
 
     tenancy()->initialize($tenant);
@@ -87,7 +85,7 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
     expect(config('fortify.home'))->toBe($originalFortifyHome);
     expect(config('fortify.redirects'))->toBe($originalFortifyRedirects);
 
-    // Bootstrapper should generate URLs using PathTenantResolver
+    // The bootstrapper should use PathTenantResolver while generating the URLs now
     FortifyRouteBootstrapper::$passQueryParameter = false;
 
     tenancy()->initialize($tenant);

--- a/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
+++ b/tests/Bootstrappers/FortifyRouteBootstrapperTest.php
@@ -73,13 +73,13 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
     ]);
 
     // The bootstrapper overrides the URLs in the Fortify config correctly (the URLs have the correct tenant parameter + parameter value)
-    // RequestDataTenantResolver config should be used
+    // Bootstrapper should generate URLs using RequestDataTenantResolver
     FortifyRouteBootstrapper::$passQueryParameter = true;
 
     tenancy()->initialize($tenant);
 
     expect(config('fortify.home'))->toBe('http://localhost/home?team_query=Acme');
-    expect(config('fortify.redirects'))->toEqual(['login' => 'http://localhost/welcome?team_query=Acme']);
+    expect(config('fortify.redirects'))->toBe(['login' => 'http://localhost/welcome?team_query=Acme']);
 
     // The bootstrapper restores the original Fortify config when ending tenancy
     tenancy()->end();
@@ -87,13 +87,13 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
     expect(config('fortify.home'))->toBe($originalFortifyHome);
     expect(config('fortify.redirects'))->toBe($originalFortifyRedirects);
 
-    // PathTenantResolver config should be used now
+    // Bootstrapper should generate URLs using PathTenantResolver
     FortifyRouteBootstrapper::$passQueryParameter = false;
 
     tenancy()->initialize($tenant);
 
     expect(config('fortify.home'))->toBe('http://localhost/home?team_path=Foo');
-    expect(config('fortify.redirects'))->toEqual(['login' => 'http://localhost/welcome?team_path=Foo']);
+    expect(config('fortify.redirects'))->toBe(['login' => 'http://localhost/welcome?team_path=Foo']);
 
     tenancy()->end();
 
@@ -102,8 +102,6 @@ test('fortify route tenancy bootstrapper updates fortify config correctly', func
 
     tenancy()->initialize($tenant);
 
-    expect(config('fortify.home'))->toBe('http://localhost/home')
-        ->not()->toBe($originalFortifyHome);
-    expect(config('fortify.redirects'))->toEqual(['login' => 'http://localhost/welcome'])
-        ->not()->toBe($originalFortifyRedirects);
+    expect(config('fortify.home'))->toBe('http://localhost/home');
+    expect(config('fortify.redirects'))->toBe(['login' => 'http://localhost/welcome']);
 });

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -19,6 +19,7 @@ use function Stancl\Tenancy\Tests\pest;
 
 test('tenants can be resolved using cached resolvers', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+
     $tenant->createDomain($tenant->{$tenantColumn});
 
     expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
@@ -33,6 +34,7 @@ test('tenants can be resolved using cached resolvers', function (string $resolve
 
 test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+
     $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();
@@ -62,6 +64,7 @@ test('the underlying resolver is not touched when using the cached resolver', fu
 
 test('cache is invalidated when the tenant is updated', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+
     $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -18,11 +18,11 @@ use Stancl\Tenancy\Resolvers\RequestDataTenantResolver;
 use function Stancl\Tenancy\Tests\pest;
 
 test('tenants can be resolved using cached resolvers', function (string $resolver, bool $configureTenantModelColumn) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
+    $tenant = Tenant::create([$tenantModelColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
-    $tenant->createDomain($tenant->{$tenantColumn});
+    $tenant->createDomain($tenant->{$tenantModelColumn});
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
 })->with([
     DomainTenantResolver::class,
     PathTenantResolver::class,
@@ -33,25 +33,25 @@ test('tenants can be resolved using cached resolvers', function (string $resolve
 ]);
 
 test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $configureTenantModelColumn) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
+    $tenant = Tenant::create([$tenantModelColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
-    $tenant->createDomain($tenant->{$tenantColumn});
+    $tenant->createDomain($tenant->{$tenantModelColumn});
 
     DB::enableQueryLog();
 
     config(['tenancy.identification.resolvers.' . $resolver . '.cache' => false]);
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     DB::flushQueryLog();
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
 
     pest()->assertNotEmpty(DB::getQueryLog()); // not empty
 
     config(['tenancy.identification.resolvers.' . $resolver . '.cache' => true]);
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     DB::flushQueryLog();
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     expect(DB::getQueryLog())->toBeEmpty(); // empty
 })->with([
     DomainTenantResolver::class,
@@ -63,20 +63,20 @@ test('the underlying resolver is not touched when using the cached resolver', fu
 ]);
 
 test('cache is invalidated when the tenant is updated', function (string $resolver, bool $configureTenantModelColumn) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
+    $tenant = Tenant::create([$tenantModelColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
-    $tenant->createDomain($tenant->{$tenantColumn});
+    $tenant->createDomain($tenant->{$tenantModelColumn});
 
     DB::enableQueryLog();
 
     config(['tenancy.identification.resolvers.' . $resolver . '.cache' => true]);
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     expect(DB::getQueryLog())->not()->toBeEmpty();
 
     DB::flushQueryLog();
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     expect(DB::getQueryLog())->toBeEmpty();
 
     // Tenant cache gets invalidated when the tenant is updated
@@ -84,7 +84,7 @@ test('cache is invalidated when the tenant is updated', function (string $resolv
 
     DB::flushQueryLog();
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
 
     expect(DB::getQueryLog())->not()->toBeEmpty(); // Cache was invalidated, so the tenant was retrieved from the DB
 })->with([
@@ -98,25 +98,25 @@ test('cache is invalidated when the tenant is updated', function (string $resolv
 
 test('cache is invalidated when the tenant is deleted', function (string $resolver, bool $configureTenantModelColumn) {
     DB::statement('SET FOREIGN_KEY_CHECKS=0;'); // allow deleting the tenant
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
-    $tenant->createDomain($tenant->{$tenantColumn});
+    $tenant = Tenant::create([$tenantModelColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
+    $tenant->createDomain($tenant->{$tenantModelColumn});
 
     DB::enableQueryLog();
 
     config(['tenancy.identification.resolvers.' . $resolver . '.cache' => true]);
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     expect(DB::getQueryLog())->not()->toBeEmpty();
 
     DB::flushQueryLog();
 
-    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
+    expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn))))->toBeTrue();
     expect(DB::getQueryLog())->toBeEmpty();
 
     $tenant->delete();
     DB::flushQueryLog();
 
-    expect(fn () => app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn)))->toThrow(TenantCouldNotBeIdentifiedException::class);
+    expect(fn () => app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantModelColumn)))->toThrow(TenantCouldNotBeIdentifiedException::class);
     expect(DB::getQueryLog())->not()->toBeEmpty(); // Cache was invalidated, so the DB was queried
 })->with([
     DomainTenantResolver::class,
@@ -332,23 +332,23 @@ test('PathTenantResolver properly separates cache for each tenant column', funct
  */
 function tenantModelColumn(bool $configureTenantModelColumn): string {
     // Default tenant model column is 'id'
-    $tenantColumn = 'id';
+    $tenantModelColumn = 'id';
 
     if ($configureTenantModelColumn) {
         // Use 'name' as the custom tenant model column
-        $tenantColumn = 'name';
+        $tenantModelColumn = 'name';
 
-        Tenant::$extraCustomColumns = [$tenantColumn];
+        Tenant::$extraCustomColumns = [$tenantModelColumn];
 
-        Schema::table('tenants', function (Blueprint $table) use ($tenantColumn) {
-            $table->string($tenantColumn)->unique();
+        Schema::table('tenants', function (Blueprint $table) use ($tenantModelColumn) {
+            $table->string($tenantModelColumn)->unique();
         });
 
-        config(['tenancy.identification.resolvers.' . PathTenantResolver::class . '.tenant_model_column' => $tenantColumn]);
-        config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => $tenantColumn]);
+        config(['tenancy.identification.resolvers.' . PathTenantResolver::class . '.tenant_model_column' => $tenantModelColumn]);
+        config(['tenancy.identification.resolvers.' . RequestDataTenantResolver::class . '.tenant_model_column' => $tenantModelColumn]);
     }
 
-    return $tenantColumn;
+    return $tenantModelColumn;
 }
 
 /**

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -17,6 +17,12 @@ use Stancl\Tenancy\Middleware\InitializeTenancyByPath;
 use Stancl\Tenancy\Resolvers\RequestDataTenantResolver;
 use function Stancl\Tenancy\Tests\pest;
 
+beforeEach($cleanup = function () {
+    Tenant::$extraCustomColumns = [];
+});
+
+afterEach($cleanup);
+
 test('tenants can be resolved using cached resolvers', function (string $resolver, bool $configureTenantModelColumn) {
     $tenant = Tenant::create([$tenantModelColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
@@ -320,8 +326,6 @@ test('PathTenantResolver properly separates cache for each tenant column', funct
     pest()->get("/x/bar/b")->assertSee('foo');
     expect(count(DB::getRawQueryLog()))->toBe(4); // unchanged
     expect(count($redisKeys()))->toBe(4); // unchanged
-
-    Tenant::$extraCustomColumns = []; // reset
 });
 
 /**

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -19,9 +19,7 @@ use function Stancl\Tenancy\Tests\pest;
 
 test('tenants can be resolved using cached resolvers', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
-    $tenantParameterValue = $tenant->{$tenantColumn};
-
-    $tenant->createDomain($tenantParameterValue);
+    $tenant->createDomain($tenant->{$tenantColumn});
 
     expect($tenant->is(app($resolver)->resolve(getResolverArgument($resolver, $tenant, $tenantColumn))))->toBeTrue();
 })->with([
@@ -35,9 +33,7 @@ test('tenants can be resolved using cached resolvers', function (string $resolve
 
 test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
-    $tenantParameterValue = $tenant->{$tenantColumn};
-
-    $tenant->createDomain($tenantParameterValue);
+    $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();
 
@@ -66,9 +62,7 @@ test('the underlying resolver is not touched when using the cached resolver', fu
 
 test('cache is invalidated when the tenant is updated', function (string $resolver, bool $default) {
     $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
-    $tenantParameterValue = $tenant->{$tenantColumn};
-
-    $tenant->createDomain($tenantParameterValue);
+    $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();
 
@@ -100,12 +94,9 @@ test('cache is invalidated when the tenant is updated', function (string $resolv
 ]);
 
 test('cache is invalidated when the tenant is deleted', function (string $resolver, bool $default) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
-    $tenantParameterValue = $tenant->{$tenantColumn};
-
     DB::statement('SET FOREIGN_KEY_CHECKS=0;'); // allow deleting the tenant
-
-    $tenant->createDomain($tenantParameterValue);
+    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+    $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();
 
@@ -134,8 +125,8 @@ test('cache is invalidated when the tenant is deleted', function (string $resolv
 ]);
 
 test('cache is invalidated when a tenants domain is changed', function () {
-    $tenant = Tenant::create(['id' => $domain = 'acme']);
-    $tenant->createDomain($domain);
+    $tenant = Tenant::create(['id' => $tenantKey = 'acme']);
+    $tenant->createDomain($tenantKey);
 
     DB::enableQueryLog();
 
@@ -160,8 +151,8 @@ test('cache is invalidated when a tenants domain is changed', function () {
 });
 
 test('cache is invalidated when a tenants domain is deleted', function () {
-    $tenant = Tenant::create(['id' => $domain = 'acme']);
-    $tenant->createDomain($domain);
+    $tenant = Tenant::create(['id' => $tenantKey = 'acme']);
+    $tenant->createDomain($tenantKey);
 
     DB::enableQueryLog();
 

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -388,6 +388,6 @@ function getResolverArgument(string $resolver, Tenant $tenant, string $parameter
 
     // Assuming that:
     // - with RequestDataTenantResolver, the tenant model column value is the payload value
-    // - with DomainTenantResolver, the tenant has a domain with name equal to the tenant model column value
+    // - with DomainTenantResolver, the tenant has a domain with name equal to the tenant model column value (see the createDomain() calls in various tests)
     return $tenant->{$parameterColumn};
 }

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -28,8 +28,8 @@ test('tenants can be resolved using cached resolvers', function (string $resolve
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => false,
-    'tenant column is name (custom)' => true,
+    'tenant model column is id (default)' => false,
+    'tenant model column is name (custom)' => true,
 ]);
 
 test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $configureTenantModelColumn) {
@@ -58,8 +58,8 @@ test('the underlying resolver is not touched when using the cached resolver', fu
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => false,
-    'tenant column is name (custom)' => true,
+    'tenant model column is id (default)' => false,
+    'tenant model column is name (custom)' => true,
 ]);
 
 test('cache is invalidated when the tenant is updated', function (string $resolver, bool $configureTenantModelColumn) {
@@ -92,8 +92,8 @@ test('cache is invalidated when the tenant is updated', function (string $resolv
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => false,
-    'tenant column is name (custom)' => true,
+    'tenant model column is id (default)' => false,
+    'tenant model column is name (custom)' => true,
 ]);
 
 test('cache is invalidated when the tenant is deleted', function (string $resolver, bool $configureTenantModelColumn) {
@@ -123,8 +123,8 @@ test('cache is invalidated when the tenant is deleted', function (string $resolv
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => false,
-    'tenant column is name (custom)' => true,
+    'tenant model column is id (default)' => false,
+    'tenant model column is name (custom)' => true,
 ]);
 
 test('cache is invalidated when a tenants domain is changed', function () {
@@ -358,7 +358,7 @@ function tenantModelColumn(bool $configureTenantModelColumn): string {
  * For PathTenantResolver, return a route instance with the value retrieved using $tenant->{$parameterColumn} as the parameter.
  * For RequestDataTenantResolver and DomainTenantResolver, return the value retrieved using $tenant->{$parameterColumn}.
  *
- * Tenant column name is 'id' by default, but in the generic tests,
+ * Tenant model column is 'id' by default, but in the generic tests,
  * we also configure that to 'name' to ensure everything works both with default and custom config.
  */
 function getResolverArgument(string $resolver, Tenant $tenant, string $parameterColumn = 'id'): string|Route

--- a/tests/CachedTenantResolverTest.php
+++ b/tests/CachedTenantResolverTest.php
@@ -17,8 +17,8 @@ use Stancl\Tenancy\Middleware\InitializeTenancyByPath;
 use Stancl\Tenancy\Resolvers\RequestDataTenantResolver;
 use function Stancl\Tenancy\Tests\pest;
 
-test('tenants can be resolved using cached resolvers', function (string $resolver, bool $default) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+test('tenants can be resolved using cached resolvers', function (string $resolver, bool $configureTenantModelColumn) {
+    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
     $tenant->createDomain($tenant->{$tenantColumn});
 
@@ -28,12 +28,12 @@ test('tenants can be resolved using cached resolvers', function (string $resolve
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => true,
-    'tenant column is name (custom)' => false,
+    'tenant column is id (default)' => false,
+    'tenant column is name (custom)' => true,
 ]);
 
-test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $default) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+test('the underlying resolver is not touched when using the cached resolver', function (string $resolver, bool $configureTenantModelColumn) {
+    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
     $tenant->createDomain($tenant->{$tenantColumn});
 
@@ -58,12 +58,12 @@ test('the underlying resolver is not touched when using the cached resolver', fu
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => true,
-    'tenant column is name (custom)' => false,
+    'tenant column is id (default)' => false,
+    'tenant column is name (custom)' => true,
 ]);
 
-test('cache is invalidated when the tenant is updated', function (string $resolver, bool $default) {
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+test('cache is invalidated when the tenant is updated', function (string $resolver, bool $configureTenantModelColumn) {
+    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
 
     $tenant->createDomain($tenant->{$tenantColumn});
 
@@ -92,13 +92,13 @@ test('cache is invalidated when the tenant is updated', function (string $resolv
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => true,
-    'tenant column is name (custom)' => false,
+    'tenant column is id (default)' => false,
+    'tenant column is name (custom)' => true,
 ]);
 
-test('cache is invalidated when the tenant is deleted', function (string $resolver, bool $default) {
+test('cache is invalidated when the tenant is deleted', function (string $resolver, bool $configureTenantModelColumn) {
     DB::statement('SET FOREIGN_KEY_CHECKS=0;'); // allow deleting the tenant
-    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($default) => 'acme']);
+    $tenant = Tenant::create([$tenantColumn = tenantModelColumn($configureTenantModelColumn) => 'acme']);
     $tenant->createDomain($tenant->{$tenantColumn});
 
     DB::enableQueryLog();
@@ -123,8 +123,8 @@ test('cache is invalidated when the tenant is deleted', function (string $resolv
     PathTenantResolver::class,
     RequestDataTenantResolver::class,
 ])->with([
-    'tenant column is id (default)' => true,
-    'tenant column is name (custom)' => false,
+    'tenant column is id (default)' => false,
+    'tenant column is name (custom)' => true,
 ]);
 
 test('cache is invalidated when a tenants domain is changed', function () {
@@ -327,13 +327,13 @@ test('PathTenantResolver properly separates cache for each tenant column', funct
 /**
  * This method is used in generic tests to ensure that caching works correctly both with default and custom resolver config.
  *
- * If $default is true, the tenant model column is 'id' -- don't configure anything, keep the defaults.
- * If $default is false, the tenant model column should be 'name' -- configure tenant_model_column in the resolvers.
+ * If $configureTenantModelColumn is false, the tenant model column is 'id' -- don't configure anything, keep the defaults.
+ * If $configureTenantModelColumn is true, the tenant model column should be 'name' -- configure tenant_model_column in the resolvers.
  */
-function tenantModelColumn(bool $default): string {
-    $tenantColumn = $default ? 'id' : 'name';
+function tenantModelColumn(bool $configureTenantModelColumn): string {
+    $tenantColumn = $configureTenantModelColumn ? 'name' : 'id';
 
-    if (! $default) {
+    if ($configureTenantModelColumn) {
         Tenant::$extraCustomColumns = [$tenantColumn];
 
         Schema::table('tenants', function (Blueprint $table) use ($tenantColumn) {

--- a/tests/RequestDataIdentificationTest.php
+++ b/tests/RequestDataIdentificationTest.php
@@ -89,7 +89,7 @@ test('cookie identification works', function (string|null $tenantModelColumn) {
     // Default cookie name
     $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $payload)->get('test')->assertSee($tenant->id);
 
-    // Encrypted cookie (encrypt cookie like MakesHttpRequests does)
+    // Manually encrypted cookie (encrypt the cookie exactly like MakesHttpRequests does in prepareCookiesForRequest())
     $encryptedPayload = encrypt(CookieValuePrefix::create('tenant', app('encrypter')->getKey()) . $payload, false);
 
     $this->withoutExceptionHandling()->withUnencryptedCookie('tenant', $encryptedPayload)->get('test')->assertSee($tenant->id);


### PR DESCRIPTION
This PR adds tests for the untested logic (resolves most of the `todo@tests` group todos -- the ones I was specifically told to ignore for now are not resolved yet).

### FortifyRouteBoostrapperTest (test behavior with `$passQueryParameter` set to `true` vs `false`)
FortifyRouteBoostrapper was updated recently. The value of `$passQueryParameter` now affects if the RequestDataTenantResolver _or_ PathTenantResolver config will be used while generating the URLs in the bootstrapper. This distinction wasn't tested. Using custom resolver config instead of the default one also wasn't tested.

Now, the bootstraper test asserts that the URLs are generated using the configured values correctly. The test was also a bit excessive and not concrete about the expected URLs -- this PR fixes that. Also added comments to make everything clearer.

### CachedTenantResolverTest (cached resolvers weren't tested with custom resolver config)
RequestDataTenantResolver was updated recently. Now, `RequestDataTenantResolver::payloadValue($tenant)` is used in `getPossibleCacheKeys()` instead of `$tenant->getTenantKey()`, but no assertions are checking that the payload doesn't have to be `$tenant->getTenantKey()`. Everywhere in the tests, we just assumed the tenant key was the payload value. It should have been tested that **even when the resolver config is customized, the caching still works correctly** (PathTenantResolver is also a concern here, the parameter value can be anything, not just the tenant key).

I made all the generic tests that check if the caching works correctly with any resolver. The behavior with customized resolver config is tested now (as well as the behavior with the default config).

So all the generic tests now have an additional `->with()`: `bool $configureTenantModelColumn` (datasets can get messy, but for this, it was the cleanest solution I could think of)
- `true` = custom config, tenant model column is 'name'
- `false` = default config, tenant model column is 'id'

There's also a new helper method that configures and returns the tenant model column based on the `$configureTenantModelColumn` dataset to reduce code duplication (four tests out of eight use this method).

The `getResolverArgument()` helper was somewhat confusing, messy, and felt incorrect, so I made the method clearer (the code itself + proper comments) and updated it so that it retrieves the correct resolver argument, even when with custom resolver config (before, it implied that the resolver config was default).

### RequestDataIdentificationTest (tenant identification wasn't tested with manually encrypted cookies)
When cookie identification is used, the request data identification middleware automatically detects if the cookie is encrypted, decrypts it, and identifies the tenant. Using encrypted cookies with cookie identification wasn't tested.

This PR adds an assertion to the cookie identification test where the payload (cookie) is manually encrypted, and it's asserted that the tenant gets identified correctly, even with the encrypted cookie (now, it's tested that the cookies are decrypted properly during tenant identification).

Note that Laravel automatically encrypts cookies when `->withCookie()` is used instead of `->withUnencryptedCookie()` (and with `->withCookie()`, cookie identification works without issues). In the test, `->withUnencryptedCookie()` is used with the cookie encryption logic from MakesHttpsRequests so that we're very specific about the cookie encryption in the test. But just FYI:
```php
test('cookie identification works with encrypted cookies', function () {
    $tenant = Tenant::create(['id' => 'acme']);

    $this->withoutExceptionHandling()->withCookie('tenant', 'acme')->get('test')->assertSee($tenant->id);
});
```

The cookie **will be encrypted** here, and the test will pass.