### PR TITLE
[4.x] Create pending tenants with pending_since, improve --with-pending

### DIFF
--- a/src/Concerns/HasTenantOptions.php
+++ b/src/Concerns/HasTenantOptions.php
@@ -18,7 +18,7 @@ trait HasTenantOptions
     {
         return array_merge([
            new InputOption('tenants', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'The tenants to run this command for. Leave empty for all tenants', null),
-           new InputOption('with-pending', null, InputOption::VALUE_NONE, 'Include pending tenants in query'), // todo@pending should we also offer without-pending? if we add this, mention in docs
+           new InputOption('with-pending', null, InputOption::VALUE_OPTIONAL, 'Include pending tenants in query if true/1, exclude if false/0. Defaults to the tenancy.pending.include_in_queries config value.'), // todo@pending mention in docs
         ], parent::getOptions());
     }
 
@@ -43,7 +43,11 @@ trait HasTenantOptions
                 $query->whereIn(tenancy()->model()->getTenantKeyName(), $this->option('tenants'));
             })
             ->when(tenancy()->model()::hasGlobalScope(PendingScope::class), function ($query) {
-                $query->withPending(config('tenancy.pending.include_in_queries') ?: $this->option('with-pending'));
+                $includePending = $this->input->hasParameterOption('--with-pending')
+                    ? filter_var($this->option('with-pending') ?? true, FILTER_VALIDATE_BOOLEAN)
+                    : config('tenancy.pending.include_in_queries');
+
+                $query->withPending($includePending);
             });
     }
 

--- a/src/Concerns/HasTenantOptions.php
+++ b/src/Concerns/HasTenantOptions.php
@@ -18,7 +18,7 @@ trait HasTenantOptions
     {
         return array_merge([
            new InputOption('tenants', null, InputOption::VALUE_IS_ARRAY|InputOption::VALUE_OPTIONAL, 'The tenants to run this command for. Leave empty for all tenants', null),
-           new InputOption('with-pending', null, InputOption::VALUE_OPTIONAL, 'Include pending tenants in query if true/1, exclude if false/0. Defaults to the tenancy.pending.include_in_queries config value.'), // todo@pending mention in docs
+           new InputOption('with-pending', null, InputOption::VALUE_OPTIONAL, 'Include pending tenants in query if true/1, exclude if false/0. Defaults to the tenancy.pending.include_in_queries config value.'),
         ], parent::getOptions());
     }
 

--- a/src/Database/Concerns/HasPending.php
+++ b/src/Database/Concerns/HasPending.php
@@ -49,18 +49,15 @@ trait HasPending
      */
     public static function createPending(array $attributes = []): Model&Tenant
     {
-        $tenant = null;
+        $tenant = static::make(array_merge(
+            ['pending_since' => now()->timestamp],
+            static::getPendingAttributes($attributes),
+            $attributes
+        ));
 
-        try {
-            $tenant = static::create(array_merge(static::getPendingAttributes($attributes), $attributes));
-            event(new CreatingPendingTenant($tenant));
-        } finally {
-            // Update the pending_since value only after the tenant is created so it's
-            // not marked as pending until after migrations, seeders, etc are run.
-            $tenant?->update([
-                'pending_since' => now()->timestamp,
-            ]);
-        }
+        event(new CreatingPendingTenant($tenant));
+
+        $tenant->save();
 
         event(new PendingTenantCreated($tenant));
 

--- a/src/Database/Concerns/HasPending.php
+++ b/src/Database/Concerns/HasPending.php
@@ -28,6 +28,18 @@ trait HasPending
     public static function bootHasPending(): void
     {
         static::addGlobalScope(new PendingScope());
+
+        static::creating(function (self $tenant): void {
+            if ($tenant->pending()) {
+                event(new CreatingPendingTenant($tenant));
+            }
+        });
+
+        static::created(function (self $tenant): void {
+            if ($tenant->pending()) {
+                event(new PendingTenantCreated($tenant));
+            }
+        });
     }
 
     /** Initialize the trait. */
@@ -49,19 +61,11 @@ trait HasPending
      */
     public static function createPending(array $attributes = []): Model&Tenant
     {
-        $tenant = static::make(array_merge(
+        return static::create(array_merge(
             ['pending_since' => now()->timestamp],
             static::getPendingAttributes($attributes),
             $attributes
         ));
-
-        event(new CreatingPendingTenant($tenant));
-
-        $tenant->save();
-
-        event(new PendingTenantCreated($tenant));
-
-        return $tenant;
     }
 
     /**

--- a/src/Database/Concerns/HasPending.php
+++ b/src/Database/Concerns/HasPending.php
@@ -62,9 +62,9 @@ trait HasPending
     public static function createPending(array $attributes = []): Model&Tenant
     {
         return static::create(array_merge(
-            ['pending_since' => now()->timestamp],
             static::getPendingAttributes($attributes),
-            $attributes
+            $attributes,
+            ['pending_since' => now()->timestamp],
         ));
     }
 

--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -17,6 +17,12 @@ class MigrateDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * Should pending tenants be included while migrating,
+     * regardless of the tenancy.pending.include_in_queries config value.
+     */
+    public static bool $includePending = true;
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}
@@ -25,6 +31,7 @@ class MigrateDatabase implements ShouldQueue
     {
         Artisan::call('tenants:migrate', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--with-pending' => static::$includePending,
         ]);
     }
 }

