### PR TITLE
[4.x] Make SyncMaster's tenants relationship customizable

### DIFF
--- a/src/ResourceSyncing/Listeners/DeleteResourcesInTenants.php
+++ b/src/ResourceSyncing/Listeners/DeleteResourcesInTenants.php
@@ -19,13 +19,15 @@ class DeleteResourcesInTenants extends QueueableListener
         $centralResource = $event->centralResource;
         $forceDelete = $event->forceDelete;
 
-        tenancy()->runForMultiple($centralResource->tenants()->cursor(), function () use ($centralResource, $forceDelete) {
+        $relationshipName = $centralResource->getTenantsRelationshipName();
+
+        tenancy()->runForMultiple($centralResource->{$relationshipName}()->cursor(), function () use ($centralResource, $forceDelete, $relationshipName) {
             $this->deleteSyncedResource($centralResource, $forceDelete);
 
             // Delete pivot records if the central resource doesn't use soft deletes
             // or the central resource was deleted using forceDelete()
             if ($forceDelete || ! in_array(SoftDeletes::class, class_uses_recursive($centralResource::class), true)) {
-                $centralResource->tenants()->detach(tenant());
+                $centralResource->{$relationshipName}()->detach(tenant());
             }
         });
     }

--- a/src/ResourceSyncing/Listeners/RestoreResourcesInTenants.php
+++ b/src/ResourceSyncing/Listeners/RestoreResourcesInTenants.php
@@ -24,7 +24,9 @@ class RestoreResourcesInTenants extends QueueableListener
             return;
         }
 
-        tenancy()->runForMultiple($centralResource->tenants()->cursor(), function () use ($centralResource) {
+        $relationshipName = $centralResource->getTenantsRelationshipName();
+
+        tenancy()->runForMultiple($centralResource->{$relationshipName}()->cursor(), function () use ($centralResource) {
             $tenantResourceClass = $centralResource->getTenantModelName();
             /**
              * @var Syncable $centralResource

--- a/src/ResourceSyncing/ResourceSyncing.php
+++ b/src/ResourceSyncing/ResourceSyncing.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Stancl\Tenancy\ResourceSyncing;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Stancl\Tenancy\Contracts\UniqueIdentifierGenerator;
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;

--- a/src/ResourceSyncing/ResourceSyncing.php
+++ b/src/ResourceSyncing/ResourceSyncing.php
@@ -105,12 +105,6 @@ trait ResourceSyncing
         return true;
     }
 
-    public function tenants(): BelongsToMany
-    {
-        return $this->morphToMany(config('tenancy.models.tenant'), 'tenant_resources', 'tenant_resources', 'resource_global_id', 'tenant_id', $this->getGlobalIdentifierKeyName())
-            ->using(TenantMorphPivot::class);
-    }
-
     public function getGlobalIdentifierKeyName(): string
     {
         return 'global_id';

--- a/src/ResourceSyncing/SyncMaster.php
+++ b/src/ResourceSyncing/SyncMaster.php
@@ -13,7 +13,6 @@ use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
  */
 interface SyncMaster extends Syncable
 {
-
     public function getTenantModelName(): string;
 
     /**

--- a/src/ResourceSyncing/SyncMaster.php
+++ b/src/ResourceSyncing/SyncMaster.php
@@ -6,7 +6,6 @@ namespace Stancl\Tenancy\ResourceSyncing;
 
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
 
 /**
@@ -14,12 +13,15 @@ use Stancl\Tenancy\Database\Contracts\TenantWithDatabase;
  */
 interface SyncMaster extends Syncable
 {
-    /**
-     * @return BelongsToMany<TenantWithDatabase&Model, self&Model>
-     */
-    public function tenants(): BelongsToMany;
 
     public function getTenantModelName(): string;
+
+    /**
+     * Should return the name of the relationship to the tenants table (e.g. 'tenants').
+     *
+     * In the class where this interface is implemented, the relationship method also has to be defined.
+     */
+    public function getTenantsRelationshipName(): string;
 
     public function triggerDetachEvent(TenantWithDatabase&Model $tenant): void;
 

--- a/tests/Etc/ResourceSyncing/CentralUser.php
+++ b/tests/Etc/ResourceSyncing/CentralUser.php
@@ -8,10 +8,13 @@ use Illuminate\Database\Eloquent\Model;
 use Stancl\Tenancy\Database\Concerns\CentralConnection;
 use Stancl\Tenancy\ResourceSyncing\ResourceSyncing;
 use Stancl\Tenancy\ResourceSyncing\SyncMaster;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Stancl\Tenancy\ResourceSyncing\TenantMorphPivot;
 
 class CentralUser extends Model implements SyncMaster
 {
     use ResourceSyncing, CentralConnection;
+
     protected $guarded = [];
 
     public $timestamps = false;
@@ -28,6 +31,19 @@ class CentralUser extends Model implements SyncMaster
     {
         return TenantUser::class;
     }
+
+    public function getTenantsRelationshipName(): string
+    {
+        return 'tenants';
+    }
+
+
+    public function tenants(): BelongsToMany
+    {
+        return $this->morphToMany(config('tenancy.models.tenant'), 'tenant_resources', 'tenant_resources', 'resource_global_id', 'tenant_id', $this->getGlobalIdentifierKeyName())
+            ->using(TenantMorphPivot::class);
+    }
+
 
     public function shouldSync(): bool
     {


### PR DESCRIPTION
Resource syncing only worked properly when the SyncMaster model had the `tenants()` relationship. Now, the SyncMaster model can use any name for the relationship, but it needs to be returned by the SyncMaster's `getTenantsRelationshipName()` method

In most cases, this method would return `tenants`, so now, a SyncMaster model would have these two extra methods :

```php
public function getTenantsRelationshipName(): string
{
        return 'tenants';
]


public function tenants(): BelongsToMany
{
        return $this->morphToMany(config('tenancy.models.tenant'), 'tenant_resources', 'tenant_resources', 'resource_global_id', 'tenant_id', $this->getGlobalIdentifierKeyName())
            ->using(TenantMorphPivot::class);
}
```

Before, these methods weren't needed to be added manually: it was assumed that the tenants relationship method was 'tenants', and the method was added to the SyncMaster class by the ResourceSyncing trait.