### PR TITLE
[4.x] UserImpersonation: store auth guard in session, add `$logout` param to `stopImpersonating()`

### DIFF
--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -81,7 +81,13 @@ class UserImpersonation implements Feature
     }
 
     /**
-     * Logout from the current domain and forget impersonation session.
+     * Stop user impersonation by forgetting the impersonation session.
+     *
+     * When $logout is true, the user will also be logged out
+     * from the impersonation guard stored in the session.
+     *
+     * Throws an exception if impersonation is not active
+     * (= the impersonation guard is not in the session).
      */
     public static function stopImpersonating(bool $logout = true): void
     {

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Stancl\Tenancy\Features;
 
+use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
@@ -11,7 +12,6 @@ use Stancl\Tenancy\Contracts\Feature;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Database\Models\ImpersonationToken;
 use Stancl\Tenancy\Tenancy;
-use Exception;
 
 class UserImpersonation implements Feature
 {

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -11,6 +11,7 @@ use Stancl\Tenancy\Contracts\Feature;
 use Stancl\Tenancy\Contracts\Tenant;
 use Stancl\Tenancy\Database\Models\ImpersonationToken;
 use Stancl\Tenancy\Tenancy;
+use Exception;
 
 class UserImpersonation implements Feature
 {
@@ -84,6 +85,10 @@ class UserImpersonation implements Feature
      */
     public static function stopImpersonating(bool $logout = true): void
     {
+        if (! static::isImpersonating()) {
+            throw new Exception('Not currently impersonating any user.');
+        }
+
         if ($logout) {
             $guard = session()->get('tenancy_impersonation_guard');
 

--- a/src/Features/UserImpersonation.php
+++ b/src/Features/UserImpersonation.php
@@ -61,9 +61,9 @@ class UserImpersonation implements Feature
 
         Auth::guard($token->auth_guard)->loginUsingId($token->user_id, $token->remember);
 
-        $token->delete();
+        session()->put('tenancy_impersonation_guard', $token->auth_guard);
 
-        session()->put('tenancy_impersonating', true);
+        $token->delete();
 
         return redirect($token->redirect_url);
     }
@@ -76,16 +76,20 @@ class UserImpersonation implements Feature
 
     public static function isImpersonating(): bool
     {
-        return session()->has('tenancy_impersonating');
+        return session()->has('tenancy_impersonation_guard');
     }
 
     /**
      * Logout from the current domain and forget impersonation session.
      */
-    public static function stopImpersonating(): void
+    public static function stopImpersonating(bool $logout = true): void
     {
-        auth()->logout();
+        if ($logout) {
+            $guard = session()->get('tenancy_impersonation_guard');
 
-        session()->forget('tenancy_impersonating');
+            auth($guard)->logout();
+        }
+
+        session()->forget('tenancy_impersonation_guard');
     }
 }

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -191,7 +191,7 @@ test('stopImpersonating can keep the user authenticated', function() {
         ->assertSee('You are logged in as Joe');
 });
 
-test('stopImpersonating logs out the user from tenancy_impersonation_guard stored in session', function() {
+test('stopImpersonating logs out the user from the impersonation guard stored in session', function() {
     Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
 
     $tenant = Tenant::create([

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -148,6 +148,47 @@ test('tenant user can be impersonated on a tenant path', function () {
         ->assertRedirect('/login');
 });
 
+test('stopImpersonating can keep the user authenticated', function() {
+    makeLoginRoute();
+
+    Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
+
+    $tenant = Tenant::create([
+        'id' => 'acme',
+        'tenancy_db_name' => 'db' . Str::random(16),
+    ]);
+
+    migrateTenants();
+
+    $user = $tenant->run(function () {
+        return ImpersonationUser::create([
+            'name' => 'Joe',
+            'email' => 'joe@local',
+            'password' => bcrypt('secret'),
+        ]);
+    });
+
+    // Impersonate the user
+    $token = tenancy()->impersonate($tenant, $user->id, '/acme/dashboard');
+
+    pest()->get('/acme/impersonate/' . $token->token)
+        ->assertRedirect('/acme/dashboard');
+
+    expect(UserImpersonation::isImpersonating())->toBeTrue();
+
+    // Stop impersonating without logging out
+    UserImpersonation::stopImpersonating(false);
+
+    // The impersonation session key should be cleared
+    expect(UserImpersonation::isImpersonating())->toBeFalse();
+    expect(session('tenancy_impersonation_guard'))->toBeNull();
+
+    // The user should still be authenticated
+    pest()->get('/acme/dashboard')
+        ->assertSuccessful()
+        ->assertSee('You are logged in as Joe');
+});
+
 test('tokens have a limited ttl', function () {
     Route::middleware(InitializeTenancyByDomain::class)->group(getRoutes());
 

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -89,7 +89,8 @@ test('tenant user can be impersonated on a tenant domain', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonation_guard'))->toBe($token->auth_guard);
+    expect(session('tenancy_impersonation_guard'))->toBe('web');
+    expect($token->auth_guard)->toBe('web');
 
     // Leave impersonation
     UserImpersonation::stopImpersonating();
@@ -135,7 +136,8 @@ test('tenant user can be impersonated on a tenant path', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonation_guard'))->toBe($token->auth_guard);
+    expect(session('tenancy_impersonation_guard'))->toBe('web');
+    expect($token->auth_guard)->toBe('web');
 
     // Leave impersonation
     UserImpersonation::stopImpersonating();

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -234,6 +234,14 @@ test('stopImpersonating logs out the user from tenancy_impersonation_guard store
 
     expect(auth('web')->check())->toBeFalse();
     expect(auth('test')->check())->toBeTrue();
+
+    expect(UserImpersonation::isImpersonating())->toBeFalse();
+
+    // tenancy_impersonation_guard isn't in the session anymore,
+    // stopImpersonating should throw an exception instead of logging out
+    expect(fn() => UserImpersonation::stopImpersonating())->toThrow(Exception::class);
+
+    expect(auth()->check())->toBeTrue();
 });
 
 test('tokens have a limited ttl', function () {

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -191,6 +191,50 @@ test('stopImpersonating can keep the user authenticated', function() {
         ->assertSee('You are logged in as Joe');
 });
 
+test('stopImpersonating logs out the user from the guard used while starting impersonation', function() {
+    Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
+
+    $tenant = Tenant::create([
+        'id' => 'acme',
+        'tenancy_db_name' => 'db' . Str::random(16),
+    ]);
+
+    migrateTenants();
+
+    $user = $tenant->run(function () {
+        return ImpersonationUser::create([
+            'name' => 'Joe',
+            'email' => 'joe@local',
+            'password' => bcrypt('secret'),
+        ]);
+    });
+
+    // Impersonate the user
+    $token = tenancy()->impersonate($tenant, $user->id, '/acme/dashboard');
+
+    pest()->get('/acme/impersonate/' . $token->token)
+        ->assertRedirect('/acme/dashboard');
+
+    expect(session('tenancy_impersonation_guard'))->toBe('web');
+
+    // Impersonation logged in the user using the current guard ('web')
+    expect(auth('web')->check())->toBeTrue();
+
+    config(['auth.guards.test' => [
+        'driver' => 'session',
+        'provider' => 'users',
+    ]]);
+
+    // Manually log in the user using a different guard
+    auth('test')->loginUsingId($user->id);
+
+    // Should log out the user from the guard used for impersonation ('web')
+    UserImpersonation::stopImpersonating();
+
+    expect(auth('web')->check())->toBeFalse();
+    expect(auth('test')->check())->toBeTrue();
+});
+
 test('tokens have a limited ttl', function () {
     Route::middleware(InitializeTenancyByDomain::class)->group(getRoutes());
 

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -191,7 +191,7 @@ test('stopImpersonating can keep the user authenticated', function() {
         ->assertSee('You are logged in as Joe');
 });
 
-test('stopImpersonating logs out the user from the guard used while starting impersonation', function() {
+test('stopImpersonating logs out the user from tenancy_impersonation_guard stored in session', function() {
     Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
 
     $tenant = Tenant::create([
@@ -225,8 +225,9 @@ test('stopImpersonating logs out the user from the guard used while starting imp
         'provider' => 'users',
     ]]);
 
-    // Manually log in the user using a different guard
-    auth('test')->loginUsingId($user->id);
+    // Switch guard from 'web' to 'test' and manually log in the user through 'test'
+    auth()->shouldUse('test');
+    auth()->loginUsingId($user->id);
 
     // Should log out the user from the guard used for impersonation ('web')
     UserImpersonation::stopImpersonating();

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -89,13 +89,13 @@ test('tenant user can be impersonated on a tenant domain', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonating'))->toBeTrue();
+    expect(session('tenancy_impersonation_guard'))->toBe($token->auth_guard);
 
     // Leave impersonation
     UserImpersonation::stopImpersonating();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
-    expect(session('tenancy_impersonating'))->toBeNull();
+    expect(session('tenancy_impersonation_guard'))->toBeNull();
 
     // Assert can't access the tenant dashboard
     pest()->get('http://foo.localhost/dashboard')
@@ -135,13 +135,13 @@ test('tenant user can be impersonated on a tenant path', function () {
         ->assertSee('You are logged in as Joe');
 
     expect(UserImpersonation::isImpersonating())->toBeTrue();
-    expect(session('tenancy_impersonating'))->toBeTrue();
+    expect(session('tenancy_impersonation_guard'))->toBe($token->auth_guard);
 
     // Leave impersonation
     UserImpersonation::stopImpersonating();
 
     expect(UserImpersonation::isImpersonating())->toBeFalse();
-    expect(session('tenancy_impersonating'))->toBeNull();
+    expect(session('tenancy_impersonation_guard'))->toBeNull();
 
     // Assert can't access the tenant dashboard
     pest()->get('/acme/dashboard')

--- a/tests/TenantUserImpersonationTest.php
+++ b/tests/TenantUserImpersonationTest.php
@@ -150,7 +150,7 @@ test('tenant user can be impersonated on a tenant path', function () {
         ->assertRedirect('/login');
 });
 
-test('stopImpersonating can keep the user authenticated', function() {
+test('stopImpersonating can keep the user authenticated', function () {
     makeLoginRoute();
 
     Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
@@ -191,7 +191,7 @@ test('stopImpersonating can keep the user authenticated', function() {
         ->assertSee('You are logged in as Joe');
 });
 
-test('stopImpersonating logs out the user from the impersonation guard stored in session', function() {
+test('stopImpersonating logs out the user from the impersonation guard stored in session', function () {
     Route::middleware(InitializeTenancyByPath::class)->prefix('/{tenant}')->group(getRoutes(false));
 
     $tenant = Tenant::create([
@@ -225,11 +225,10 @@ test('stopImpersonating logs out the user from the impersonation guard stored in
         'provider' => 'users',
     ]]);
 
-    // Switch guard from 'web' to 'test' and manually log in the user through 'test'
-    auth()->shouldUse('test');
-    auth()->loginUsingId($user->id);
+    // Manually log the user in through the 'test' guard
+    auth('test')->loginUsingId($user->id);
 
-    // Should log out the user from the guard used for impersonation ('web')
+    // Should log the user out from the guard used for impersonation ('web')
     UserImpersonation::stopImpersonating();
 
     expect(auth('web')->check())->toBeFalse();
@@ -241,7 +240,7 @@ test('stopImpersonating logs out the user from the impersonation guard stored in
     // stopImpersonating should throw an exception instead of logging out
     expect(fn() => UserImpersonation::stopImpersonating())->toThrow(Exception::class);
 
-    expect(auth()->check())->toBeTrue();
+    expect(auth('test')->check())->toBeTrue();
 });
 
 test('tokens have a limited ttl', function () {


### PR DESCRIPTION
> Minor breaking change: `session('tenancy_impersonating')` doesn't work anymore. We're using `session('tenancy_impersonation_guard')` instead.

The 'tenancy_impersonating' session variable got replaced by 'tenancy_impersonation_guard'. `UserImpersonation::stopImpersonating()` now calls `logout()` on the guard retrieved by `session()->get('tenancy_impersonation_guard')` instead of calling `logout()` on the _current_ auth guard. Now. if you create the impersonation token with guard 'web', and call `UserImpersonation::stopImpersonating()`, for example in a route that has the `auth:sanctum` middleware (= the current guard in that route would be `RequestGuard` which doesn't even have the `logout()` method -- not the guard for which the impersonation token was created), the method will correctly log the user out of the 'web' guard using which he was actually authenticated instead of the current guard of the visited route (which doesn't have to be the same guard for which impersonation started).

`UserImpersonation::stopImpersonating()` now also accepts the `$logout` parameter, which is `true` by default. If `false` is passed, the method just forgets `tenancy_impersonation_guard` from session without logging out.

`UserImpersonation::stopImpersonating()` now throws an exception if impersonation wasn't active at the point of calling the method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Impersonation now records which authentication guard is active. Stopping impersonation can optionally preserve the current session or log out only the impersonation guard; attempting to stop when not impersonating now raises an error.

* **Tests**
  * Updated and added tests to verify guard-aware impersonation state, optional logout behavior, and logout isolation across guards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->