### PR TITLE
[4.x] Fix MW group unpacking in DealsWithRouteContexts' getRouteMiddleware()

### DIFF
--- a/src/Concerns/DealsWithRouteContexts.php
+++ b/src/Concerns/DealsWithRouteContexts.php
@@ -110,7 +110,7 @@ trait DealsWithRouteContexts
 
             foreach ($middleware as $inner) {
                 if (! $inner instanceof Closure && isset($middlewareGroups[$inner])) {
-                    $innerMiddleware = Arr::wrap($middlewareGroups[$inner]);
+                    $innerMiddleware = array_merge($innerMiddleware, Arr::wrap($middlewareGroups[$inner]));
                 }
             }
 

--- a/tests/RouteMiddlewareTest.php
+++ b/tests/RouteMiddlewareTest.php
@@ -69,6 +69,18 @@ test('tenancy detects presence of route middleware correctly', function (string 
     InitializeTenancyByDomainOrSubdomain::class,
 ]);
 
+test('getRouteMiddleware properly unpacks all mw groups on a route', function() {
+    $route = Route::get('/foo', fn () => true)->middleware(['foo', 'bar']);
+
+    Route::middlewareGroup('foo', [PreventAccessFromUnwantedDomains::class]);
+    Route::middlewareGroup('bar', [InitializeTenancyByDomain::class]);
+
+    expect(tenancy()->getRouteMiddleware($route))->toContain(
+        PreventAccessFromUnwantedDomains::class,
+        InitializeTenancyByDomain::class
+    );
+});
+
 test('domain identification middleware is configurable', function() {
     $route = Route::get('/welcome-route', fn () => 'welcome')->middleware([InitializeTenancyByDomain::class]);
 


### PR DESCRIPTION
If a route had multiple MW groups, and you'd wan't to get all the route's MW (properly unpacked), `tenancy()->getRouteMiddleware($route)` would return an array of MW with only the last MW group unpacked (see the added regression test). This caused issues when attempting to use the 'tenant' flag as a MW group (e.g. with the identification MW) while simultaneously using more MW groups on a route.

Now during unpacking, the group's inner middleware is merged to the previously unpacked middleware instead of overwriting it.