### PR TITLE
[4.x] Only revert initialized bootstrappers

### DIFF
--- a/src/Database/TenantDatabaseManagers/SQLiteDatabaseManager.php
+++ b/src/Database/TenantDatabaseManagers/SQLiteDatabaseManager.php
@@ -46,7 +46,7 @@ class SQLiteDatabaseManager implements TenantDatabaseManager
      * tenant instances passed to $closeInMemoryConnectionUsing closures,
      * if you're setting that property as well.
      *
-     * @property Closure(PDO, string)|null
+     * @var Closure(PDO, string)|null
      */
     public static Closure|null $persistInMemoryConnectionUsing = null;
 
@@ -59,7 +59,7 @@ class SQLiteDatabaseManager implements TenantDatabaseManager
      * NOTE: The parameter provided to the closure is the Tenant
      * instance, not a PDO connection.
      *
-     * @property Closure(Tenant)|null
+     * @var Closure(Tenant)|null
      */
     public static Closure|null $closeInMemoryConnectionUsing = null;
 

--- a/src/Listeners/BootstrapTenancy.php
+++ b/src/Listeners/BootstrapTenancy.php
@@ -20,6 +20,10 @@ class BootstrapTenancy
             $tenant = $event->tenancy->tenant;
 
             $bootstrapper->bootstrap($tenant);
+
+            if (! in_array($bootstrapper::class, $event->tenancy->initializedBootstrappers)) {
+                $event->tenancy->initializedBootstrappers[] = $bootstrapper::class;
+            }
         }
 
         event(new TenancyBootstrapped($event->tenancy));

--- a/src/Listeners/RevertToCentralContext.php
+++ b/src/Listeners/RevertToCentralContext.php
@@ -15,7 +15,9 @@ class RevertToCentralContext
         event(new RevertingToCentralContext($event->tenancy));
 
         foreach (array_reverse($event->tenancy->getBootstrappers()) as $bootstrapper) {
-            $bootstrapper->revert();
+            if (in_array($bootstrapper::class, $event->tenancy->initializedBootstrappers)) {
+                $bootstrapper->revert();
+            }
         }
 
         event(new RevertedToCentralContext($event->tenancy));

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -35,6 +35,18 @@ class Tenancy
      */
     public static array $findWith = [];
 
