### PR TITLE
[4x] Remove redundant universal route check from PreventAccess MW

### DIFF
--- a/src/Middleware/PreventAccessFromUnwantedDomains.php
+++ b/src/Middleware/PreventAccessFromUnwantedDomains.php
@@ -31,7 +31,7 @@ class PreventAccessFromUnwantedDomains
     {
         $route = tenancy()->getRoute($request);
 
-        if ($this->shouldBeSkipped($route) || tenancy()->routeIsUniversal($route)) {
+        if ($this->shouldBeSkipped($route)) {
             return $next($request);
         }
 

--- a/src/Middleware/PreventAccessFromUnwantedDomains.php
+++ b/src/Middleware/PreventAccessFromUnwantedDomains.php
@@ -35,6 +35,8 @@ class PreventAccessFromUnwantedDomains
             return $next($request);
         }
 
+        // If the route is universal, neither of these checks will pass and the logic will
+        // fall through to the $next($request) call at the end.
         if ($this->accessingTenantRouteFromCentralDomain($request, $route) || $this->accessingCentralRouteFromTenantDomain($request, $route)) {
             $abortRequest = static::$abortRequest ?? function () {
                 abort(404);


### PR DESCRIPTION
The PreventAcessFromUnwantedDomains MW had the `tenancy()->routeIsUniversal($route)` check either for returning early, or it was a leftover from some older implementation, so I removed it.

The middleware aborts if the `$this->accessingTenantRouteFromCentralDomain($request, $route) || $this->accessingCentralRouteFromTenantDomain($request, $route)` check passes. Meaning, **for the middleware to abort, the route has to be either in central or tenant mode**. When the route is in universal mode, the middleware will never reach `return $abortRequest()`. `return $next($request)` will always get reached, even when the `|| tenancy()->routeIsUniversal($route)` check is deleted from the previous condition, so that check was basically useless.

Since the docblock for the class does mention the behavior for universal routes explicitly, we've instead added a comment documenting that things work this way. That's probably the most reasonable way to have this explicit behavior for universal routes easily understandable in this fairly complex logic without redundant code.

Resolves #1418

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Domain access checks are now applied consistently, including routes that were previously skipped, ensuring tenant vs. central domain restrictions are enforced and preventing unauthorized access that could bypass protections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/archtechx/tenancy/pull/1427)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->