### PR TITLE
[4.x] Update route cloning example in TenancyServiceProvider stub

### DIFF
--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -227,23 +227,23 @@ class TenancyServiceProvider extends ServiceProvider
         /** @var CloneRoutesAsTenant $cloneRoutes */
         $cloneRoutes = $this->app->make(CloneRoutesAsTenant::class);
 
-        // // The cloning action has two modes:
-        // // 1. Clone all routes that have the middleware present in the action's $cloneRoutesWithMiddleware property.
-        // // You can customize the middleware that triggers cloning by using cloneRoutesWithMiddleware() on the action.
-        // //
-        // // By default, the middleware is ['clone'], but using $cloneRoutes->cloneRoutesWithMiddleware(['clone', 'universal'])->handle()
-        // // will clone all routes that have either 'clone' or 'universal' middleware (mentioning 'universal' since that's a common use case).
-        // //
-        // // Also, you can use the shouldClone() method to provide a custom closure that determines if a route should be cloned.
-        // //
-        // // 2. Clone only the routes that were manually added to the action using cloneRoute().
-        // //
-        // // Regardless of the mode, you can provide a custom closure for defining the cloned route, e.g.:
+        // The cloning action has two modes:
+        // 1. Clone all routes that have the middleware present in the action's $cloneRoutesWithMiddleware property.
+        // You can customize the middleware that triggers cloning by using cloneRoutesWithMiddleware() on the action.
+        //
+        // By default, the middleware is ['clone'], but using $cloneRoutes->cloneRoutesWithMiddleware(['clone', 'universal'])->handle()
+        // will clone all routes that have either 'clone' or 'universal' middleware (mentioning 'universal' since that's a common use case).
+        //
+        // Also, you can use the shouldClone() method to provide a custom closure that determines if a route should be cloned.
+        //
+        // 2. Clone only the routes that were manually added to the action using cloneRoute().
+        //
+        // Regardless of the mode, you can provide a custom closure for defining the cloned route, e.g.:
         // $cloneRoutesAction->cloneUsing(function (Route $route) {
         //     RouteFacade::get('/cloned/' . $route->uri(), fn () => 'cloned route')->name('cloned.' . $route->getName());
         // })->handle();
-        // // This will make all cloned routes use the custom closure to define the cloned route instead of the default behavior.
-        // // See Stancl\Tenancy\Actions\CloneRoutesAsTenant for more details.
+        // This will make all cloned routes use the custom closure to define the cloned route instead of the default behavior.
+        // See Stancl\Tenancy\Actions\CloneRoutesAsTenant for more details.
 
         $cloneRoutes->handle();
     }

--- a/assets/TenancyServiceProvider.stub.php
+++ b/assets/TenancyServiceProvider.stub.php
@@ -216,7 +216,9 @@ class TenancyServiceProvider extends ServiceProvider
     }
 
     /**
-     * Clone universal routes as tenant.
+     * Clone routes as tenant.
+     *
+     * This is used primarily for integrating packages.
      *
      * @see CloneRoutesAsTenant
      */
@@ -225,13 +227,23 @@ class TenancyServiceProvider extends ServiceProvider
         /** @var CloneRoutesAsTenant $cloneRoutes */
         $cloneRoutes = $this->app->make(CloneRoutesAsTenant::class);
 
-        // // You can provide a closure for cloning a specific route, e.g.:
-        // $cloneRoutes->cloneUsing('welcome', function () {
-        //     RouteFacade::get('/tenant-welcome', fn () => 'Current tenant: ' . tenant()->getTenantKey())
-        //         ->middleware(['universal', InitializeTenancyByPath::class])
-        //         ->name('tenant.welcome');
-        // });
-        // // To see the default behavior of cloning the universal routes, check out the cloneRoute() method in CloneRoutesAsTenant.
+        // // The cloning action has two modes:
+        // // 1. Clone all routes that have the middleware present in the action's $cloneRoutesWithMiddleware property.
+        // // You can customize the middleware that triggers cloning by using cloneRoutesWithMiddleware() on the action.
+        // //
+        // // By default, the middleware is ['clone'], but using $cloneRoutes->cloneRoutesWithMiddleware(['clone', 'universal'])->handle()
+        // // will clone all routes that have either 'clone' or 'universal' middleware (mentioning 'universal' since that's a common use case).
+        // //
+        // // Also, you can use the shouldClone() method to provide a custom closure that determines if a route should be cloned.
+        // //
+        // // 2. Clone only the routes that were manually added to the action using cloneRoute().
+        // //
+        // // Regardless of the mode, you can provide a custom closure for defining the cloned route, e.g.:
+        // $cloneRoutesAction->cloneUsing(function (Route $route) {
+        //     RouteFacade::get('/cloned/' . $route->uri(), fn () => 'cloned route')->name('cloned.' . $route->getName());
+        // })->handle();
+        // // This will make all cloned routes use the custom closure to define the cloned route instead of the default behavior.
+        // // See Stancl\Tenancy\Actions\CloneRoutesAsTenant for more details.
 
         $cloneRoutes->handle();
     }


### PR DESCRIPTION
Route cloning got updated recently. This PR updates the cloning example in TSP stub so that it's up-to-date with the recent cloning refactor.