### PR TITLE
Add MigrateStatus command and corresponding tests

### DIFF
--- a/src/Commands/MigrateStatus.php
+++ b/src/Commands/MigrateStatus.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Stancl\Tenancy\Commands;
+
+use Illuminate\Database\Console\Migrations\StatusCommand;
+use Illuminate\Database\Migrations\Migrator;
+use Stancl\Tenancy\Concerns\DealsWithMigrations;
+use Stancl\Tenancy\Concerns\ExtendsLaravelCommand;
+use Stancl\Tenancy\Concerns\HasATenantsOption;
+
+class MigrateStatus extends StatusCommand
+{
+    use HasATenantsOption, DealsWithMigrations, ExtendsLaravelCommand;
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Show the status of each migration for tenant(s).';
+
+    protected static function getTenantCommandName(): string
+    {
+        return 'tenants:migrate-status';
+    }
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct($migrator);
+
+        $this->specifyTenantSignature();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        foreach (config('tenancy.migration_parameters') as $parameter => $value) {
+            if (! $this->input->hasParameterOption($parameter)) {
+                if ($this->getDefinition()->hasOption(ltrim($parameter, '-'))) {
+                    $this->input->setOption(ltrim($parameter, '-'), $value);
+                }
+            }
+        }
+
+        tenancy()->runForMultiple($this->option('tenants'), function ($tenant) {
+            $this->line("Tenant: {$tenant->getTenantKey()}");
+
+            parent::handle();
+        });
+    }
+}

--- a/src/TenancyServiceProvider.php
+++ b/src/TenancyServiceProvider.php
@@ -65,6 +65,9 @@ class TenancyServiceProvider extends ServiceProvider
         $this->app->singleton(Commands\Rollback::class, function ($app) {
             return new Commands\Rollback($app['migrator']);
         });
+        $this->app->singleton(Commands\MigrateStatus::class, function ($app) {
+            return new Commands\MigrateStatus($app['migrator']);
+        });
 
         $this->app->singleton(Commands\Seed::class, function ($app) {
             return new Commands\Seed($app['db']);
@@ -90,6 +93,7 @@ class TenancyServiceProvider extends ServiceProvider
             Commands\Rollback::class,
             Commands\TenantList::class,
             Commands\MigrateFresh::class,
+            Commands\MigrateStatus::class,
         ]);
 
         $this->publishes([

--- a/tests/CommandsTest.php
+++ b/tests/CommandsTest.php
@@ -107,6 +107,34 @@ class CommandsTest extends TestCase
     }
 
     #[Test]
+    public function migrate_status_command_works()
+    {
+        $tenant = Tenant::create();
+
+        $this->artisan('tenants:migrate-status')
+            ->expectsOutputToContain('Tenant: ' . $tenant->getTenantKey());
+
+        Artisan::call('tenants:migrate', ['--tenants' => [$tenant->getTenantKey()]]);
+
+        $this->artisan('tenants:migrate-status', ['--tenants' => [$tenant->getTenantKey()]])
+            ->expectsOutputToContain('Tenant: ' . $tenant->getTenantKey())
+            ->expectsOutputToContain('Ran');
+    }
+
+    #[Test]
+    public function migrate_status_command_works_with_multiple_tenants()
+    {
+        $tenant1 = Tenant::create()->getTenantKey();
+        $tenant2 = Tenant::create()->getTenantKey();
+
+        Artisan::call('tenants:migrate', ['--tenants' => [$tenant1, $tenant2]]);
+
+        $this->artisan('tenants:migrate-status')
+            ->expectsOutputToContain('Tenant: ' . $tenant1)
+            ->expectsOutputToContain('Tenant: ' . $tenant2);
+    }
+
+    #[Test]
     public function seed_command_works()
     {
         $this->markTestIncomplete();


### PR DESCRIPTION
Adds a new Artisan command tenants:migrate-status that mirrors Laravel's built-in migrate:status, but runs against tenant databases. Useful for inspecting which migrations have already been applied (or are
  still pending) for one or more tenants, without having to switch context manually.

  Usage

  # All tenants
  php artisan tenants:migrate-status

  # Specific tenant(s)
  php artisan tenants:migrate-status --tenants=<id>
  php artisan tenants:migrate-status --tenants=<id1> --tenants=<id2>

  For each tenant, the command prints a header line (Tenant: <key>) followed by the standard Laravel migration status table (Ran / Pending / Batch).