### PR TITLE
[4.x] Cloning: addTenantParameter(bool), domain(string|null)

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -21,7 +21,6 @@ $rules = [
     'blank_line_before_statement' => [
         'statements' => ['return']
     ],
-    'braces' => true,
     'cast_spaces' => true,
     'class_definition' => true,
     'concat_space' => [

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -10,7 +10,6 @@ use Illuminate\Routing\Router;
 use Illuminate\Support\Str;
 use Stancl\Tenancy\Resolvers\PathTenantResolver;
 
-
 // todo@addTenantParameter revisit annotation
 /**
  * Clones either all existing routes for which shouldBeCloned() returns true

--- a/src/Actions/CloneRoutesAsTenant.php
+++ b/src/Actions/CloneRoutesAsTenant.php
@@ -30,7 +30,9 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  * You may customize $cloneRoutesWithMiddleware using cloneRoutesWithMiddleware() to make any middleware of your choice trigger cloning.
  * By providing a callback to shouldClone(), you can change how it's determined if a route should be cloned if you don't want to use middleware flags.
  *
- * Cloned routes are prefixed with '/{tenant}', flagged with 'tenant' middleware, and have their names prefixed with 'tenant.'.
+ * Cloned routes are prefixed with '/{tenant}' (the tenant parameter can be omitted by passing the addTenantParameter() method `false`),
+ * flagged with 'tenant' middleware, and have their names prefixed with 'tenant.'.
+ *
  * The parameter name and prefix can be changed e.g. to `/{team}` and `team.` by configuring the path resolver (tenantParameterName and tenantRouteNamePrefix).
  * Routes with names that are already prefixed won't be cloned - but that's just the default behavior.
  * The cloneUsing() method allows you to completely override the default behavior and customize how the cloned routes will be defined.
@@ -59,6 +61,12 @@ use Stancl\Tenancy\Resolvers\PathTenantResolver;
  *
  * // Clone baz route as /{tenant}/bar and name it tenant.baz ('universal' middleware won't be present in the cloned route)
  * $cloneAction->cloneRoute('baz')->handle();
+ *
+ * Route::get('/no-tenant-parameter', fn () => true)->name('no-tenant-parameter'->middleware('clone');
+ *
+ * // Clone baz route as /no-tenant-parameter and name it tenant.no-tenant-parameter (the route won't have the tenant parameter)
+ * // This can be useful e.g. with domain identification.
+ * $cloneAction->addTenantParameter(false)->cloneRoutesWithMiddleware(['clone'])->cloneRoute('no-tenant-parameter')->handle();
  * ```
  *
  * Calling handle() will also clear the $routesToClone array.

--- a/tests/CloneActionTest.php
+++ b/tests/CloneActionTest.php
@@ -339,21 +339,53 @@ test('clone action can be used fluently', function() {
         ->toContain('tenant.foo', 'tenant.bar', 'tenant.baz');
 });
 
-test('addTenantParameter affects if the cloned route will have the tenant parameter', function(bool $addTenantParameter) {
-    RouteFacade::get('/foo', fn () => true)->name('foo')->middleware('clone');
+test('the cloned route can be scoped to a specified domain', function () {
+    RouteFacade::domain('foo.localhost')->get('/foo', fn () => in_array('tenant', request()->route()->middleware()) ? 'tenant' : 'central')->name('foo')->middleware('clone');
 
+    // Importantly, we CANNOT add a domain to the cloned route *if the original route didn't have a domain*.
+    // This is due to the route registration order - the more strongly scoped route (= route with a domain)
+    // must be registered first, so that Laravel tries that route first and only moves on if the domain check fails.
     $cloneAction = app(CloneRoutesAsTenant::class);
+    // To keep the test simple we don't even need a tenant parameter
+    $cloneAction->domain('bar.localhost')->addTenantParameter(false)->handle();
 
+    expect(route('foo'))->toBe('http://foo.localhost/foo');
+    expect(route('tenant.foo'))->toBe('http://bar.localhost/foo');
+});
+
+test('tenant parameter addition can be controlled by setting addTenantParameter', function (bool $addTenantParameter) {
+    RouteFacade::domain('central.localhost')
+        ->get('/foo', fn () => in_array('tenant', request()->route()->middleware()) ? 'tenant' : 'central')
+        ->name('foo')
+        ->middleware('clone');
+
+    // By default this action also removes the domain
+    $cloneAction = app(CloneRoutesAsTenant::class);
     $cloneAction->addTenantParameter($addTenantParameter)->handle();
 
     $clonedRoute = RouteFacade::getRoutes()->getByName('tenant.foo');
 
+    // We only use the route() helper here, since once a request is made
+    // the URL generator caches the request's domain and it affects route
+    // generation for routes that do not have domain() specified (tenant.foo)
+    expect(route('foo'))->toBe('http://central.localhost/foo');
+    if ($addTenantParameter)
+        expect(route('tenant.foo', ['tenant' => 'abc']))->toBe('http://localhost/abc/foo');
+    else
+        expect(route('tenant.foo'))->toBe('http://localhost/foo');
+
+    // Original route still works
+    $this->withoutExceptionHandling()->get(route('foo'))->assertSee('central');
+
     if ($addTenantParameter) {
         expect($clonedRoute->uri())->toContain('{tenant}');
-        expect(fn () => $this->get(route('tenant.foo')))->toThrow(UrlGenerationException::class, 'Missing parameter: tenant');
-        $this->withoutExceptionHandling()->get(route('tenant.foo', ['tenant' => Tenant::create()->id]))->assertOk();
+
+        $this->withoutExceptionHandling()->get('http://localhost/abc/foo')->assertSee('tenant');
+        $this->withoutExceptionHandling()->get('http://central.localhost/foo')->assertSee('central');
     } else {
         expect($clonedRoute->uri())->not()->toContain('{tenant}');
-        $this->withoutExceptionHandling()->get(route('tenant.foo'))->assertOk();
+
+        $this->withoutExceptionHandling()->get('http://localhost/foo')->assertSee('tenant');
+        $this->withoutExceptionHandling()->get('http://central.localhost/foo')->assertSee('central');
     }
 })->with([true, false]);


### PR DESCRIPTION
Adds the `$addTenantParameter` to CloneRoutesAsTenant action, which is `true` by default. Also adds the addTenantParameter() method which can be used fluently like `$cloneAction->addTenantParameter(false)->handle()` -- this will clone the route WITHOUT the tenant parameter being added, making cloning a viable thing even with e.g. domain identification, making integrating packages a bit easier.

In addition to `addTenantParameter`, the `domain()` method is added for controlling the domain of the cloned route (defaults to null). When `addTenantParameter(false)` is used, the two routes MUST differ in domains. Due to how route registration works, it's also important that the *original* route has a domain set, regardless of whether the cloned route has a domain or not.