### PR TITLE
[4.x] Make RouteMode a backed enum

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -132,6 +132,7 @@ $finder = Finder::create()
     ->in([
         $project_path . '/src',
     ])
+    ->exclude('Enums')
     ->name('*.php')
     ->notName('*.blade.php')
     ->ignoreDotFiles(true)

--- a/src/Enums/RouteMode.php
+++ b/src/Enums/RouteMode.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Enums;
 
-enum RouteMode
+/**
+ * Note: The backing values are not part of the public API and are subject to change.
+ */
+enum RouteMode: int
 {
-    case TENANT;
-    case CENTRAL;
-    case UNIVERSAL;
+    case CENTRAL   = 0b01;
+    case TENANT    = 0b10;
+    case UNIVERSAL = 0b11;
 }


### PR DESCRIPTION
Resubmission of https://github.com/archtechx/tenancy/pull/1355

This makes the enum JSON serializable which in turn makes the config file supported by the Laravel VS Code extension.

Quoting my reply:
> Hey, thanks for reporting this.
> 
> Honestly, I don't love the idea of having to make an enum backed if we never use the backing values, only for serialization support. On the other hand, pure enums not being serializable is a ... painful decision on PHP's side.
> 
> This sounds like a good fit for https://github.com/archtechx/enums. However I don't really want to bring in an entire new dependency (even if it's our own package) because of one simple enum.
> 
> I was thinking if I can make the backing values make some actual sense. Strings are intuitive but don't add any value. Ints on their own are completely arbitrary. So for now I'm going with:
> 
> ```php
> enum RouteMode: int
> {
>     case CENTRAL   = 0b01;
>     case TENANT    = 0b10;
>     case UNIVERSAL = 0b11;
> }
> 
> $central = RouteMode::CENTRAL;
> $tenant = RouteMode::TENANT;
> $universal = RouteMode::UNIVERSAL;
> 
> assert($central->value === 1);
> assert($tenant->value === 2);
> assert($universal->value === 3);
> 
> // The nice property of this approach:
> assert($universal->value & $central->value);
> assert($universal->value & $tenant->value);
> 
> assert(! ($central->value & $tenant->value));
> assert(! ($tenant->value & $central->value));
> ```
> 
> This just makes central 1, tenant 2, and universal 3, but expressed in this way it has the nice benefit of working as a bit field of flags.
> 
> That way we could check for "does this route mode support tenant routes?" as `$mode->value & RouteMode::TENANT->value` instead of `$mode === RouteMode::TENANT || $mode === RouteMode::UNIVERSAL`. It at least has some meaning and value, though I don't think we're going to use this bitwise logic in our code (nor do we seem to have such conditionals anyway at this time).

