### PR TITLE
[4.x] Use --database in tenants:migrate as the template connection

### DIFF
--- a/src/Commands/Migrate.php
+++ b/src/Commands/Migrate.php
@@ -58,12 +58,12 @@ class Migrate extends MigrateCommand
         }
 
         if ($this->getProcesses() > 1) {
-            return $this->runConcurrently($this->getTenantChunks()->map(function ($chunk) {
+            $code = $this->runConcurrently($this->getTenantChunks()->map(function ($chunk) {
                 return $this->getTenants($chunk);
             }));
+        } else {
+            $code = $this->migrateTenants($this->getTenants()) ? 0 : 1;
         }
-
-        $code = $this->migrateTenants($this->getTenants()) ? 0 : 1;
 
         // Reset the template tenant connection to the original one
         config(['tenancy.database.template_tenant_connection' => $originalTemplateConnection]);


### PR DESCRIPTION
This PR makes the `tenants:migrate` command read the `--database` option, and when the option is passed, use that database connection name as the template for the tenant connection _while migrating the tenant DBs_. (feature requested on Discord https://discord.com/channels/976506366502006874/976506701782069308/1348777081164660818). After `tenants:migrate` gets executed, the tenant template connection gets restored back to the default.

For example, `tenants:migrate --database='foo'` will use the 'foo' connection as the template for the tenant connection (= the `tenancy.database.template_tenant_connection` will be set to `foo`), and after the command finishes running, the `tenancy.database.template_tenant_connection` config will be set back to its default value (e.g. `null`).