--- a/src/Jobs/MigrateDatabase.php
+++ b/src/Jobs/MigrateDatabase.php
@@ -20,8 +20,12 @@ class MigrateDatabase implements ShouldQueue
     /**
      * Should pending tenants be included while migrating,
      * regardless of the tenancy.pending.include_in_queries config value.
+     *
+     * If false, pending tenants will be specifically excluded.
+     *
+     * If null, default to tenancy.pending.include_in_queries config.
      */
-    public static bool $includePending = true;
+    public static ?bool $includePending = true;
 
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
@@ -31,7 +35,7 @@ class MigrateDatabase implements ShouldQueue
     {
         Artisan::call('tenants:migrate', [
             '--tenants' => [$this->tenant->getTenantKey()],
-            '--with-pending' => static::$includePending,
+            '--with-pending' => static::$includePending ?? config('tenancy.pending.include_in_queries'),
         ]);
     }
 }

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -17,6 +17,12 @@ class SeedDatabase implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
 
+    /**
+     * Should pending tenants be included while seeding,
+     * regardless of the tenancy.pending.include_in_queries config value.
+     */
+    public static bool $includePending = true;
+
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
     ) {}
@@ -25,6 +31,7 @@ class SeedDatabase implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenant->getTenantKey()],
+            '--with-pending' => static::$includePending,
         ]);
     }
 }

--- a/src/Jobs/SeedDatabase.php
+++ b/src/Jobs/SeedDatabase.php
@@ -20,8 +20,12 @@ class SeedDatabase implements ShouldQueue
     /**
      * Should pending tenants be included while seeding,
      * regardless of the tenancy.pending.include_in_queries config value.
+     *
+     * If false, pending tenants will be specifically excluded.
+     *
+     * If null, default to tenancy.pending.include_in_queries config.
      */
-    public static bool $includePending = true;
+    public static ?bool $includePending = true;
 
     public function __construct(
         protected TenantWithDatabase&Model $tenant,
@@ -31,7 +35,7 @@ class SeedDatabase implements ShouldQueue
     {
         Artisan::call('tenants:seed', [
             '--tenants' => [$this->tenant->getTenantKey()],
-            '--with-pending' => static::$includePending,
+            '--with-pending' => static::$includePending ?? config('tenancy.pending.include_in_queries'),
         ]);
     }
 }

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -154,8 +154,8 @@ test('pending events are dispatched', function () {
     Event::assertDispatched(PendingTenantPulled::class);
 });
 
