### PR TITLE
[4.x] Add charset support to PostgreSQLDatabaseManager

### DIFF
--- a/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -11,10 +11,9 @@ class PostgreSQLDatabaseManager extends TenantDatabaseManager
     public function createDatabase(TenantWithDatabase $tenant): bool
     {
         $database = $tenant->database()->getName();
-        $charset = $this->connection()->getConfig('charset');
-        $collation = $this->connection()->getConfig('collation');
+        $charset = strtoupper($this->connection()->getConfig('charset') ?? 'UTF8');
 
-        return $this->connection()->statement("CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0 ENCODING='{$charset}' LC_COLLATE='{$collation}' LC_CTYPE='{$collation}'");
+        return $this->connection()->statement("CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0 ENCODING='{$charset}'");
     }
 
     public function deleteDatabase(TenantWithDatabase $tenant): bool

--- a/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -10,7 +10,11 @@ class PostgreSQLDatabaseManager extends TenantDatabaseManager
 {
     public function createDatabase(TenantWithDatabase $tenant): bool
     {
-        return $this->connection()->statement("CREATE DATABASE \"{$tenant->database()->getName()}\" WITH TEMPLATE=template0");
+        $database = $tenant->database()->getName();
+        $charset = $this->connection()->getConfig('charset');
+        $collation = $this->connection()->getConfig('collation');
+
+        return $this->connection()->statement("CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0 ENCODING='{$charset}' LC_COLLATE='{$collation}' LC_CTYPE='{$collation}'");
     }
 
     public function deleteDatabase(TenantWithDatabase $tenant): bool

--- a/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -11,9 +11,16 @@ class PostgreSQLDatabaseManager extends TenantDatabaseManager
     public function createDatabase(TenantWithDatabase $tenant): bool
     {
         $database = $tenant->database()->getName();
-        $charset = strtoupper($this->connection()->getConfig('charset') ?? 'UTF8');
+        // If null, Postgres creates the DB with the server's default charset
+        $charset = $this->connection()->getConfig('charset');
 
-        return $this->connection()->statement("CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0 ENCODING='{$charset}'");
+        $query = "CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0";
+
+        if ($charset !== null) {
+            $query .= " ENCODING='" . strtoupper($charset) . "'";
+        }
+
+        return $this->connection()->statement($query);
     }
 
     public function deleteDatabase(TenantWithDatabase $tenant): bool

--- a/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
+++ b/src/Database/TenantDatabaseManagers/PostgreSQLDatabaseManager.php
@@ -11,16 +11,17 @@ class PostgreSQLDatabaseManager extends TenantDatabaseManager
     public function createDatabase(TenantWithDatabase $tenant): bool
     {
         $database = $tenant->database()->getName();
+
         // If null, Postgres creates the DB with the server's default charset
         $charset = $this->connection()->getConfig('charset');
 
-        $query = "CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0";
+        $statement = "CREATE DATABASE \"{$database}\" WITH TEMPLATE=template0";
 
         if ($charset !== null) {
-            $query .= " ENCODING='" . strtoupper($charset) . "'";
+            $statement .= " ENCODING='{$charset}'";
         }
 
-        return $this->connection()->statement($query);
+        return $this->connection()->statement($statement);
     }
 
     public function deleteDatabase(TenantWithDatabase $tenant): bool

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -539,6 +539,43 @@ test('partial tenant connection templates get merged into the central connection
     expect($manager->connection()->getConfig('url'))->toBeNull();
 });
 