+    /**
+     * A list of bootstrappers that have been initialized.
+     *
+     * This is used when reverting tenancy, mainly if an exception
+     * occurs during bootstrapping, to ensure we don't revert
+     * bootstrappers that haven't been properly initialized
+     * (bootstrapped for the first time) previously.
+     *
+     * @property list<class-string<TenancyBootstrapper>>
+     */
+    public array $initializedBootstrappers = [];
+
     /** Initialize tenancy for the passed tenant. */
     public function initialize(Tenant|int|string $tenant): void
     {
@@ -192,7 +204,6 @@ class Tenancy
 
     /**
      * Run a callback for multiple tenants.
-     * More performant than running $tenant->run() one by one.
      *
      * @param array<Tenant>|array<string|int>|\Traversable|string|int|null $tenants
      */

--- a/src/Tenancy.php
+++ b/src/Tenancy.php
@@ -43,7 +43,9 @@ class Tenancy
      * bootstrappers that haven't been properly initialized
      * (bootstrapped for the first time) previously.
      *
-     * @property list<class-string<TenancyBootstrapper>>
+     * @internal
+     *
+     * @var list<class-string<TenancyBootstrapper>>
      */
     public array $initializedBootstrappers = [];
 

--- a/tests/InitializedBootstrappersTest.php
+++ b/tests/InitializedBootstrappersTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Illuminate\Support\Facades\Event;
+use Stancl\Tenancy\Contracts\TenancyBootstrapper;
+use Stancl\Tenancy\Contracts\Tenant;
+use Stancl\Tenancy\Events\TenancyEnded;
+use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Listeners\BootstrapTenancy;
+use Stancl\Tenancy\Listeners\RevertToCentralContext;
+use Stancl\Tenancy\Tests\Etc\Tenant as TenantModel;
+
+test('only bootstrappers that have been initialized are reverted', function () {
+    config(['tenancy.bootstrappers' => [
+        Initialized_DummyBootstrapperFoo::class,
+        Initialized_DummyBootstrapperBar::class,
+        Initialized_DummyBootstrapperBaz::class,
+    ]]);
+
+    Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
+    Event::listen(TenancyEnded::class, RevertToCentralContext::class);
+
+    // Only needs to be done in tests
+    app()->singleton(Initialized_DummyBootstrapperFoo::class);
+    app()->singleton(Initialized_DummyBootstrapperBar::class);
+    app()->singleton(Initialized_DummyBootstrapperBaz::class);
+
+    $tenant = TenantModel::create();
+
+    try {
+        $tenant->run(fn() => null);
+        // Should throw an exception
+        expect(true)->toBe(false);
+    } catch (Exception $e) {
+        // NOT 'baz fail in revert' as was the behavior before
+        // the commit that added this test
+        expect($e->getMessage())->toBe('bar fail in bootstrap');
+    }
+
+    expect(tenancy()->initializedBootstrappers)->toBe([
+        Initialized_DummyBootstrapperFoo::class,
+    ]);
+});
+
+class Initialized_DummyBootstrapperFoo implements TenancyBootstrapper
+{
+    public string $bootstrapped = 'uninitialized';
+
+    public function bootstrap(Tenant $tenant): void
+    {
+        $this->bootstrapped = 'bootstrapped';
+    }
+
+    public function revert(): void
+    {
+        $this->bootstrapped = 'reverted';
+    }
+}
+
+class Initialized_DummyBootstrapperBar implements TenancyBootstrapper
+{
+    public string $bootstrapped = 'uninitialized';
+
+    public function bootstrap(Tenant $tenant): void
+    {
+        throw new Exception('bar fail in bootstrap');
+    }
+
+    public function revert(): void
+    {
+        $this->bootstrapped = 'reverted';
+    }
+}
+
+class Initialized_DummyBootstrapperBaz implements TenancyBootstrapper
+{
+    public string $bootstrapped = 'uninitialized';
+
+    public function bootstrap(Tenant $tenant): void
+    {
+        $this->bootstrapped = 'bootstrapped';
+    }
+
+    public function revert(): void
+    {
+        throw new Exception('baz fail in revert');
+    }
+}


### PR DESCRIPTION
This PR adds the `Tenancy::initializedBootstrappers` property (singleton-scoped) which keeps track of which bootstrappers have been initialized (bootstrapped for the first time) and therefore can be reverted when calling `end()`.

## Bootstrapper considerations

This logic works with a few assumptions about tenancy bootstrappers (most of which the codebase already worked with but I'm specifically writing out this long PR description to spell them out):

1. Bootstrappers are stateful singletons
2. They're initialized *once* (constructor + first `bootstrap()` call, in terms of changes to object properties, are what's considered initialization here)
3. A common pattern is to do `$this->centralSomething ??= ...` in `bootstrap()`
4. Therefore, bootstrappers do not react to changes to central config/state in between tenancy "sessions"
5. Therefore, the `initializedBootstrappers` property is append-only, it doesn't track the state of bootstrappers "in the current tenancy session" but rather within the lifetime of the service container and all its singletons (`Tenancy` and the bootstrappers)
6. To keep bootstrappers simple, we track this externally, rather than requiring that every bootstrapper is reversible even without being bootstrapped
7. Bootstrappers can reliably expect `bootstrap()` only runs in the central context (+ any changes previous bootstrappers made as part of the bootstrapping process), and `revert()` only runs in the tenant context, and after `bootstrap()` has been run at least once

## Implementation considerations

I first wanted to make this an associative array so we could avoid the `in_array()` / pushing to an array logic, a hash table (`array<class-string<TenancyBootstrapper>, bool>`) is *theoretically* faster but since there's generally < 20 bootstrappers, it likely makes no difference at all and a simple list is more expressive.

## Background

Recently, I noticed that many support questions mentioned this exception:

```
   ErrorException 

  Undefined array key "local"

  at vendor/stancl/tenancy/src/Bootstrappers/FilesystemTenancyBootstrapper.php:122
    118▕ 
    119▕     protected function diskRoot(string $disk, Tenant|false $tenant): void
    120▕     {
    121▕         if ($tenant === false) {
  ➜ 122▕             $this->app['config']["filesystems.disks.$disk.root"] = $this->originalDisks[$disk]['root'];
    123▕ 
    124▕             return;
    125▕         }
    126▕ 
```

The intuitive immediate answer is that `local` is included in `tenancy.filesystem.disks` but not `filesystems.disks`. However the exception comes from the right side of the assignment — `originalDisk` has not been fully initialized.

If you look at the full stack trace, you can see something like:

```
  1   vendor/stancl/tenancy/src/Bootstrappers/FilesystemTenancyBootstrapper.php:122
      Illuminate\Foundation\Bootstrap\HandleExceptions::{closure:Illuminate\Foundation\Bootstrap\HandleExceptions::forwardsTo():255}("Undefined array key "local"", "/redacted/vendor/stancl/tenancy/src/Bootstrappers/FilesystemTenancyBootstrapper.php")

  2   vendor/stancl/tenancy/src/Bootstrappers/FilesystemTenancyBootstrapper.php:65
      Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper::diskRoot("local")

  3   vendor/stancl/tenancy/src/Listeners/RevertToCentralContext.php:18
      Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper::revert()
  4   vendor/stancl/tenancy/src/Tenancy.php:110

  5   vendor/stancl/tenancy/src/Tenancy.php:93
      Stancl\Tenancy\Tenancy::end()

  6   vendor/stancl/tenancy/src/Bootstrappers/DatabaseTenancyBootstrapper.php:39
      Stancl\Tenancy\Database\Exceptions\TenantDatabaseDoesNotExistException::("Database tenantfoo does not exist.")
```

There's an exception thrown in frame 6, which then leads to the exception in `FilesystemTenancyBootstrapper`. The lines of `Tenancy` are the `run()` function, which does:
```php
try {
    $this->initialize($tenant);
    $result = $callback($tenant);
} finally {
    if ($result instanceof PendingDispatch) { // #1277
        $result = null;
    }

    if ($originalTenant) {
        $this->initialize($originalTenant);
    } else {
        $this->end();
    }
}
```

An exception occurs in the `try` block (during initialization), so we try to revert back to the original context, calling `end()` (either directly or via the other `initialize()` call), however that triggers *a different* exception.

The issue is that bootstrappers that haven't been fully initialized yet (first `bootstrap()` call) are being reverted in the `end()` call. The solution is to only revert bootstrappers that have been initialized.