-test('commands do not run for pending tenants if tenancy.pending.include_in_queries is false and the with pending option does not get passed', function() {
-    config(['tenancy.pending.include_in_queries' => false]);
+test('commands include tenants based on the include_in_queries config when --with-pending is not passed', function (bool $includeInQueries) {
+    config(['tenancy.pending.include_in_queries' => $includeInQueries]);
 
     $tenants = collect([
         Tenant::create(),
@@ -164,40 +164,21 @@ test('commands do not run for pending tenants if tenancy.pending.include_in_quer
         Tenant::createPending(),
     ]);
 
-    pest()->artisan('tenants:migrate --with-pending');
+    $command = pest()->artisan("tenants:run 'bar testing testing@test.test password foo'");
 
-    $artisan = pest()->artisan("tenants:run 'foo foo --b=bar --c=xyz'");
+    $tenants->each(function ($tenant) use ($command, $includeInQueries) {
+        if ($tenant->pending() && ! $includeInQueries) {
+            $command->doesntExpectOutputToContain("Tenant: {$tenant->getTenantKey()}");
+        } else {
+            $command->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}");
+        }
+    });
 
-    $pendingTenants = $tenants->filter->pending();
-    $readyTenants = $tenants->reject->pending();
+    $command->assertSuccessful();
+})->with([true, false]);
 
-    $pendingTenants->each(fn ($tenant) => $artisan->doesntExpectOutputToContain("Tenant: {$tenant->getTenantKey()}"));
-    $readyTenants->each(fn ($tenant) => $artisan->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}"));
-
-    $artisan->assertExitCode(0);
-});
-
-test('commands run for pending tenants too if tenancy.pending.include_in_queries is true', function() {
-    config(['tenancy.pending.include_in_queries' => true]);
-
-    $tenants = collect([
-        Tenant::create(),
-        Tenant::create(),
-        Tenant::createPending(),
-        Tenant::createPending(),
-    ]);
-
-    pest()->artisan('tenants:migrate --with-pending');
-
-    $artisan = pest()->artisan("tenants:run 'foo foo --b=bar --c=xyz'");
-
-    $tenants->each(fn ($tenant) => $artisan->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}"));
-
-    $artisan->assertExitCode(0);
-});
-
-test('commands run for pending tenants too if the with pending option is passed', function() {
-    config(['tenancy.pending.include_in_queries' => false]);
+test('commands include pending tenants when truthy --with-pending is passed', function (bool $includeInQueries) {
+    config(['tenancy.pending.include_in_queries' => $includeInQueries]);
 
     $tenants = collect([
         Tenant::create(),
@@ -206,14 +187,41 @@ test('commands run for pending tenants too if the with pending option is passed'
         Tenant::createPending(),
     ]);
 
-    pest()->artisan('tenants:migrate --with-pending');
+    foreach (['--with-pending', '--with-pending=true', '--with-pending=1'] as $option) {
+        $command = pest()->artisan("tenants:run 'bar testing testing@test.test password foo' {$option}");
 
-    $artisan = pest()->artisan("tenants:run 'foo foo --b=bar --c=xyz' --with-pending");
+        // Pending tenants are included regardless of tenancy.pending.include_in_queries
+        $tenants->each(fn ($tenant) => $command->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}"));
 
-    $tenants->each(fn ($tenant) => $artisan->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}"));
+        $command->assertSuccessful();
+    }
+})->with([true, false]);
 
-    $artisan->assertExitCode(0);
-});
+test('commands exclude pending tenants when falsy --with-pending is passed', function (bool $includeInQueries) {
+    config(['tenancy.pending.include_in_queries' => $includeInQueries]);
+
+    $tenants = collect([
+        Tenant::create(),
+        Tenant::create(),
+        Tenant::createPending(),
+        Tenant::createPending(),
+    ]);
+
+    foreach (['--with-pending=false', '--with-pending=0'] as $option) {
+        $command = pest()->artisan("tenants:run 'bar testing testing@test.test password foo' {$option}");
+
+        $tenants->each(function ($tenant) use ($command) {
+            if ($tenant->pending()) {
+                // Pending tenants are excluded regardless of tenancy.pending.include_in_queries
+                $command->doesntExpectOutputToContain("Tenant: {$tenant->getTenantKey()}");
+            } else {
+                $command->expectsOutputToContain("Tenant: {$tenant->getTenantKey()}");
+            }
+        });
+
+        $command->assertSuccessful();
+    }
+})->with([true, false]);
 
 test('pending tenants can have default attributes for non-nullable columns', function (bool $withPendingAttributes) {
     Schema::table('tenants', function (Blueprint $table) {

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -202,7 +202,11 @@ test('commands include pending tenants when truthy --with-pending is passed', fu
         Tenant::createPending(),
     ]);
 
-    foreach (['--with-pending', '--with-pending=true', '--with-pending=1'] as $option) {
+    foreach ([
+        '--with-pending',
+        '--with-pending=true',
+        '--with-pending=1'
+    ] as $option) {
         $command = pest()->artisan("tenants:run 'bar testing testing@test.test password foo' {$option}");
 
         // Pending tenants are included regardless of tenancy.pending.include_in_queries
@@ -222,7 +226,11 @@ test('commands exclude pending tenants when falsy --with-pending is passed', fun
         Tenant::createPending(),
     ]);
 
-    foreach (['--with-pending=false', '--with-pending=0'] as $option) {
+    foreach ([
+        '--with-pending=false',
+        '--with-pending=0',
+        '--with-pending=foo' // Invalid values are treated as false
+    ] as $option) {
         $command = pest()->artisan("tenants:run 'bar testing testing@test.test password foo' {$option}");
 
         $tenants->each(function ($tenant) use ($command) {

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -16,10 +16,25 @@ use Stancl\Tenancy\Events\PendingTenantPulled;
 use Stancl\Tenancy\Events\PullingPendingTenant;
 use Stancl\Tenancy\Tests\Etc\Tenant;
 use function Stancl\Tenancy\Tests\pest;
+use Stancl\Tenancy\Events\TenantCreated;
+use Stancl\JobPipeline\JobPipeline;
+use Stancl\Tenancy\Jobs\CreateDatabase;
+use Stancl\Tenancy\Jobs\MigrateDatabase;
+use Stancl\Tenancy\Jobs\SeedDatabase;
+use Stancl\Tenancy\Tests\Etc\User;
+use Stancl\Tenancy\Tests\Etc\TestSeeder;
+use Stancl\Tenancy\Bootstrappers\DatabaseTenancyBootstrapper;
+use Stancl\Tenancy\Events\TenancyInitialized;
+use Stancl\Tenancy\Listeners\BootstrapTenancy;
+use Stancl\Tenancy\Events\TenancyEnded;
+use Stancl\Tenancy\Listeners\RevertToCentralContext;
 
 beforeEach($cleanup = function () {
     Tenant::$extraCustomColumns = [];
     Tenant::$getPendingAttributesUsing = null;
+
+    MigrateDatabase::$includePending = true;
+    SeedDatabase::$includePending = true;
 });
 
 afterEach($cleanup);
@@ -244,3 +259,72 @@ test('pending tenants can have default attributes for non-nullable columns', fun
     else
         expect($fn)->toThrow(QueryException::class);
 })->with([true, false]);
+
+test('pending tenant databases can be migrated using a job unless configured otherwise', function (bool $includeInQueries, bool $migrateWithPending) {
+    config([
+        'tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class],
+        'tenancy.pending.include_in_queries' => $includeInQueries,
+    ]);
+
+    MigrateDatabase::$includePending = $migrateWithPending;
+
+    Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
+    Event::listen(TenancyEnded::class, RevertToCentralContext::class);
+    Event::listen(TenantCreated::class, JobPipeline::make([
+        CreateDatabase::class,
+        MigrateDatabase::class,
+    ])->send(function (TenantCreated $event) {
+        return $event->tenant;
+    })->toListener());
+
+    $pendingTenant = Tenant::createPending();
+
+    expect(Schema::hasTable('users'))->toBeFalse();
+
+    tenancy()->initialize($pendingTenant);
+
+    // MigrateDatabase includes/excludes pending tenants based on its $includePending property,
+    // regardless of the tenancy.pending.include_in_queries config.
+    expect(Schema::hasTable('users'))->toBe($migrateWithPending);
+})->with([
+    'include pending in queries' => [true],
+    'exclude pending from queries' => [false],
+])->with([
+    'migrate with pending' => [true],
+    'migrate without pending' => [false],
+]);
+
+test('pending tenant databases can be seeded using a job unless configured otherwise', function ($includeInQueries, $seedWithPending) {
+    config([
+        'tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class],
+        'tenancy.pending.include_in_queries' => $includeInQueries,
+        'tenancy.seeder_parameters.--class' => TestSeeder::class,
+    ]);
+
+    MigrateDatabase::$includePending = true;
+    SeedDatabase::$includePending = $seedWithPending;
+
+    Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
+    Event::listen(TenancyEnded::class, RevertToCentralContext::class);
+    Event::listen(TenantCreated::class, JobPipeline::make([
+        CreateDatabase::class,
+        MigrateDatabase::class,
+        SeedDatabase::class,
+    ])->send(function (TenantCreated $event) {
+        return $event->tenant;
+    })->toListener());
+
+    $pendingTenant = Tenant::createPending();
+
+    tenancy()->initialize($pendingTenant);
+
+    // SeedDatabase includes/excludes pending tenants based on its $includePending property,
+    // regardless of the tenancy.pending.include_in_queries config.
+    expect(User::where('email', 'seeded@user')->exists())->toBe($seedWithPending);
+})->with([
+    'include pending in queries' => [true],
+    'exclude pending from queries' => [false],
+])->with([
+    'seed with pending' => [true],
+    'seed without pending' => [false],
+]);

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -336,3 +336,34 @@ test('pending tenant databases can be seeded using a job unless configured other
     'seed with pending' => [true],
     'seed without pending' => [false],
 ]);
+
+test('jobs that run before tenants get fully created recognize pending tenants', function () {
+    config([
+        'tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class],
+    ]);
+
+    Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
+    Event::listen(TenancyEnded::class, RevertToCentralContext::class);
+    Event::listen(TenantCreated::class, JobPipeline::make([
+        CreateDatabase::class,
+        PendingTenantJob::class,
+    ])->send(function (TenantCreated $event) {
+        return $event->tenant;
+    })->toListener());
+
+    Tenant::createPending();
+
+    expect(app('tenant_is_pending'))->toBeTrue();
+});
+
+class PendingTenantJob
+{
+    public function __construct(
+        public Tenant $tenant,
+    ) {}
+
+    public function handle()
+    {
+        app()->instance('tenant_is_pending', $this->tenant->pending());
+    }
+}

--- a/tests/PendingTenantsTest.php
+++ b/tests/PendingTenantsTest.php
@@ -268,7 +268,7 @@ test('pending tenants can have default attributes for non-nullable columns', fun
         expect($fn)->toThrow(QueryException::class);
 })->with([true, false]);
 
-test('pending tenant databases can be migrated using a job unless configured otherwise', function (bool $includeInQueries, bool $migrateWithPending) {
+test('pending tenant databases can be migrated using a job unless configured otherwise', function (bool $includeInQueries, ?bool $migrateWithPending) {
     config([
         'tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class],
         'tenancy.pending.include_in_queries' => $includeInQueries,
@@ -293,16 +293,17 @@ test('pending tenant databases can be migrated using a job unless configured oth
 
     // MigrateDatabase includes/excludes pending tenants based on its $includePending property,
     // regardless of the tenancy.pending.include_in_queries config.
-    expect(Schema::hasTable('users'))->toBe($migrateWithPending);
+    expect(Schema::hasTable('users'))->toBe($migrateWithPending ?? $includeInQueries);
 })->with([
     'include pending in queries' => [true],
     'exclude pending from queries' => [false],
 ])->with([
     'migrate with pending' => [true],
     'migrate without pending' => [false],
+    'default to config' => [null],
 ]);
 
-test('pending tenant databases can be seeded using a job unless configured otherwise', function ($includeInQueries, $seedWithPending) {
+test('pending tenant databases can be seeded using a job unless configured otherwise', function (bool $includeInQueries, ?bool $seedWithPending) {
     config([
         'tenancy.bootstrappers' => [DatabaseTenancyBootstrapper::class],
         'tenancy.pending.include_in_queries' => $includeInQueries,
@@ -328,13 +329,14 @@ test('pending tenant databases can be seeded using a job unless configured other
 
     // SeedDatabase includes/excludes pending tenants based on its $includePending property,
     // regardless of the tenancy.pending.include_in_queries config.
-    expect(User::where('email', 'seeded@user')->exists())->toBe($seedWithPending);
+    expect(User::where('email', 'seeded@user')->exists())->toBe($seedWithPending ?? $includeInQueries);
 })->with([
     'include pending in queries' => [true],
     'exclude pending from queries' => [false],
 ])->with([
     'seed with pending' => [true],
     'seed without pending' => [false],
+    'default to config' => [null],
 ]);
 
 test('jobs that run before tenants get fully created recognize pending tenants', function () {


### PR DESCRIPTION
> Minor breaking change: Pending tenants would previously go through the creation pipeline as *not* pending and would only be marked as pending after full creation. Now, pending tenants go through the creation process with pending_since set from the start.

Pending tenants aren't getting their `pending_since` set until they're created completely (e.g. their DB was created, migrated and seeded -- first, the tenant is created fully, and only after that, the tenant is updated to have `pending_since`). This is a problem if someone wants to e.g. add a job to the `DatabaseCreated` job pipeline that would check `$this->tenant->pending()`. Since at the point of `DatabaseCreated`, the tenant's `pending_since` isn't set yet, `$this->tenant->pending()` returns `false`, even for tenants created using `createPending()`. So instead of letting the pending tenant get fully created, and only after that, setting its `pending_since` (using `update()`), we now set `pending_since` in `create()`. `CreatingPendingTenant` is now dispatched from the `static::creating` hook, and `PendingTenantCreated` is dispatched from `static::created` for consistency.

Setting `pending_since` right in `create()` made the `MigrateDatabase` and `SeedDatabase` jobs exclude the pending tenants during their creation if the `tenancy.pending.include_in_queries` config was set to `false` -- in that case, these jobs would never migrate or seed the databases of pending tenants. So these jobs now pass `--with-pending` to their underlying commands, with the value set in their `$includePending` static property (`true` by default). This overrides the `tenancy.pending.include_in_queries` config -- unless the `$includePending` properties are set to `false`, these jobs will always include pending tenants.

The `--with-pending` tenant command option originally worked just to opt-in for including pending tenants in the command. Now, `--with-pending` can accept values (`true`/`1` or `false`/`0`), so e.g.
- `tenants:run foo` with `--with-pending`/`--with-pending=true`/`--with-pending=1` includes pending tenants
- `tenants:run foo` with `--with-pending=false`/`--with-pending=0` **excludes** pending tenants (also `--with-pending=foobar` -- invalid input, considered `false`)

Passing `--with-pending` makes the command bypass the `tenancy.pending.include_in_queries` config (so e.g. if `tenancy.pending.include_in_queries` is set to `true`, and `--with-pending=false` is passed to a command, the command will exclude pending tenants). When `--with-pending` is not passed, the command will include or exclude pending tenants based on the `tenancy.pending.include_in_queries` config.

In tenancy-docs, I opened a PR with a note about the `--with-pending` and job changes (https://github.com/archtechx/tenancy-docs/pull/5).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The pending option now accepts explicit boolean-like values; when omitted, configuration governs behavior.
  * Migration and seeding jobs gain configurable flags to include/exclude pending tenants.
* **Bug Fixes**
  * Pending tenants record their "pending" timestamp at creation and emit lifecycle events consistently.
* **Tests**
  * Expanded coverage for pending-option parsing, job-driven migration/seeding behavior, and lifecycle/job integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->