### PR TITLE
[4.x] Correct `DomainTenantResolver::isSubdomain()` check

### DIFF
--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -7,13 +7,13 @@ namespace Stancl\Tenancy\Resolvers;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use Stancl\Tenancy\Contracts\Domain;
 use Stancl\Tenancy\Contracts\SingleDomainTenant;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedOnDomainException;
 use Stancl\Tenancy\Tenancy;
-use Illuminate\Support\Arr;
 
 class DomainTenantResolver extends Contracts\CachedTenantResolver
 {

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -13,6 +13,7 @@ use Stancl\Tenancy\Contracts\SingleDomainTenant;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Exceptions\TenantCouldNotBeIdentifiedOnDomainException;
 use Stancl\Tenancy\Tenancy;
+use Illuminate\Support\Arr;
 
 class DomainTenantResolver extends Contracts\CachedTenantResolver
 {
@@ -58,7 +59,19 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
 
     public static function isSubdomain(string $domain): bool
     {
-        return Str::endsWith($domain, config('tenancy.identification.central_domains'));
+        $centralDomains = Arr::wrap(config('tenancy.identification.central_domains'));
+
+        foreach ($centralDomains as $centralDomain) {
+            if ($domain === $centralDomain) {
+                return false;
+            }
+
+            if (Str::endsWith($domain, '.' . $centralDomain)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     public function resolved(Tenant $tenant, mixed ...$args): void

--- a/src/Resolvers/DomainTenantResolver.php
+++ b/src/Resolvers/DomainTenantResolver.php
@@ -61,11 +61,11 @@ class DomainTenantResolver extends Contracts\CachedTenantResolver
     {
         $centralDomains = Arr::wrap(config('tenancy.identification.central_domains'));
 
-        foreach ($centralDomains as $centralDomain) {
-            if ($domain === $centralDomain) {
-                return false;
-            }
+        if (in_array($domain, $centralDomains, true)) {
+            return false;
+        }
 
+        foreach ($centralDomains as $centralDomain) {
             if (Str::endsWith($domain, '.' . $centralDomain)) {
                 return true;
             }

--- a/tests/EarlyIdentificationTest.php
+++ b/tests/EarlyIdentificationTest.php
@@ -300,7 +300,7 @@ test('using different default route modes works with global domain identificatio
         $exception = match ($middleware) {
             InitializeTenancyByDomain::class => TenantCouldNotBeIdentifiedOnDomainException::class,
             InitializeTenancyBySubdomain::class => NotASubdomainException::class,
-            InitializeTenancyByDomainOrSubdomain::class => NotASubdomainException::class,
+            InitializeTenancyByDomainOrSubdomain::class => TenantCouldNotBeIdentifiedOnDomainException::class,
         };
 
         expect(fn () => $this->withoutExceptionHandling()->get('http://localhost/central-route'))->toThrow($exception);

--- a/tests/SubdomainTest.php
+++ b/tests/SubdomainTest.php
@@ -7,6 +7,7 @@ use Stancl\Tenancy\Database\Concerns\HasDomains;
 use Stancl\Tenancy\Exceptions\NotASubdomainException;
 use Stancl\Tenancy\Middleware\InitializeTenancyBySubdomain;
 use Stancl\Tenancy\Database\Models;
+use Stancl\Tenancy\Resolvers\DomainTenantResolver;
 use function Stancl\Tenancy\Tests\pest;
 
 beforeEach(function () {
@@ -106,6 +107,13 @@ test('we cant use a subdomain that doesnt belong to our central domains', functi
     $this
         ->withoutExceptionHandling()
         ->get('http://foo.localhost/foo/abc/xyz');
+});
+
+test('domain resolver correctly determines if string is a subdomain', function() {
+    config(['tenancy.identification.central_domains' => ['app.test']]);
+
+    expect(DomainTenantResolver::isSubdomain('foo.app.test'))->toBeTrue();
+    expect(DomainTenantResolver::isSubdomain('fooapp.test'))->toBeFalse();
 });
 
 class SubdomainTenant extends Models\Tenant

--- a/tests/SubdomainTest.php
+++ b/tests/SubdomainTest.php
@@ -110,10 +110,11 @@ test('we cant use a subdomain that doesnt belong to our central domains', functi
 });
 
 test('domain resolver correctly determines if string is a subdomain', function() {
-    config(['tenancy.identification.central_domains' => ['app.test']]);
+    config(['tenancy.identification.central_domains' => ['site.com', 'blog.site.com']]);
 
-    expect(DomainTenantResolver::isSubdomain('foo.app.test'))->toBeTrue();
-    expect(DomainTenantResolver::isSubdomain('fooapp.test'))->toBeFalse();
+    expect(DomainTenantResolver::isSubdomain('blog.site.com'))->toBeFalse();
+    expect(DomainTenantResolver::isSubdomain('tenant.site.com'))->toBeTrue();
+    expect(DomainTenantResolver::isSubdomain('tenantsite.com'))->toBeFalse();
 });
 
 class SubdomainTenant extends Models\Tenant


### PR DESCRIPTION
Added a failing test for determining if a host is a subdomain, then fixed `DomainTenantResolver::isSubdomain()` (similar fix as in #1423) and a related assertion.

Previously, while having `tenancy.identification.central_domains` set to e.g. `['site.com']`, the `isSubdomain()` check consider `tenantsite.com` a subdomain because it ends with `site.com`. Now, instead of the `endsWith()` check, the method checks if the passed domain is in the configured central domains. If it is, it returns `false`. Otherwise, loop through all the central domains and check if the passed domain matches any of the central domains prefixed with a dot (e.g. `tenant.site.com` would be considered a subdomain, `tenant.site.com` wouldn't).

Because in InitializeTenancyByDomainOrSubdomain, if tenancy fails to initialize using a subdomain (before this PR's changes, e.g. `tenantsite.com` would be considered a subdomain, and `tenantsite` would be used for initializing tenancy), it'll catch the exception and use the whole domain for identification instead, this error will likely never be noticed in real-world usage. So this PR corrects the subdomain detection logic, but the real-world impact of that is negligible.

> Note: The subdomain error catching logic in domainOrSubdomain ID MW was added in v4. If we applied this change in v3, it'd fix a real issue where domainOrSubdomain ID MW would just fail at the subdomain initialization, without attempting domain initialization after the failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed domain identification so central domains are not misclassified as tenant subdomains and multiple central domains are handled correctly.
* **Tests**
  * Added and adjusted tests to verify subdomain detection and updated expectations for domain-based identification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->