+test('newly created postgres databases use the correct charset', function (string|null $charset) {
+    config([
+        'tenancy.database.managers.pgsql' => PostgreSQLDatabaseManager::class,
+        'database.connections.pgsql.charset' => $charset, // If null, Postgres creates the DB with the server's default charset
+    ]);
+
+    // Purge connection to make sure the updated charset config is used
+    DB::purge('pgsql');
+
+    Event::listen(TenantCreated::class, JobPipeline::make([CreateDatabase::class])->send(function (TenantCreated $event) {
+        return $event->tenant;
+    })->toListener());
+
+    $tenant = Tenant::create([
+        'tenancy_db_connection' => 'pgsql',
+    ]);
+
+    $databaseName = $tenant->database()->getName();
+
+    // Postgres server's default charset (utf8)
+    $serverCharset = DB::connection('pgsql')
+        ->selectOne("SELECT pg_encoding_to_char(encoding) AS encoding FROM pg_database WHERE datname = 'template1'")
+        ->encoding;
+
+    // Charset of the newly created tenant database
+    $dbCharset = DB::connection('pgsql')
+        ->selectOne('SELECT pg_encoding_to_char(encoding) AS encoding FROM pg_database WHERE datname = ?', [$databaseName])
+        ->encoding;
+
+    $expectedCharset = $charset !== null ? strtoupper($charset) : $serverCharset;
+
+    expect($dbCharset)->toBe($expectedCharset);
+})->with([
+    null,
+    'utf8',
+]);
+
 // Datasets
 dataset('database_managers', [
     ['mysql', MySQLDatabaseManager::class],

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -558,7 +558,7 @@ test('newly created postgres databases use the correct charset', function (strin
 
     $databaseName = $tenant->database()->getName();
 
-    // Postgres server's default charset (utf8)
+    // Postgres server's default charset
     $serverCharset = DB::connection('pgsql')
         ->selectOne("SELECT pg_encoding_to_char(encoding) AS encoding FROM pg_database WHERE datname = 'template1'")
         ->encoding;

--- a/tests/TenantDatabaseManagerTest.php
+++ b/tests/TenantDatabaseManagerTest.php
@@ -568,12 +568,17 @@ test('newly created postgres databases use the correct charset', function (strin
         ->selectOne('SELECT pg_encoding_to_char(encoding) AS encoding FROM pg_database WHERE datname = ?', [$databaseName])
         ->encoding;
 
-    $expectedCharset = $charset !== null ? strtoupper($charset) : $serverCharset;
+    if ($charset) {
+        expect($dbCharset)->toBe(strtoupper($charset));
+    } else {
+        expect($dbCharset)->toBe($serverCharset);
 
-    expect($dbCharset)->toBe($expectedCharset);
+        // Server charset should be UTF8 by default
+        expect($dbCharset)->toBe('UTF8');
+    }
 })->with([
     null,
-    'utf8',
+    'latin1',
 ]);
 
 // Datasets


### PR DESCRIPTION
## Problem

The `PostgreSQLDatabaseManager` creates tenant databases without specifying encoding, unlike `MySQLDatabaseManager` which respects the connection's charset configuration.

When encoding is not explicitly defined, PostgreSQL uses the server's default encoding (inherited from `template0`). This causes issues on systems where the default encoding differs from the application's expected encoding:

- **Windows systems** often default to `WIN1252` encoding
- **Some Linux configurations** may use `LATIN1` or other regional encodings
- **Docker containers** may have different defaults depending on the base image

This mismatch leads to errors like:
`SQLSTATE[22P05]: Untranslatable character: 7 ERROR: character with byte sequence 0xe2 0x86 0x92 in encoding "UTF8" has no equivalent in encoding "WIN1252"`


## Solution

Follow the same pattern as `MySQLDatabaseManager` by reading the `charset` value from the database connection configuration and applying them when creating tenant databases.

## Changes

- Read `charset` value from the connection config
- Apply `ENCODING` parameter to the CREATE DATABASE statement

## Configuration

Users can now control the encoding via their `config/database.php`:

```php
'pgsql' => [
    // ...
    'charset' => 'UTF8',
],
```

**Notes**
- Maintains consistency with 
- MySQLDatabaseManager.php
-  implementation
- template0 is required (already in use) to allow encoding override
- Backward compatible for users who already have charset configured

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database creation now conditionally includes the configured character encoding: tenant databases use the specified encoding when set, otherwise they inherit the server default.

* **Tests**
  * Added parameterized tests verifying tenant databases are created with the expected encoding for both configured charset and null (unset) scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->