### PR TITLE
[MINOR BC] [4.x] Fix FilesystemTenancyBootstrapper discarding configured cache and session paths

### DIFF
--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -97,7 +97,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
     protected function tenantStoragePath(string $suffix): string
     {
-        return $this->originalStoragePath . DIRECTORY_SEPARATOR . $suffix;
+        return rtrim($this->originalStoragePath, '/\\') . DIRECTORY_SEPARATOR . $suffix;
     }
 
     protected function assetHelper(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -258,18 +258,19 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      * Normalize the path to use the separator of the current OS.
      *
      * The separators are also deduplicated, with two exceptions:
-     * - if the path begins with \\ on Windows (i.e. a UNC path), the *leading* separators won't end up deduplicated
-     * - if the path contains non-UTF-8 characters, the separators won't be deduplicated at all (since str()->deduplicate() only works on UTF-8 strings).
+     * - if the path begins with \\ on Windows (i.e. a UNC path), the *leading* separators won't be deduplicated
+     * - if the path contains non-UTF-8 characters, the separators won't be deduplicated since str()->deduplicate() only supports UTF-8 strings)
      */
     protected function normalizePath(string $path): string
     {
         $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 
         // On Windows, a path starting with two separators is a UNC path (e.g. '\\server\share'),
-        // so the leading separator that got collapsed by deduplicate() should be added back.
+        // so the leading separator that got collapsed by deduplicate() should be added back (only one \ will be kept, so we use one for the prefix).
         $uncPrefix = DIRECTORY_SEPARATOR === '\\' && str_starts_with($path, '\\\\') ? DIRECTORY_SEPARATOR : '';
 
-        // Since deduplicate() only supports UTF-8 paths, paths with non-UTF-8 characters will keep the duplicate separators.
+        // Since deduplicate() only supports UTF-8 paths, paths with non-UTF-8 characters will not
+        // be deduplicated since deduplicate() returns an empty result with unsupported strings
         $path = str($path)->deduplicate(DIRECTORY_SEPARATOR)->toString() ?: $path;
 
         return $uncPrefix . rtrim($path, DIRECTORY_SEPARATOR);

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -226,6 +226,8 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
 
         foreach ($this->fileCacheStores() as $name) {
+            // Capture the paths only once. The config holds the central values on the first
+            // bootstrap, but not necessarily later (if an earlier bootstrap threw, revert() didn't run).
             $this->originalCachePaths[$name] ??= [
                 'path' => $this->app['config']["cache.stores.{$name}.path"],
                 'lock_path' => $this->app['config']["cache.stores.{$name}.lock_path"],
@@ -241,6 +243,8 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
         foreach ($this->fileCacheStores() as $name) {
             if (! isset($this->originalCachePaths[$name])) {
+                // Only scope stores captured during bootstrap. If one was added to tenancy.cache.stores
+                // mid-request, it has no original path here -- reading it would throw when tenancy ends.
                 continue;
             }
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -97,7 +97,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
     protected function tenantStoragePath(string $suffix): string
     {
-        return $this->originalStoragePath . "/{$suffix}";
+        return $this->originalStoragePath . DIRECTORY_SEPARATOR . $suffix;
     }
 
     protected function assetHelper(string|false $suffix): void
@@ -241,17 +241,20 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      */
     protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
-        if (str_starts_with($configuredPath, $this->originalStoragePath . '/')) {
+        // Normalize the path to use the separator of the current OS.
+        $configuredPath = str_replace('/', DIRECTORY_SEPARATOR, $configuredPath);
+
+        if (str_starts_with($configuredPath, $this->originalStoragePath . DIRECTORY_SEPARATOR)) {
             // Swap the central storage path prefix for the tenant's.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
             return str($configuredPath)
-                ->after($this->originalStoragePath . '/')
-                ->prepend($this->tenantStoragePath($suffix) . '/')
+                ->after($this->originalStoragePath . DIRECTORY_SEPARATOR)
+                ->prepend($this->tenantStoragePath($suffix) . DIRECTORY_SEPARATOR)
                 ->toString();
         }
 
         // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the suffix directly.
-        return rtrim($configuredPath, '/') . '/' . $suffix;
+        return rtrim($configuredPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $suffix;
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -46,6 +46,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $this->storagePath($suffix);
         $this->assetHelper($suffix);
         $this->forgetDisks();
+        $this->storeOriginalCachePaths();
         $this->scopeCache($suffix);
         $this->scopeSessions($suffix);
 
@@ -200,13 +201,10 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
     }
 
-    public function scopeCache(string|false $suffix): void
+    /** Returns the names of the file-driver stores listed in tenancy.cache.stores. */
+    protected function fileCacheStores(): array
     {
-        if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
-            return;
-        }
-
-        $stores = array_filter($this->app['config']['tenancy.cache.stores'], function ($name) {
+        return array_filter($this->app['config']['tenancy.cache.stores'], function ($name) {
             $store = $this->app['config']["cache.stores.{$name}"];
 
             if ($store === null) {
@@ -215,15 +213,36 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
             return $store['driver'] === 'file';
         });
+    }
 
-        foreach ($stores as $name) {
-            // Store the original configured cache paths, unless they're already stored --
-            // scopeCache() is also called in revert(), by which point the originals were
-            // already captured in bootstrap().
+    /**
+     * Store the original configured cache paths, so that they can be properly scoped
+     * to a tenant and restored back to the central context when tenancy ends.
+     */
+    protected function storeOriginalCachePaths(): void
+    {
+        if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
+            return;
+        }
+
+        foreach ($this->fileCacheStores() as $name) {
             $this->originalCachePaths[$name] ??= [
                 'path' => $this->app['config']["cache.stores.{$name}.path"],
                 'lock_path' => $this->app['config']["cache.stores.{$name}.lock_path"],
             ];
+        }
+    }
+
+    protected function scopeCache(string|false $suffix): void
+    {
+        if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
+            return;
+        }
+
+        foreach ($this->fileCacheStores() as $name) {
+            if (! isset($this->originalCachePaths[$name])) {
+                continue;
+            }
 
             $path = $this->scopeCachePath($this->originalCachePaths[$name]['path'], $suffix);
             $lockPath = $this->originalCachePaths[$name]['lock_path'];

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -194,9 +194,6 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             return;
         }
 
-        // On revert, restore exactly the stores captured during bootstrap -- not the current
-        // (possibly mutated) tenancy.cache.stores. Otherwise, removing a store from that
-        // config in tenant context would make revert() skip it (so the store would be stuck with a tenant-scoped path).
         $stores = $suffix !== false
             ? $this->app['config']['tenancy.cache.stores']
             : array_keys($this->originalCachePaths);

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -164,7 +164,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             // This is executed if the disk is in tenancy.filesystem.disks but does NOT have a root_override
             // This behavior is used for disks like S3.
             $newRoot = $originalRoot
-                ? rtrim($originalRoot, '/') . '/' . $suffix
+                ? rtrim($originalRoot, '/\\') . '/' . $suffix
                 : $suffix;
         }
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -14,21 +14,8 @@ use Stancl\Tenancy\Contracts\Tenant;
 class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 {
     public array $originalDisks = [];
-
-    /**
-     * The path and lock_path each file cache store had in the central context, keyed by store name.
-     *
-     * For example:
-     * [
-     *     'file' => [
-     *         'path' => storage_path('framework/cache/data'),
-     *         'lock_path' => storage_path('framework/cache/data'),
-     *     ],
-     * ]
-     *
-     * Used to scope the store to a tenant, and to restore it back to this when tenancy ends.
-     */
     protected array $originalCachePaths = [];
+    protected array $originalCacheLockPaths = [];
     public string|null $originalAssetUrl;
     public string $originalStoragePath;
 
@@ -46,7 +33,6 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $this->storagePath($suffix);
         $this->assetHelper($suffix);
         $this->forgetDisks();
-        $this->storeOriginalCachePaths();
         $this->scopeCache($suffix);
         $this->scopeSessions($suffix);
 
@@ -201,61 +187,40 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
     }
 
-    /** Returns the names of the file-driver stores listed in tenancy.cache.stores. */
-    protected function fileCacheStores(): array
-    {
-        return array_filter($this->app['config']['tenancy.cache.stores'], function ($name) {
-            $store = $this->app['config']["cache.stores.{$name}"];
-
-            if ($store === null) {
-                return false;
-            }
-
-            return $store['driver'] === 'file';
-        });
-    }
-
-    /**
-     * Store the original configured cache paths, so that they can be properly scoped
-     * to a tenant and restored back to the central context when tenancy ends.
-     */
-    protected function storeOriginalCachePaths(): void
-    {
-        if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
-            return;
-        }
-
-        foreach ($this->fileCacheStores() as $name) {
-            // Capture the paths only once. The config holds the central values on the first
-            // bootstrap, but not necessarily later (if an earlier bootstrap threw, revert() didn't run).
-            $this->originalCachePaths[$name] ??= [
-                'path' => $this->app['config']["cache.stores.{$name}.path"],
-                'lock_path' => $this->app['config']["cache.stores.{$name}.lock_path"],
-            ];
-        }
-    }
-
     public function scopeCache(string|false $suffix): void
     {
         if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
             return;
         }
 
-        foreach ($this->fileCacheStores() as $name) {
-            if (! isset($this->originalCachePaths[$name])) {
-                // Only scope stores captured during bootstrap. If one was added to tenancy.cache.stores
-                // mid-request, it has no original path here -- reading it would throw when tenancy ends.
+        foreach ($this->app['config']['tenancy.cache.stores'] as $name) {
+            $store = $this->app['config']["cache.stores.{$name}"];
+
+            // Only file stores have a path to scope. Skip stores that don't exist (null) or use another driver.
+            if ($store === null || $store['driver'] !== 'file') {
                 continue;
             }
 
-            $path = $this->scopeCachePath($this->originalCachePaths[$name]['path'], $suffix);
-            $lockPath = $this->originalCachePaths[$name]['lock_path'];
-            if ($lockPath !== null) {
-                // Unlike path, lock_path is optional -- if it's not set, FileStore::lock() falls
-                // back to path itself (see `$this->lockDirectory ?? $this->directory` in FileStore).
-                // Leave it null here rather than hardcoding it to $path ourselves, so a store that didn't
-                // configure a separate lock_path doesn't end up with one.
-                $lockPath = $this->scopeCachePath($lockPath, $suffix);
+            if ($suffix !== false && ! isset($this->originalCachePaths[$name])) {
+                $this->originalCachePaths[$name] = $store['path'];
+                $this->originalCacheLockPaths[$name] = $store['lock_path'] ?? null;
+            }
+
+            // Only scope stores captured during bootstrap. If one was added to tenancy.cache.stores
+            // mid-request, it has no original path here -- reading it would throw when tenancy ends.
+            if (! isset($this->originalCachePaths[$name])) {
+                continue;
+            }
+
+            $path = $suffix ? $this->tenantCachePath($this->originalCachePaths[$name], $suffix) : $this->originalCachePaths[$name];
+
+            // Unlike path, lock_path is optional -- if it's not set, FileStore::lock() falls back to path
+            // itself (see `$this->lockDirectory ?? $this->directory` in FileStore). Leave it null here rather
+            // than hardcoding it to $path ourselves, so a store that didn't configure a separate lock_path
+            // doesn't end up with one.
+            $lockPath = $this->originalCacheLockPaths[$name];
+            if ($suffix && $lockPath !== null) {
+                $lockPath = $this->tenantCachePath($lockPath, $suffix);
             }
 
             $this->app['config']["cache.stores.{$name}.path"] = $path;
@@ -268,32 +233,20 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
     }
 
-    /**
-     * Return a configured path ($configuredPath is e.g. storage_path('framework/cache/data')),
-     * scoped to the current tenant when called from bootstrap(),
-     * or unchanged when called from revert() (= when $suffix is false).
-     */
-    protected function scopeCachePath(string $configuredPath, string|false $suffix): string
+    /** Scope a configured cache path (path or lock_path) to the tenant identified by $suffix. */
+    protected function tenantCachePath(string $configuredPath, string $suffix): string
     {
-        if ($suffix === false) {
-            return $configuredPath;
-        }
-
         if (str_starts_with($configuredPath, $this->originalStoragePath . '/')) {
             // Swap the central storage path prefix for the tenant's.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
-            $scopedPath = str($configuredPath)
+            return str($configuredPath)
                 ->after($this->originalStoragePath . '/')
                 ->prepend($this->tenantStoragePath($suffix) . '/')
                 ->toString();
-        } else {
-            // Append the tenant suffix so tenants don't share the same cache directory. $configuredPath
-            // isn't guaranteed to be storage_path()-based (e.g. it could point to a shared network
-            // mount used to keep the file cache off each server's local disk in a multi-server setup).
-            $scopedPath = rtrim($configuredPath, '/') . '/' . $suffix;
         }
 
-        return $scopedPath;
+        // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the suffix directly.
+        return rtrim($configuredPath, '/') . '/' . $suffix;
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -213,12 +213,6 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 $this->originalCacheLockPaths[$name] = $store['lock_path'] ?? null;
             }
 
-            // Only scope stores captured during bootstrap. If one was added to tenancy.cache.stores
-            // mid-request, it has no original path here -- reading it would throw when tenancy ends.
-            if (! isset($this->originalCachePaths[$name])) {
-                continue;
-            }
-
             $path = $suffix ? $this->tenantCachePath($this->originalCachePaths[$name], $suffix) : $this->originalCachePaths[$name];
 
             // Unlike path, lock_path is optional -- if it's not set, FileStore::lock() falls back to path

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -250,7 +250,8 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 ->toString();
         }
 
-        // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the suffix directly.
+        // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the
+        // suffix as a subdirectory, e.g. '/var/cache/foo' becomes '/var/cache/foo/tenant1'.
         return rtrim($configuredPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $suffix;
     }
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -16,6 +16,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     public array $originalDisks = [];
     protected array $originalCachePaths = [];
     protected array $originalCacheLockPaths = [];
+    protected string|null $originalSessionPath = null;
     public string|null $originalAssetUrl;
     public string $originalStoragePath;
 
@@ -213,7 +214,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 $this->originalCacheLockPaths[$name] = $store['lock_path'] ?? null;
             }
 
-            $path = $suffix ? $this->tenantCachePath($this->originalCachePaths[$name], $suffix) : $this->originalCachePaths[$name];
+            $path = $suffix ? $this->tenantScopedPath($this->originalCachePaths[$name], $suffix) : $this->originalCachePaths[$name];
 
             // Unlike path, lock_path is optional -- if it's not set, FileStore::lock() falls back to path
             // itself (see `$this->lockDirectory ?? $this->directory` in FileStore). Leave it null here rather
@@ -221,7 +222,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             // doesn't end up with one.
             $lockPath = $this->originalCacheLockPaths[$name];
             if ($suffix && $lockPath !== null) {
-                $lockPath = $this->tenantCachePath($lockPath, $suffix);
+                $lockPath = $this->tenantScopedPath($lockPath, $suffix);
             }
 
             $this->app['config']["cache.stores.{$name}.path"] = $path;
@@ -234,8 +235,11 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
     }
 
-    /** Scope a configured cache path (path or lock_path) to the tenant identified by $suffix. */
-    protected function tenantCachePath(string $configuredPath, string $suffix): string
+    /**
+     * Scope a configured path (a cache store's path or lock_path, or the session path)
+     * to the tenant identified by $suffix.
+     */
+    protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
         if (str_starts_with($configuredPath, $this->originalStoragePath . '/')) {
             // Swap the central storage path prefix for the tenant's.
@@ -256,12 +260,15 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             return;
         }
 
+        $originalPath = $this->originalSessionPath ?? $this->app['config']['session.files'];
+        $this->originalSessionPath = $originalPath;
+
         $path = $suffix
-            ? $this->tenantStoragePath($suffix) . '/framework/sessions'
-            : $this->originalStoragePath . '/framework/sessions';
+            ? $this->tenantScopedPath($originalPath, $suffix)
+            : $originalPath;
 
         if (! is_dir($path)) {
-            // Create tenant framework/sessions directory if it does not exist.
+            // Create tenant session directory if it does not exist.
             // We ignore errors due to TOCTOU race conditions, instead we check for success below.
             @mkdir($path, 0750, true);
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -238,22 +238,35 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      */
     protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
-        // Normalize the paths to use the separator of the current OS.
-        $configuredPath = str_replace('/', DIRECTORY_SEPARATOR, $configuredPath);
-        $storagePath = str_replace('/', DIRECTORY_SEPARATOR, $this->originalStoragePath);
+        $configuredPath = $this->normalizePath($configuredPath);
+        $storagePath = $this->normalizePath($this->originalStoragePath);
 
         if (str_starts_with($configuredPath, $storagePath . DIRECTORY_SEPARATOR)) {
             // Swap the central storage path prefix for the tenant's.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
             return str($configuredPath)
-                ->after($storagePath . DIRECTORY_SEPARATOR)
-                ->prepend($this->tenantStoragePath($suffix) . DIRECTORY_SEPARATOR)
+                ->replaceFirst($storagePath, $this->tenantStoragePath($suffix))
                 ->toString();
         }
 
         // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the
         // suffix as a subdirectory, e.g. '/var/cache/foo' becomes '/var/cache/foo/tenant1'.
-        return rtrim($configuredPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $suffix;
+        return $configuredPath . DIRECTORY_SEPARATOR . $suffix;
+    }
+
+    /** Normalize the path to use the separator of the current OS, deduplicated. */
+    protected function normalizePath(string $path): string
+    {
+        $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
+
+        // On Windows, a path starting with two separators is a UNC path (e.g. '\\server\share'),
+        // so the leading separator that got collapsed by deduplicate() should be added back.
+        $uncPrefix = DIRECTORY_SEPARATOR === '\\' && str_starts_with($path, '\\\\') ? DIRECTORY_SEPARATOR : '';
+
+        return $uncPrefix . str($path)
+            ->deduplicate(DIRECTORY_SEPARATOR)
+            ->rtrim(DIRECTORY_SEPARATOR)
+            ->toString();
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Foundation\Application;
 use Illuminate\Session\FileSessionHandler;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
 use Stancl\Tenancy\Contracts\TenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Tenant;
 
@@ -259,21 +260,24 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      *
      * The separators are also deduplicated, with two exceptions:
      * - if the path begins with \\ on Windows (i.e. a UNC path), the *leading* separators won't be deduplicated
-     * - if the path contains non-UTF-8 characters, the separators won't be deduplicated since str()->deduplicate() only supports UTF-8 strings)
+     * - if the path contains non-UTF-8 characters, the separators won't be deduplicated since Str::deduplicate() only supports UTF-8 strings)
      */
     protected function normalizePath(string $path): string
     {
         $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
 
-        // On Windows, a path starting with two separators is a UNC path (e.g. '\\server\share'),
-        // so the leading separator that got collapsed by deduplicate() should be added back (only one \ will be kept, so we use one for the prefix).
         $uncPrefix = DIRECTORY_SEPARATOR === '\\' && str_starts_with($path, '\\\\') ? DIRECTORY_SEPARATOR : '';
 
-        // Since deduplicate() only supports UTF-8 paths, paths with non-UTF-8 characters will not
-        // be deduplicated since deduplicate() returns an empty result with unsupported strings
-        $path = str($path)->deduplicate(DIRECTORY_SEPARATOR)->toString() ?: $path;
-
-        return $uncPrefix . rtrim($path, DIRECTORY_SEPARATOR);
+        if ($deduplicated = Str::deduplicate($path, DIRECTORY_SEPARATOR)) {
+            // On Windows, a path starting with two separators is a UNC path (e.g. '\\server\share'),
+            // so the leading separator that got collapsed by deduplicate() should be added back
+            // (only one \ will be kept, so we use one for the prefix).
+            return $uncPrefix . rtrim($deduplicated, DIRECTORY_SEPARATOR);
+        } else {
+            // Because deduplicate() only supports UTF-8 paths, paths with non-UTF-8 characters will not
+            // be deduplicated since deduplicate() returns an empty result with unsupported strings
+            return rtrim($path, DIRECTORY_SEPARATOR);
+        }
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -238,22 +238,20 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      */
     protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
-        // Normalize the paths to use the separator of the current OS.
-        $configuredPath = str_replace('/', DIRECTORY_SEPARATOR, $configuredPath);
-        $storagePath = str_replace('/', DIRECTORY_SEPARATOR, $this->originalStoragePath);
+        $centralPath = rtrim($this->originalStoragePath, '/\\');
 
-        if (str_starts_with($configuredPath, $storagePath . DIRECTORY_SEPARATOR)) {
-            // Swap the central storage path prefix for the tenant's.
+        if (str($configuredPath)->startsWith([$centralPath . '/', $centralPath . '\\'])) {
+            // Swap the central storage path prefix for the tenant's, keeping the configured separators.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
             return str($configuredPath)
-                ->after($storagePath . DIRECTORY_SEPARATOR)
-                ->prepend($this->tenantStoragePath($suffix) . DIRECTORY_SEPARATOR)
+                ->after($centralPath)
+                ->prepend($this->tenantStoragePath($suffix))
                 ->toString();
         }
 
         // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the
         // suffix as a subdirectory, e.g. '/var/cache/foo' becomes '/var/cache/foo/tenant1'.
-        return rtrim($configuredPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $suffix;
+        return rtrim($configuredPath, '/\\') . DIRECTORY_SEPARATOR . $suffix;
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -238,20 +238,22 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      */
     protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
-        $centralPath = rtrim($this->originalStoragePath, '/\\');
+        // Normalize the paths to use the separator of the current OS.
+        $configuredPath = str_replace('/', DIRECTORY_SEPARATOR, $configuredPath);
+        $storagePath = str_replace('/', DIRECTORY_SEPARATOR, $this->originalStoragePath);
 
-        if (str($configuredPath)->startsWith([$centralPath . '/', $centralPath . '\\'])) {
-            // Swap the central storage path prefix for the tenant's, keeping the configured separators.
+        if (str_starts_with($configuredPath, $storagePath . DIRECTORY_SEPARATOR)) {
+            // Swap the central storage path prefix for the tenant's.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
             return str($configuredPath)
-                ->after($centralPath)
-                ->prepend($this->tenantStoragePath($suffix))
+                ->after($storagePath . DIRECTORY_SEPARATOR)
+                ->prepend($this->tenantStoragePath($suffix) . DIRECTORY_SEPARATOR)
                 ->toString();
         }
 
         // Otherwise $configuredPath isn't necessarily storage_path()-based, so just append the
         // suffix as a subdirectory, e.g. '/var/cache/foo' becomes '/var/cache/foo/tenant1'.
-        return rtrim($configuredPath, '/\\') . DIRECTORY_SEPARATOR . $suffix;
+        return rtrim($configuredPath, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $suffix;
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -238,14 +238,15 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      */
     protected function tenantScopedPath(string $configuredPath, string $suffix): string
     {
-        // Normalize the path to use the separator of the current OS.
+        // Normalize the paths to use the separator of the current OS.
         $configuredPath = str_replace('/', DIRECTORY_SEPARATOR, $configuredPath);
+        $storagePath = str_replace('/', DIRECTORY_SEPARATOR, $this->originalStoragePath);
 
-        if (str_starts_with($configuredPath, $this->originalStoragePath . DIRECTORY_SEPARATOR)) {
+        if (str_starts_with($configuredPath, $storagePath . DIRECTORY_SEPARATOR)) {
             // Swap the central storage path prefix for the tenant's.
             // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
             return str($configuredPath)
-                ->after($this->originalStoragePath . DIRECTORY_SEPARATOR)
+                ->after($storagePath . DIRECTORY_SEPARATOR)
                 ->prepend($this->tenantStoragePath($suffix) . DIRECTORY_SEPARATOR)
                 ->toString();
         }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -14,6 +14,21 @@ use Stancl\Tenancy\Contracts\Tenant;
 class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 {
     public array $originalDisks = [];
+
+    /**
+     * The path and lock_path each file cache store had in the central context, keyed by store name.
+     *
+     * For example:
+     * [
+     *     'file' => [
+     *         'path' => storage_path('framework/cache/data'),
+     *         'lock_path' => storage_path('framework/cache/data'),
+     *     ],
+     * ]
+     *
+     * Used to scope the store to a tenant, and to restore it back to this when tenancy ends.
+     */
+    protected array $originalCachePaths = [];
     public string|null $originalAssetUrl;
     public string $originalStoragePath;
 
@@ -191,10 +206,6 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             return;
         }
 
-        $storagePath = $suffix
-            ? $this->tenantStoragePath($suffix)
-            : $this->originalStoragePath;
-
         $stores = array_filter($this->app['config']['tenancy.cache.stores'], function ($name) {
             $store = $this->app['config']["cache.stores.{$name}"];
 
@@ -206,15 +217,60 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         });
 
         foreach ($stores as $name) {
-            $path = $storagePath . '/framework/cache/data';
+            // Store the original configured cache paths, unless they're already stored --
+            // scopeCache() is also called in revert(), by which point the originals were
+            // already captured in bootstrap().
+            $this->originalCachePaths[$name] ??= [
+                'path' => $this->app['config']["cache.stores.{$name}.path"],
+                'lock_path' => $this->app['config']["cache.stores.{$name}.lock_path"],
+            ];
+
+            $path = $this->scopeCachePath($this->originalCachePaths[$name]['path'], $suffix);
+            $lockPath = $this->originalCachePaths[$name]['lock_path'];
+            if ($lockPath !== null) {
+                // Unlike path, lock_path is optional -- if it's not set, FileStore::lock() falls
+                // back to path itself (see `$this->lockDirectory ?? $this->directory` in FileStore).
+                // Leave it null here rather than hardcoding it to $path ourselves, so a store that didn't
+                // configure a separate lock_path doesn't end up with one.
+                $lockPath = $this->scopeCachePath($lockPath, $suffix);
+            }
+
             $this->app['config']["cache.stores.{$name}.path"] = $path;
-            $this->app['config']["cache.stores.{$name}.lock_path"] = $path;
+            $this->app['config']["cache.stores.{$name}.lock_path"] = $lockPath;
 
             /** @var \Illuminate\Cache\FileStore $store */
             $store = $this->app['cache']->store($name)->getStore();
             $store->setDirectory($path);
-            $store->setLockDirectory($path);
+            $store->setLockDirectory($lockPath);
         }
+    }
+
+    /**
+     * Return a configured path ($configuredPath is e.g. storage_path('framework/cache/data')),
+     * scoped to the current tenant when called from bootstrap(),
+     * or unchanged when called from revert() (= when $suffix is false).
+     */
+    protected function scopeCachePath(string $configuredPath, string|false $suffix): string
+    {
+        if ($suffix === false) {
+            return $configuredPath;
+        }
+
+        if (str_starts_with($configuredPath, $this->originalStoragePath . '/')) {
+            // Swap the central storage path prefix for the tenant's.
+            // For example, storage_path('framework/cache/data') becomes storage_path('tenant1/framework/cache/data').
+            $scopedPath = str($configuredPath)
+                ->after($this->originalStoragePath . '/')
+                ->prepend($this->tenantStoragePath($suffix) . '/')
+                ->toString();
+        } else {
+            // Append the tenant suffix so tenants don't share the same cache directory. $configuredPath
+            // isn't guaranteed to be storage_path()-based (e.g. it could point to a shared network
+            // mount used to keep the file cache off each server's local disk in a multi-server setup).
+            $scopedPath = rtrim($configuredPath, '/') . '/' . $suffix;
+        }
+
+        return $scopedPath;
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -193,7 +193,14 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
             return;
         }
 
-        foreach ($this->app['config']['tenancy.cache.stores'] as $name) {
+        // On revert, restore exactly the stores captured during bootstrap -- not the current
+        // (possibly mutated) tenancy.cache.stores. Otherwise, removing a store from that
+        // config in tenant context would make revert() skip it (so the store would be stuck with a tenant-scoped path).
+        $stores = $suffix !== false
+            ? $this->app['config']['tenancy.cache.stores']
+            : array_keys($this->originalCachePaths);
+
+        foreach ($stores as $name) {
             $store = $this->app['config']["cache.stores.{$name}"];
 
             // Only file stores have a path to scope. Skip stores that don't exist (null) or use another driver.

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -254,7 +254,13 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         return $configuredPath . DIRECTORY_SEPARATOR . $suffix;
     }
 
-    /** Normalize the path to use the separator of the current OS, deduplicated. */
+    /**
+     * Normalize the path to use the separator of the current OS.
+     *
+     * The separators are also deduplicated, with two exceptions:
+     * - if the path begins with \\ on Windows (i.e. a UNC path), the *leading* separators won't end up deduplicated
+     * - if the path contains non-UTF-8 characters, the separators won't be deduplicated at all (since str()->deduplicate() only works on UTF-8 strings).
+     */
     protected function normalizePath(string $path): string
     {
         $path = str_replace('/', DIRECTORY_SEPARATOR, $path);
@@ -263,10 +269,10 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         // so the leading separator that got collapsed by deduplicate() should be added back.
         $uncPrefix = DIRECTORY_SEPARATOR === '\\' && str_starts_with($path, '\\\\') ? DIRECTORY_SEPARATOR : '';
 
-        return $uncPrefix . str($path)
-            ->deduplicate(DIRECTORY_SEPARATOR)
-            ->rtrim(DIRECTORY_SEPARATOR)
-            ->toString();
+        // Since deduplicate() only supports UTF-8 paths, paths with non-UTF-8 characters will keep the duplicate separators.
+        $path = str($path)->deduplicate(DIRECTORY_SEPARATOR)->toString() ?: $path;
+
+        return $uncPrefix . rtrim($path, DIRECTORY_SEPARATOR);
     }
 
     public function scopeSessions(string|false $suffix): void

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -233,7 +233,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         }
     }
 
-    protected function scopeCache(string|false $suffix): void
+    public function scopeCache(string|false $suffix): void
     {
         if (! $this->app['config']['tenancy.filesystem.scope_cache']) {
             return;

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -305,7 +305,10 @@ test('file cache stores are separated per tenant', function () {
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
         ],
-        'tenancy.cache.stores' => ['file'],
+        // Only stores that use the 'file' driver are scoped.
+        // The 'redis' store won't be scoped since it doesn't use the 'file' driver,
+        // and 'nonexistent_store' won't be scoped since it just doesn't exist.
+        'tenancy.cache.stores' => ['file', 'redis', 'nonexistent_store'],
         // Laravel's default 'file' store config (set explicitly here just for clarity).
         'cache.stores.file' => [
             'driver' => 'file',
@@ -318,11 +321,22 @@ test('file cache stores are separated per tenant', function () {
     $tenant2 = Tenant::create();
 
     Cache::store('file')->put('key', 'central');
+    Cache::store('redis')->put('key', 'central');
 
-    tenancy()->initialize($tenant1);
+    // 'redis' and 'nonexistent_store' are skipped before scopeCache() attempts to read their config.
+    // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
+    // line in scopeCache() would throw an ErrorException (with 'redis', we'd get an
+    // 'Undefined array key "path"' exception, and with 'nonexistent_store',
+    // we'd get 'Trying to access array offset on null').
+    expect(fn () => tenancy()->initialize($tenant1))->not()->toThrow(ErrorException::class);
 
     expect(Cache::store('file')->get('key'))->toBeNull();
     Cache::store('file')->put('key', 'tenant1');
+
+    // The 'redis' store doesn't use the file driver (no path to scope),
+    // so FilesystemTenancyBootstrapper skips it in scopeCache().
+    // The central value is retained in the tenant context.
+    expect(Cache::store('redis')->get('key'))->toBe('central');
 
     tenancy()->initialize($tenant2);
 
@@ -336,11 +350,25 @@ test('file cache stores are separated per tenant', function () {
     tenancy()->end();
 
     expect(Cache::store('file')->get('key'))->toBe('central');
+
+    // Turn FilesystemTenancyBootstrapper's cache scoping off
+    config(['tenancy.filesystem.scope_cache' => false]);
+
+    tenancy()->initialize($tenant1);
+
+    expect(Cache::store('file')->get('key'))->toBe('central');
+    Cache::store('file')->put('key', 'written in tenant context');
+
+    tenancy()->end();
+
+    expect(Cache::store('file')->get('key'))->toBe('written in tenant context');
 });
 
 test('central cache is not lost when tenancy ends', function () {
     $path = storage_path('framework/cache/foo_file');
+    $barPath = storage_path('framework/cache/bar_file');
     File::deleteDirectory($path);
+    File::deleteDirectory($barPath);
 
     // Use a separate 'foo' store rather than reconfiguring 'file'.
     // TestCase::setUp() calls `cache:clear file`, which resolves the 'file' store and leaves it
@@ -351,12 +379,19 @@ test('central cache is not lost when tenancy ends', function () {
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
         ],
-        'tenancy.cache.stores' => ['foo_file'],
         'cache.stores.foo_file' => [
             'driver' => 'file',
             'path' => $path,
             'lock_path' => $path,
         ],
+        'cache.stores.bar_file' => [
+            'driver' => 'file',
+            'path' => $barPath,
+            'lock_path' => $barPath,
+        ],
+        // Only include foo_file in tenancy.cache.stores,
+        // leave bar_file excluded (= not scoped by FilesystemTenancyBootstrapper) for now.
+        'tenancy.cache.stores' => ['foo_file'],
     ]);
 
     $tenant = Tenant::create();
@@ -365,13 +400,21 @@ test('central cache is not lost when tenancy ends', function () {
 
     // Just initialize and revert tenancy to trigger FilesystemTenancyBootstrapper
     tenancy()->initialize($tenant);
+
+    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was stored for it,
+    // and it's left with its configured path (not scoped).
+    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
+    Cache::store('bar_file')->put('bar', 'not scoped');
+
     tenancy()->end();
 
     // Nothing deleted the 'foo' entry, so its value should stay 'central' even after reverting tenancy.
     // FilesystemTenancyBootstrapper::revert() makes the store use its original configured path.
     expect(Cache::store('foo_file')->get('foo'))->toBe('central');
+    expect(Cache::store('bar_file')->get('bar'))->toBe('not scoped');
 
     File::deleteDirectory($path);
+    File::deleteDirectory($barPath);
 });
 
 test('file cache stores with different configured paths do not share a directory', function () {
@@ -540,157 +583,5 @@ test('a cache store using a path not based on storage_path() is suffixed in plac
 
     tenancy()->end();
 
-    File::deleteDirectory($path);
-});
-
-test('cache stores are not scoped at all when scope_cache is disabled', function () {
-    $path = storage_path('framework/cache/foo');
-    File::deleteDirectory($path);
-
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.filesystem.scope_cache' => false,
-        'tenancy.cache.stores' => ['foo_file'],
-        'cache.stores.foo_file' => [
-            'driver' => 'file',
-            'path' => $path,
-            'lock_path' => $path,
-        ],
-    ]);
-
-    tenancy()->initialize(Tenant::create());
-
-    // The store keeps its configured path, so tenants share a single cache directory
-    expect(config('cache.stores.foo_file.path'))->toBe($path);
-    Cache::store('foo_file')->put('key', 'tenant');
-    expect(File::isDirectory($path))->toBeTrue();
-
-    tenancy()->end();
-
-    expect(config('cache.stores.foo_file.path'))->toBe($path);
-    expect(Cache::store('foo_file')->get('key'))->toBe('tenant');
-
-    File::deleteDirectory($path);
-});
-
-test('a store added to tenancy.cache.stores while tenancy is initialized is skipped', function () {
-    $fooPath = storage_path('framework/cache/foo');
-    $barPath = storage_path('framework/cache/bar');
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
-
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.cache.stores' => ['foo_file'],
-        'cache.stores.foo_file' => [
-            'driver' => 'file',
-            'path' => $fooPath,
-            'lock_path' => $fooPath,
-        ],
-        'cache.stores.bar_file' => [
-            'driver' => 'file',
-            'path' => $barPath,
-            'lock_path' => $barPath,
-        ],
-    ]);
-
-    $tenant = Tenant::create();
-    tenancy()->initialize($tenant);
-
-    expect(config('cache.stores.foo_file.path'))->toBe(storage_path('framework/cache/foo'));
-
-    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was stored for it
-    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
-
-    tenancy()->end();
-
-    // foo_file gets reverted, but bar_file is left with the path it's configured with
-    expect(config('cache.stores.foo_file.path'))->toBe($fooPath);
-    expect(config('cache.stores.bar_file.path'))->toBe($barPath);
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
-});
-
-test('a store listed in tenancy.cache.stores that has no cache config is skipped', function () {
-    $path = storage_path('framework/cache/foo');
-    File::deleteDirectory($path);
-
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.cache.stores' => ['foo_file', 'nonexistent_store'],
-        'cache.stores.foo_file' => [
-            'driver' => 'file',
-            'path' => $path,
-            'lock_path' => $path,
-        ],
-    ]);
-
-    $tenant = Tenant::create();
-
-    // The store doesn't exist in cache.stores, so there's nothing to scope (resolving it would throw)
-    tenancy()->initialize($tenant);
-
-    expect(config('cache.stores.foo_file.path'))->toBe(storage_path('framework/cache/foo'));
-    expect(config('cache.stores.nonexistent_store'))->toBeNull();
-
-    tenancy()->end();
-
-    expect(config('cache.stores.foo_file.path'))->toBe($path);
-
-    File::deleteDirectory($path);
-});
-
-test('the original cache paths are only stored on the first bootstrap', function () {
-    // If bootstrap() throws after scopeCache(), the bootstrapper isn't reverted, so the config still
-    // holds the previous tenant's scoped paths during the next bootstrap. Storing the paths again there
-    // would lose the central ones forever.
-    $centralStoragePath = storage_path();
-    $path = "{$centralStoragePath}/framework/cache/foo";
-    File::deleteDirectory($path);
-
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.cache.stores' => ['foo_file'],
-        'cache.stores.foo_file' => [
-            'driver' => 'file',
-            'path' => $path,
-            'lock_path' => $path,
-        ],
-    ]);
-
-    $tenant1 = Tenant::create();
-    $tenant2 = Tenant::create();
-
-    // Make scopeSessions() fail for tenant1 by putting a file where its sessions directory should be.
-    // scopeSessions() runs after scopeCache(), so the cache paths are already scoped when bootstrap() throws.
-    $sessionsPath = "{$centralStoragePath}/tenant{$tenant1->id}/framework/sessions";
-    File::deleteDirectory($sessionsPath);
-    File::ensureDirectoryExists(dirname($sessionsPath));
-    File::put($sessionsPath, '');
-
-    expect(fn () => tenancy()->initialize($tenant1))->toThrow(Exception::class, "Unable to create tenant session directory [{$sessionsPath}].");
-
-    // bootstrap() threw, so the bootstrapper isn't in initializedBootstrappers and revert() gets skipped for it.
-    expect(config('cache.stores.foo_file.path'))->toBe("{$centralStoragePath}/tenant{$tenant1->id}/framework/cache/foo");
-
-    tenancy()->initialize($tenant2);
-
-    expect(config('cache.stores.foo_file.path'))->toBe("{$centralStoragePath}/tenant{$tenant2->id}/framework/cache/foo");
-
-    tenancy()->end();
-
-    expect(config('cache.stores.foo_file.path'))->toBe($path);
-
-    File::deleteDirectory("{$centralStoragePath}/tenant{$tenant1->id}");
     File::deleteDirectory($path);
 });

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -309,7 +309,7 @@ test('file cache stores are separated per tenant', function () {
         // The 'redis' store won't be scoped since it doesn't use the 'file' driver,
         // and 'nonexistent_store' won't be scoped since it just doesn't exist.
         'tenancy.cache.stores' => ['file', 'redis', 'nonexistent_store'],
-        // Laravel's default 'file' store config (set explicitly here just for clarity).
+        // Laravel's default 'file' store config (set explicitly here for clarity)
         'cache.stores.file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
@@ -323,7 +323,7 @@ test('file cache stores are separated per tenant', function () {
     Cache::store('file')->put('key', 'central');
     Cache::store('redis')->put('key', 'central');
 
-    // 'redis' and 'nonexistent_store' are skipped before scopeCache() attempts to read their config.
+    // 'redis' and 'nonexistent_store' are skipped by the driver check in scopeCache(), before it reads their path.
     // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
     // line in scopeCache() would throw an ErrorException (with 'redis', we'd get an
     // 'Undefined array key "path"' exception, and with 'nonexistent_store',
@@ -364,38 +364,59 @@ test('file cache stores are separated per tenant', function () {
     expect(Cache::store('file')->get('key'))->toBe('written in tenant context');
 });
 
-test('central cache is not lost when tenancy ends', function () {
-    $path = storage_path('framework/cache/foo_file');
-    File::deleteDirectory($path);
+test('file cache stores get their path scoped on bootstrap and restored back on revert', function () {
+    $fooPath = storage_path('framework/cache/foo_file');
+    $barPath = storage_path('framework/cache/bar_file');
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
 
-    // Use a separate 'foo_file' store rather than reconfiguring 'file'.
+    // Use separate 'foo_file'/'bar_file' stores rather than reconfiguring 'file'.
     // TestCase::setUp() calls `cache:clear file`, which resolves the 'file' store and leaves it
-    // in the CacheManager with the default path. A later config() call can't mutate that, so a test
-    // reconfiguring 'file' would keep using storage/framework/cache/data and pass either way.
+    // in the CacheManager with the default path. A later config() call can't mutate that,
+    // so in central context, cache would be written to 'storage/framework/cache/data' no matter how the config changes.
     // The same applies to the other tests below that configure separate cache stores rather than using 'file'.
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
         ],
+        'tenancy.cache.stores' => ['foo_file', 'bar_file'],
         'cache.stores.foo_file' => [
             'driver' => 'file',
-            'path' => $path,
-            'lock_path' => $path,
+            'path' => $fooPath,
         ],
-        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.bar_file' => [
+            'driver' => 'file',
+            'path' => $barPath,
+        ],
     ]);
 
-    Cache::store('foo_file')->put('foo', 'central');
+    Cache::store('foo_file')->put('key', 'central foo');
+    Cache::store('bar_file')->put('key', 'central bar');
 
-    // Just initialize and revert tenancy to trigger FilesystemTenancyBootstrapper
     tenancy()->initialize(Tenant::create());
+
+    Cache::store('foo_file')->put('key', 'tenant foo');
+    Cache::store('bar_file')->put('key', 'tenant bar');
+
+    // Each store uses its own scoped path.
+    // The stores don't read or overwrite each other's entries.
+    expect(Cache::store('foo_file')->get('key'))->toBe('tenant foo');
+    expect(Cache::store('bar_file')->get('key'))->toBe('tenant bar');
+
+    Cache::store('bar_file')->flush();
+
+    // Only bar_file was flushed
+    expect(Cache::store('bar_file')->get('key'))->toBeNull();
+    expect(Cache::store('foo_file')->get('key'))->toBe('tenant foo');
+
     tenancy()->end();
 
-    // Nothing deleted the 'foo' entry, so its value should stay 'central' even after reverting tenancy.
-    // FilesystemTenancyBootstrapper::revert() makes the store use its original configured path.
-    expect(Cache::store('foo_file')->get('foo'))->toBe('central');
+    // revert() points each store back at its original configured path
+    expect(Cache::store('foo_file')->get('key'))->toBe('central foo');
+    expect(Cache::store('bar_file')->get('key'))->toBe('central bar');
 
-    File::deleteDirectory($path);
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
 });
 
 test('scopeCache ignores changes to tenancy.cache.stores made in tenant context', function () {
@@ -411,14 +432,12 @@ test('scopeCache ignores changes to tenancy.cache.stores made in tenant context'
         'cache.stores.foo_file' => [
             'driver' => 'file',
             'path' => $fooPath,
-            'lock_path' => $fooPath,
         ],
         'cache.stores.bar_file' => [
             'driver' => 'file',
             'path' => $barPath,
-            'lock_path' => $barPath,
         ],
-        // Only foo_file is scoped at bootstrap()
+        // Only foo_file is scoped during bootstrap()
         'tenancy.cache.stores' => ['foo_file'],
     ]);
 
@@ -429,76 +448,32 @@ test('scopeCache ignores changes to tenancy.cache.stores made in tenant context'
 
     Cache::store('foo_file')->put('key', 'tenant');
 
-    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was captured for it,
-    // and it uses its configured path (central, not scoped).
-    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
-    expect(Cache::store('bar_file')->get('key'))->toBe('central');
-
-    // Remove foo_file from tenancy.cache.stores (original path was captured during bootstrap) in tenant context
+    // Mutate tenancy.cache.stores in tenant context (remove 'foo_file', add 'bar_file')
     config(['tenancy.cache.stores' => ['bar_file']]);
+    // 'bar_file' wasn't in tenancy.cache.stores during bootstrap.
+    // No original path is captured for that store, so it continues to use its central path.
+    expect(Cache::store('bar_file')->get('key'))->toBe('central');
+    Cache::store('bar_file')->put('key', 'written in tenant context');
 
     tenancy()->end();
 
-    // revert() still restores foo_file to its central path
+    // revert() restores the paths for the stores that were scoped during bootstrap
     expect(Cache::store('foo_file')->get('key'))->toBe('central');
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
-});
-
-test('file cache stores with different configured paths do not share a directory', function () {
-    $fooPath = storage_path('framework/cache/foo');
-    $barPath = storage_path('framework/cache/bar');
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
-
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.cache.stores' => ['foo_file', 'bar_file'],
-        'cache.stores.foo_file' => [
-            'driver' => 'file',
-            'path' => $fooPath,
-            'lock_path' => $fooPath,
-        ],
-        'cache.stores.bar_file' => [
-            'driver' => 'file',
-            'path' => $barPath,
-            'lock_path' => $barPath,
-        ],
-    ]);
-
-    tenancy()->initialize(Tenant::create());
-
-    Cache::store('foo_file')->put('key', 'foo');
-    Cache::store('bar_file')->put('key', 'bar');
-
-    // Each store uses its own directory in the tenant's context, so they don't read or overwrite
-    // each other's entries, and flushing one doesn't empty the other.
-    expect(Cache::store('foo_file')->get('key'))->toBe('foo');
-    expect(Cache::store('bar_file')->get('key'))->toBe('bar');
-
-    Cache::store('bar_file')->flush();
-
-    expect(Cache::store('foo_file')->get('key'))->toBe('foo');
-
-    tenancy()->end();
+    // 'bar_file' was never scoped, it still reads from the same path it was writing to in tenant context
+    expect(Cache::store('bar_file')->get('key'))->toBe('written in tenant context');
 
     File::deleteDirectory($fooPath);
     File::deleteDirectory($barPath);
 });
 
 test('a configured lock_path is scoped separately from path', function () {
-    // A store can configure path and lock_path as two different directories.
-    // Locks should use lock_path IF CONFIGURED, not fall back into the same directory as path.
+    // A store can configure path and lock_path as two different directories
     $centralStoragePath = storage_path();
     $path = "{$centralStoragePath}/framework/cache/foo";
     $lockPath = "{$centralStoragePath}/framework/cache/foo_locks";
 
     // Delete the directories before running assertions, not just after.
-    // Cache::lock() below defaults to a lock that never expires,
+    // Cache::store('foo_file')->lock(...) below defaults to a lock that never expires,
     // and this test never releases it, so a stale lock left over from
     // a previous run would make lock() fail forever.
     File::deleteDirectory($path);
@@ -519,31 +494,39 @@ test('a configured lock_path is scoped separately from path', function () {
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
-    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
-
     $tenantPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo";
     $tenantLockPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo_locks";
 
-    // Taking the lock creates the tenant's scoped lock_path directory.
-    // Nothing wrote a cache entry, so the tenant's scoped path directory doesn't exist (path and lock_path are scoped separately).
+    // lock('foo')->get() acquires the lock and creates the lock file at $tenantLockPath
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+
     expect(File::isDirectory($tenantLockPath))->toBeTrue();
+    // The lock file was created at $tenantLockPath, not $tenantPath
     expect(File::isDirectory($tenantPath))->toBeFalse();
 
     tenancy()->end();
 
+    // The lock was only acquired in the tenant context, so in the central context,
+    // it's free (and the lock file doesn't exist in the central context).
+    expect(File::isDirectory($lockPath))->toBeFalse();
+    // Acquire the lock in the central context
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
-
-    // After reverting, locks go back to the configured central lock_path.
+    // The lock file was created at the original (central) lock_path
     expect(File::isDirectory($lockPath))->toBeTrue();
 
     File::deleteDirectory($path);
     File::deleteDirectory($lockPath);
 });
 
-test('a cache store without a configured lock_path is scoped without error', function () {
-    // lock_path is optional -- Laravel falls back to using path for locks when it's not set.
-    // This test covers that path through scopeCache() specifically (which none of the other tests exercise).
-    $path = storage_path('framework/cache/foo');
+test('a file cache store without a configured lock_path defaults to using its scoped path for locks', function () {
+    // 'lock_path' is optional in the file store config.
+    // FileStore falls back to using 'path' for locks when 'lock_path' is not specified in the config (or set to null).
+    // scopeCache() respects the original config and leaves lock_path unset/null.
+    $centralStoragePath = storage_path();
+    $path = "{$centralStoragePath}/framework/cache/foo";
+
+    // $path is hardcoded here. The directory created at $path in a previous run can persist,
+    // so delete the directory at $path first.
     File::deleteDirectory($path);
 
     config([
@@ -554,28 +537,43 @@ test('a cache store without a configured lock_path is scoped without error', fun
         'cache.stores.foo_file' => [
             'driver' => 'file',
             'path' => $path,
-            // No 'lock_path' key at all.
+            // 'lock_path' not set (same behavior as if it were set to null)
         ],
     ]);
 
-    tenancy()->initialize(Tenant::create());
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
 
-    expect(Cache::store('foo_file')->put('key', 'tenant'))->toBeTrue();
+    $tenantPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo";
+
+    // Initializing tenancy scopes the store's 'path', but respects the configured
+    // (unset) 'lock_path' and leaves it alone.
+    expect(config('cache.stores.foo_file.path'))->toBe($tenantPath);
+    expect(config('cache.stores.foo_file.lock_path'))->toBeNull();
+
+    // With no 'lock_path' configured, the lock file will be created in the scoped 'path' directory
+    expect(File::isDirectory($tenantPath))->toBeFalse();
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+    expect(File::isDirectory($tenantPath))->toBeTrue();
+
+    // The lock is still held in the tenant context, so acquiring it again fails
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeFalse();
 
     tenancy()->end();
 
-    expect(Cache::store('foo_file')->put('key', 'central'))->toBeTrue();
+    // The same 'foo' lock is free in central context.
+    // revert() points the 'path' back to the original.
+    expect(File::isDirectory($path))->toBeFalse();
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+    expect(File::isDirectory($path))->toBeTrue();
 
+    // Clean up directory created at the hardcoded path
     File::deleteDirectory($path);
 });
 
-test('a cache store using a path not based on storage_path() is suffixed in place, not moved under the tenant storage path', function () {
-    // $path below doesn't start with the central storage path, so tenantCachePath() has no storage
-    // path prefix to swap for the tenant's -- it appends the tenant suffix directly to $path instead.
-    // Check that tenant isolation still works for a store configured like this, and that its cache
-    // ends up at $path itself, not under the tenant's storage path.
+test('a cache store using a path not based on storage_path() has the tenant suffix appended', function () {
+    // tenantCachePath() has no central storage path prefix to swap for the tenant's here,
+    // so it appends the tenant suffix to $path instead.
     $path = '/tmp/tenancy-cache-test';
     File::deleteDirectory($path);
 
@@ -587,7 +585,6 @@ test('a cache store using a path not based on storage_path() is suffixed in plac
         'cache.stores.foo_file' => [
             'driver' => 'file',
             'path' => $path,
-            'lock_path' => $path,
         ],
     ]);
 
@@ -603,11 +600,9 @@ test('a cache store using a path not based on storage_path() is suffixed in plac
     tenancy()->initialize($tenant1);
     expect(Cache::store('foo_file')->get('key'))->toBe('tenant1');
 
+    // Tenant's 'foo_file' cache directory is created at $path with
+    // the tenant suffix appended, not at the tenant-scoped storage_path().
     expect(File::isDirectory("{$path}/tenant{$tenant1->id}"))->toBeTrue();
-
-    // storage_path() is already scoped to tenant1 here (storagePath() runs before scopeCache() in
-    // bootstrap()), so this is the tenant's default cache directory. Nothing should be there, since
-    // foo_file is configured with its own $path that isn't storage_path()-based.
     expect(File::isDirectory(storage_path('framework/cache/data')))->toBeFalse();
 
     tenancy()->end();

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Stancl\JobPipeline\JobPipeline;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Stancl\Tenancy\Tests\Etc\Tenant;
 use Illuminate\Support\Facades\Event;
@@ -297,4 +298,252 @@ test('scoped disks are scoped per tenant', function () {
 
     expect(file_get_contents(storage_path() . "/app/public/scoped_disk_prefix/foo.txt"))->toBe('central2');
     expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/scoped_disk_prefix/foo.txt"))->toBe('tenant');
+});
+
+test('file cache stores are separated per tenant', function () {
+    // NOTE ABOUT REGRESSION: this is not a regression test,
+    // this just covers what wasn't covered before.
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['file'],
+        'cache.stores.file' => [
+            'driver' => 'file',
+            'path' => storage_path('framework/cache/data'),
+            'lock_path' => storage_path('framework/cache/data'),
+        ],
+    ]);
+
+    $tenant1 = Tenant::create();
+    $tenant2 = Tenant::create();
+
+    Cache::store('file')->put('key', 'central');
+
+    tenancy()->initialize($tenant1);
+
+    expect(Cache::store('file')->get('key'))->toBeNull();
+    Cache::store('file')->put('key', 'tenant1');
+
+    tenancy()->initialize($tenant2);
+
+    expect(Cache::store('file')->get('key'))->toBeNull();
+    Cache::store('file')->put('key', 'tenant2');
+
+    tenancy()->initialize($tenant1);
+
+    expect(Cache::store('file')->get('key'))->toBe('tenant1');
+
+    tenancy()->end();
+
+    expect(Cache::store('file')->get('key'))->toBe('central');
+});
+
+test('central cache is not lost when tenancy ends', function () {
+    $path = storage_path('framework/cache/foo_file');
+    File::deleteDirectory($path);
+
+    // Use a separate 'foo' store rather than reconfiguring 'file'.
+    // TestCase::setUp() calls `cache:clear file`, which resolves the 'file' store and leaves it
+    // in the CacheManager with the default path. A later config() call can't mutate that, so a test
+    // reconfiguring 'file' would keep using storage/framework/cache/data and pass either way.
+    // The same applies to the other tests below that configure separate cache stores rather than using 'file'.
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $path,
+        ],
+    ]);
+
+    $tenant = Tenant::create();
+
+    Cache::store('foo_file')->put('foo', 'central');
+
+    // Just initialize and revert tenancy to trigger FilesystemTenancyBootstrapper
+    tenancy()->initialize($tenant);
+    tenancy()->end();
+
+    // Nothing deleted the 'foo' entry, so its value should stay 'central' even after reverting tenancy.
+    // NOTE ABOUT REGRESSION: revert() sets the store to the hardcoded storage/framework/cache/data instead of
+    // setting it to whatever it was before initializing tenancy. So the central 'foo' entry is null.
+    expect(Cache::store('foo_file')->get('foo'))->toBe('central');
+
+    File::deleteDirectory($path);
+});
+
+test('file cache stores with different configured paths do not share a directory', function () {
+    $fooPath = storage_path('framework/cache/foo');
+    $barPath = storage_path('framework/cache/bar');
+
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file', 'bar_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $fooPath,
+            'lock_path' => $fooPath,
+        ],
+        'cache.stores.bar_file' => [
+            'driver' => 'file',
+            'path' => $barPath,
+            'lock_path' => $barPath,
+        ],
+    ]);
+
+    tenancy()->initialize(Tenant::create());
+
+    Cache::store('foo_file')->put('key', 'foo');
+    Cache::store('bar_file')->put('key', 'bar');
+
+    // NOTE ABOUT REGRESSION: both stores are pointed at the same path,
+    // so they overwrite and read each other's entries.
+    // For the same reason, flushing one of them empties the other.
+    expect(Cache::store('foo_file')->get('key'))->toBe('foo');
+    expect(Cache::store('bar_file')->get('key'))->toBe('bar');
+
+    Cache::store('bar_file')->flush();
+
+    expect(Cache::store('foo_file')->get('key'))->toBe('foo');
+
+    tenancy()->end();
+
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
+});
+
+test('a configured lock_path is scoped separately from path', function () {
+    // A store can configure path and lock_path as two different directories.
+    // Locks should use lock_path IF CONFIGURED, not fall back into the same directory as path.
+    $centralStoragePath = storage_path();
+    $path = "{$centralStoragePath}/framework/cache/foo";
+    $lockPath = "{$centralStoragePath}/framework/cache/foo_locks";
+
+    // Delete the directories before running assertions, not just after.
+    // Cache::lock() below defaults to a lock that never expires,
+    // and this test never releases it, so a stale lock left over from
+    // a previous run would make lock() fail forever.
+    File::deleteDirectory($path);
+    File::deleteDirectory($lockPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $lockPath,
+        ],
+    ]);
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+
+    $tenantPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo";
+    $tenantLockPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo_locks";
+
+    // NOTE ABOUT REGRESSION: path and lock_path both get hardcoded to the same default directory
+    // instead of the ones configured here, so this lock directory never gets created.
+    expect(File::isDirectory($tenantLockPath))->toBeTrue();
+    expect(File::isDirectory($tenantPath))->toBeFalse();
+
+    tenancy()->end();
+
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+
+    // NOTE ABOUT REGRESSION: revert() has the same hardcoding bug, so lock_path is never restored
+    // to what it was configured with either.
+    expect(File::isDirectory($lockPath))->toBeTrue();
+
+    File::deleteDirectory($path);
+    File::deleteDirectory($lockPath);
+});
+
+test('a cache store without a configured lock_path is scoped without error', function () {
+    // lock_path is optional -- Laravel falls back to using path for locks when it's not set.
+    // This test covers that path through scopeCache() specifically (which none of the other tests exercise).
+    $path = storage_path('framework/cache/foo');
+    File::deleteDirectory($path);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            // No 'lock_path' key at all.
+        ],
+    ]);
+
+    tenancy()->initialize(Tenant::create());
+
+    expect(Cache::store('foo_file')->put('key', 'tenant'))->toBeTrue();
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+
+    tenancy()->end();
+
+    expect(Cache::store('foo_file')->put('key', 'central'))->toBeTrue();
+    expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
+
+    File::deleteDirectory($path);
+});
+
+test('a cache store using a path not based on storage_path() is suffixed in place, not moved under the tenant storage path', function () {
+    // $path below doesn't start with the central storage path, so scopeCachePath() has no storage
+    // path prefix to swap for the tenant's -- it appends the tenant suffix directly to $path instead.
+    // Check that tenant isolation still works for a store configured like this, and that its cache
+    // ends up at $path itself, not under the tenant's storage path.
+    $path = '/tmp/tenancy-cache-test';
+    File::deleteDirectory($path);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $path,
+        ],
+    ]);
+
+    $tenant1 = Tenant::create();
+    $tenant2 = Tenant::create();
+
+    tenancy()->initialize($tenant1);
+    Cache::store('foo_file')->put('key', 'tenant1');
+
+    tenancy()->initialize($tenant2);
+    expect(Cache::store('foo_file')->get('key'))->toBeNull();
+
+    tenancy()->initialize($tenant1);
+    expect(Cache::store('foo_file')->get('key'))->toBe('tenant1');
+
+    expect(File::isDirectory("{$path}/tenant{$tenant1->id}"))->toBeTrue();
+
+    // NOTE ABOUT REGRESSION: storage_path() is already scoped to tenant1 here (storagePath() runs
+    // before scopeCache() in bootstrap()), so this is the tenant's default cache directory
+    // the code points every store's cache at, regardless of its configured path. It should stay
+    // empty here, since foo_file is configured with its own $path that's not storage_path()-based.
+    expect(File::isDirectory(storage_path('framework/cache/data')))->toBeFalse();
+
+    tenancy()->end();
+
+    File::deleteDirectory($path);
 });

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -542,3 +542,155 @@ test('a cache store using a path not based on storage_path() is suffixed in plac
 
     File::deleteDirectory($path);
 });
+
+test('cache stores are not scoped at all when scope_cache is disabled', function () {
+    $path = storage_path('framework/cache/foo');
+    File::deleteDirectory($path);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.scope_cache' => false,
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $path,
+        ],
+    ]);
+
+    tenancy()->initialize(Tenant::create());
+
+    // The store keeps its configured path, so tenants share a single cache directory
+    expect(config('cache.stores.foo_file.path'))->toBe($path);
+    Cache::store('foo_file')->put('key', 'tenant');
+    expect(File::isDirectory($path))->toBeTrue();
+
+    tenancy()->end();
+
+    expect(config('cache.stores.foo_file.path'))->toBe($path);
+    expect(Cache::store('foo_file')->get('key'))->toBe('tenant');
+
+    File::deleteDirectory($path);
+});
+
+test('a store added to tenancy.cache.stores while tenancy is initialized is skipped', function () {
+    $fooPath = storage_path('framework/cache/foo');
+    $barPath = storage_path('framework/cache/bar');
+
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $fooPath,
+            'lock_path' => $fooPath,
+        ],
+        'cache.stores.bar_file' => [
+            'driver' => 'file',
+            'path' => $barPath,
+            'lock_path' => $barPath,
+        ],
+    ]);
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    expect(config('cache.stores.foo_file.path'))->toBe(storage_path('framework/cache/foo'));
+
+    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was stored for it
+    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
+
+    tenancy()->end();
+
+    // foo_file gets reverted, but bar_file is left with the path it's configured with
+    expect(config('cache.stores.foo_file.path'))->toBe($fooPath);
+    expect(config('cache.stores.bar_file.path'))->toBe($barPath);
+
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
+});
+
+test('a store listed in tenancy.cache.stores that has no cache config is skipped', function () {
+    $path = storage_path('framework/cache/foo');
+    File::deleteDirectory($path);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file', 'nonexistent_store'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $path,
+        ],
+    ]);
+
+    $tenant = Tenant::create();
+
+    // The store doesn't exist in cache.stores, so there's nothing to scope (resolving it would throw)
+    tenancy()->initialize($tenant);
+
+    expect(config('cache.stores.foo_file.path'))->toBe(storage_path('framework/cache/foo'));
+    expect(config('cache.stores.nonexistent_store'))->toBeNull();
+
+    tenancy()->end();
+
+    expect(config('cache.stores.foo_file.path'))->toBe($path);
+
+    File::deleteDirectory($path);
+});
+
+test('the original cache paths are only stored on the first bootstrap', function () {
+    // If bootstrap() throws after scopeCache(), the bootstrapper isn't reverted, so the config still
+    // holds the previous tenant's scoped paths during the next bootstrap. Storing the paths again there
+    // would lose the central ones forever.
+    $centralStoragePath = storage_path();
+    $path = "{$centralStoragePath}/framework/cache/foo";
+    File::deleteDirectory($path);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $path,
+            'lock_path' => $path,
+        ],
+    ]);
+
+    $tenant1 = Tenant::create();
+    $tenant2 = Tenant::create();
+
+    // Make scopeSessions() fail for tenant1 by putting a file where its sessions directory should be.
+    // scopeSessions() runs after scopeCache(), so the cache paths are already scoped when bootstrap() throws.
+    $sessionsPath = "{$centralStoragePath}/tenant{$tenant1->id}/framework/sessions";
+    File::deleteDirectory($sessionsPath);
+    File::ensureDirectoryExists(dirname($sessionsPath));
+    File::put($sessionsPath, '');
+
+    expect(fn () => tenancy()->initialize($tenant1))->toThrow(Exception::class, "Unable to create tenant session directory [{$sessionsPath}].");
+
+    // bootstrap() threw, so the bootstrapper isn't in initializedBootstrappers and revert() gets skipped for it.
+    expect(config('cache.stores.foo_file.path'))->toBe("{$centralStoragePath}/tenant{$tenant1->id}/framework/cache/foo");
+
+    tenancy()->initialize($tenant2);
+
+    expect(config('cache.stores.foo_file.path'))->toBe("{$centralStoragePath}/tenant{$tenant2->id}/framework/cache/foo");
+
+    tenancy()->end();
+
+    expect(config('cache.stores.foo_file.path'))->toBe($path);
+
+    File::deleteDirectory("{$centralStoragePath}/tenant{$tenant1->id}");
+    File::deleteDirectory($path);
+});

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -350,9 +350,6 @@ test('file cache stores get their paths scoped on bootstrap and restored back on
     // revert() points each store back at its original configured path
     expect(Cache::store('foo_file')->get('key'))->toBe('central foo');
     expect(Cache::store('bar_file')->get('key'))->toBe('central bar');
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
 });
 
 test('only file driver cache stores get scoped', function () {
@@ -389,8 +386,6 @@ test('only file driver cache stores get scoped', function () {
     expect(Cache::store('redis')->get('key'))->toBe('central');
 
     tenancy()->end();
-
-    File::deleteDirectory($fooPath);
 });
 
 test('cache scoping can be toggled using the scope_cache config', function (bool $scopeCache) {
@@ -431,8 +426,6 @@ test('cache scoping can be toggled using the scope_cache config', function (bool
     } else {
         expect(Cache::store('foo_file')->get('key'))->toBe('written in tenant context');
     }
-
-    File::deleteDirectory($fooPath);
 })->with([true, false]);
 
 test('scopeCache ignores changes to tenancy.cache.stores made in tenant context', function () {
@@ -477,9 +470,6 @@ test('scopeCache ignores changes to tenancy.cache.stores made in tenant context'
     expect(Cache::store('foo_file')->get('key'))->toBe('central');
     // 'bar_file' was never scoped, it still reads from the same path it was writing to in tenant context
     expect(Cache::store('bar_file')->get('key'))->toBe('written in tenant context');
-
-    File::deleteDirectory($fooPath);
-    File::deleteDirectory($barPath);
 });
 
 test('a configured lock_path is scoped separately from path', function () {
@@ -488,7 +478,7 @@ test('a configured lock_path is scoped separately from path', function () {
     $path = "{$centralStoragePath}/framework/cache/foo";
     $lockPath = "{$centralStoragePath}/framework/cache/foo_locks";
 
-    // Delete the directories before running assertions, not just after.
+    // The paths are hardcoded, so delete the directories before running the assertions.
     // Cache::store('foo_file')->lock(...) below defaults to a lock that never expires,
     // and this test never releases it, so a stale lock left over from
     // a previous run would make lock() fail forever.
@@ -529,9 +519,6 @@ test('a configured lock_path is scoped separately from path', function () {
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
     // The lock file was created at the original (central) lock_path
     expect(File::isDirectory($lockPath))->toBeTrue();
-
-    File::deleteDirectory($path);
-    File::deleteDirectory($lockPath);
 });
 
 test('a file cache store without a configured lock_path defaults to using its scoped path for locks', function () {
@@ -582,9 +569,6 @@ test('a file cache store without a configured lock_path defaults to using its sc
     expect(File::isDirectory($path))->toBeFalse();
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
     expect(File::isDirectory($path))->toBeTrue();
-
-    // Clean up directory created at the hardcoded path
-    File::deleteDirectory($path);
 });
 
 test('a cache store using a path not based on storage_path() has the tenant suffix appended', function () {
@@ -622,6 +606,4 @@ test('a cache store using a path not based on storage_path() has the tenant suff
     expect(File::isDirectory(storage_path('framework/cache/data')))->toBeFalse();
 
     tenancy()->end();
-
-    File::deleteDirectory($path);
 });

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -366,11 +366,9 @@ test('file cache stores are separated per tenant', function () {
 
 test('central cache is not lost when tenancy ends', function () {
     $path = storage_path('framework/cache/foo_file');
-    $barPath = storage_path('framework/cache/bar_file');
     File::deleteDirectory($path);
-    File::deleteDirectory($barPath);
 
-    // Use a separate 'foo' store rather than reconfiguring 'file'.
+    // Use a separate 'foo_file' store rather than reconfiguring 'file'.
     // TestCase::setUp() calls `cache:clear file`, which resolves the 'file' store and leaves it
     // in the CacheManager with the default path. A later config() call can't mutate that, so a test
     // reconfiguring 'file' would keep using storage/framework/cache/data and pass either way.
@@ -384,36 +382,67 @@ test('central cache is not lost when tenancy ends', function () {
             'path' => $path,
             'lock_path' => $path,
         ],
-        'cache.stores.bar_file' => [
-            'driver' => 'file',
-            'path' => $barPath,
-            'lock_path' => $barPath,
-        ],
-        // Only include foo_file in tenancy.cache.stores,
-        // leave bar_file excluded (= not scoped by FilesystemTenancyBootstrapper) for now.
         'tenancy.cache.stores' => ['foo_file'],
     ]);
-
-    $tenant = Tenant::create();
 
     Cache::store('foo_file')->put('foo', 'central');
 
     // Just initialize and revert tenancy to trigger FilesystemTenancyBootstrapper
-    tenancy()->initialize($tenant);
-
-    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was stored for it,
-    // and it's left with its configured path (not scoped).
-    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
-    Cache::store('bar_file')->put('bar', 'not scoped');
-
+    tenancy()->initialize(Tenant::create());
     tenancy()->end();
 
     // Nothing deleted the 'foo' entry, so its value should stay 'central' even after reverting tenancy.
     // FilesystemTenancyBootstrapper::revert() makes the store use its original configured path.
     expect(Cache::store('foo_file')->get('foo'))->toBe('central');
-    expect(Cache::store('bar_file')->get('bar'))->toBe('not scoped');
 
     File::deleteDirectory($path);
+});
+
+test('scopeCache ignores changes to tenancy.cache.stores made in tenant context', function () {
+    $fooPath = storage_path('framework/cache/foo_file');
+    $barPath = storage_path('framework/cache/bar_file');
+    File::deleteDirectory($fooPath);
+    File::deleteDirectory($barPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $fooPath,
+            'lock_path' => $fooPath,
+        ],
+        'cache.stores.bar_file' => [
+            'driver' => 'file',
+            'path' => $barPath,
+            'lock_path' => $barPath,
+        ],
+        // Only foo_file is scoped at bootstrap()
+        'tenancy.cache.stores' => ['foo_file'],
+    ]);
+
+    Cache::store('foo_file')->put('key', 'central');
+    Cache::store('bar_file')->put('key', 'central');
+
+    tenancy()->initialize(Tenant::create());
+
+    Cache::store('foo_file')->put('key', 'tenant');
+
+    // bar_file wasn't in tenancy.cache.stores during bootstrap, so no original path was captured for it,
+    // and it uses its configured path (central, not scoped).
+    config(['tenancy.cache.stores' => ['foo_file', 'bar_file']]);
+    expect(Cache::store('bar_file')->get('key'))->toBe('central');
+
+    // Remove foo_file from tenancy.cache.stores (original path was captured during bootstrap) in tenant context
+    config(['tenancy.cache.stores' => ['bar_file']]);
+
+    tenancy()->end();
+
+    // revert() still restores foo_file to its central path
+    expect(Cache::store('foo_file')->get('key'))->toBe('central');
+
+    File::deleteDirectory($fooPath);
     File::deleteDirectory($barPath);
 });
 

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -572,7 +572,7 @@ test('a file cache store without a configured lock_path defaults to using its sc
 });
 
 test('a cache store using a path not based on storage_path() has the tenant suffix appended', function () {
-    // tenantCachePath() has no central storage path prefix to swap for the tenant's here,
+    // tenantScopedPath() has no central storage path prefix to swap for the tenant's here,
     // so it appends the tenant suffix to $path instead.
     $path = '/tmp/tenancy-cache-test';
     File::deleteDirectory($path);

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -500,7 +500,7 @@ test('a cache store without a configured lock_path is scoped without error', fun
 });
 
 test('a cache store using a path not based on storage_path() is suffixed in place, not moved under the tenant storage path', function () {
-    // $path below doesn't start with the central storage path, so scopeCachePath() has no storage
+    // $path below doesn't start with the central storage path, so tenantCachePath() has no storage
     // path prefix to swap for the tenant's -- it appends the tenant suffix directly to $path instead.
     // Check that tenant isolation still works for a store configured like this, and that its cache
     // ends up at $path itself, not under the tenant's storage path.

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -300,70 +300,6 @@ test('scoped disks are scoped per tenant', function () {
     expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/scoped_disk_prefix/foo.txt"))->toBe('tenant');
 });
 
-test('file cache stores are separated per tenant', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        // Only stores that use the 'file' driver are scoped.
-        // The 'redis' store won't be scoped since it doesn't use the 'file' driver,
-        // and 'nonexistent_store' won't be scoped since it just doesn't exist.
-        'tenancy.cache.stores' => ['file', 'redis', 'nonexistent_store'],
-        // Laravel's default 'file' store config (set explicitly here for clarity)
-        'cache.stores.file' => [
-            'driver' => 'file',
-            'path' => storage_path('framework/cache/data'),
-            'lock_path' => storage_path('framework/cache/data'),
-        ],
-    ]);
-
-    $tenant1 = Tenant::create();
-    $tenant2 = Tenant::create();
-
-    Cache::store('file')->put('key', 'central');
-    Cache::store('redis')->put('key', 'central');
-
-    // 'redis' and 'nonexistent_store' are skipped by the driver check in scopeCache(), before it reads their path.
-    // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
-    // line in scopeCache() would throw an ErrorException while initializing tenancy
-    // (with 'redis', we'd get an 'Undefined array key "path"' exception, and with 'nonexistent_store',
-    // we'd get 'Trying to access array offset on null').
-    tenancy()->initialize($tenant1);
-
-    expect(Cache::store('file')->get('key'))->toBeNull();
-    Cache::store('file')->put('key', 'tenant1');
-
-    // The 'redis' store doesn't use the file driver (no path to scope),
-    // so FilesystemTenancyBootstrapper skips it in scopeCache().
-    // The central value is retained in the tenant context.
-    expect(Cache::store('redis')->get('key'))->toBe('central');
-
-    tenancy()->initialize($tenant2);
-
-    expect(Cache::store('file')->get('key'))->toBeNull();
-    Cache::store('file')->put('key', 'tenant2');
-
-    tenancy()->initialize($tenant1);
-
-    expect(Cache::store('file')->get('key'))->toBe('tenant1');
-
-    tenancy()->end();
-
-    expect(Cache::store('file')->get('key'))->toBe('central');
-
-    // Turn FilesystemTenancyBootstrapper's cache scoping off
-    config(['tenancy.filesystem.scope_cache' => false]);
-
-    tenancy()->initialize($tenant1);
-
-    expect(Cache::store('file')->get('key'))->toBe('central');
-    Cache::store('file')->put('key', 'written in tenant context');
-
-    tenancy()->end();
-
-    expect(Cache::store('file')->get('key'))->toBe('written in tenant context');
-});
-
 test('file cache stores get their path scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');
     $barPath = storage_path('framework/cache/bar_file');
@@ -417,6 +353,82 @@ test('file cache stores get their path scoped on bootstrap and restored back on 
 
     File::deleteDirectory($fooPath);
     File::deleteDirectory($barPath);
+});
+
+test('only file driver cache stores get scoped', function () {
+    $centralStoragePath = storage_path();
+    $fooPath = storage_path('framework/cache/foo_file');
+    File::deleteDirectory($fooPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $fooPath,
+        ],
+        // Only stores that use the 'file' driver are scoped.
+        // The 'redis' store won't be scoped since it doesn't use the 'file' driver,
+        // and 'nonexistent_store' won't be scoped since it just doesn't exist.
+        'tenancy.cache.stores' => ['foo_file', 'redis', 'nonexistent_store'],
+    ]);
+
+    Cache::store('redis')->put('key', 'central');
+
+    // 'redis' and 'nonexistent_store' are skipped by the driver check in scopeCache(), before it reads their path.
+    // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
+    // line in scopeCache() would throw an ErrorException while initializing tenancy
+    // (with 'redis', we'd get an 'Undefined array key "path"' exception, and with 'nonexistent_store',
+    // we'd get 'Trying to access array offset on null').
+    tenancy()->initialize($tenant = Tenant::create());
+
+    // Only the file store's path gets scoped
+    expect(config('cache.stores.foo_file.path'))->toBe("{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo_file");
+    expect(config('cache.stores.redis'))->not()->toHaveKey('path');
+    expect(config('cache.stores.nonexistent_store'))->toBeNull();
+
+    // The 'redis' store doesn't use the file driver (no path to scope),
+    // so FilesystemTenancyBootstrapper skips it in scopeCache().
+    // The central value is retained in the tenant context.
+    expect(Cache::store('redis')->get('key'))->toBe('central');
+
+    tenancy()->end();
+
+    File::deleteDirectory($fooPath);
+});
+
+test('cache scoping can be disabled using the scope_cache config', function () {
+    $fooPath = storage_path('framework/cache/foo_file');
+    File::deleteDirectory($fooPath);
+
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.cache.stores' => ['foo_file'],
+        'cache.stores.foo_file' => [
+            'driver' => 'file',
+            'path' => $fooPath,
+        ],
+        'tenancy.filesystem.scope_cache' => false,
+    ]);
+
+    Cache::store('foo_file')->put('key', 'central');
+
+    tenancy()->initialize(Tenant::create());
+
+    // The store keeps using its central path, so the cache is shared between contexts
+    expect(config('cache.stores.foo_file.path'))->toBe($fooPath);
+    expect(Cache::store('foo_file')->get('key'))->toBe('central');
+
+    Cache::store('foo_file')->put('key', 'written in tenant context');
+
+    tenancy()->end();
+
+    expect(Cache::store('foo_file')->get('key'))->toBe('written in tenant context');
+
+    File::deleteDirectory($fooPath);
 });
 
 test('scopeCache ignores changes to tenancy.cache.stores made in tenant context', function () {

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -300,7 +300,7 @@ test('scoped disks are scoped per tenant', function () {
     expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/scoped_disk_prefix/foo.txt"))->toBe('tenant');
 });
 
-test('file cache stores get their path scoped on bootstrap and restored back on revert', function () {
+test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');
     $barPath = storage_path('framework/cache/bar_file');
     File::deleteDirectory($fooPath);
@@ -342,8 +342,8 @@ test('file cache stores get their path scoped on bootstrap and restored back on 
     Cache::store('bar_file')->flush();
 
     // Only bar_file was flushed
-    expect(Cache::store('bar_file')->get('key'))->toBeNull();
     expect(Cache::store('foo_file')->get('key'))->toBe('tenant foo');
+    expect(Cache::store('bar_file')->get('key'))->toBeNull();
 
     tenancy()->end();
 
@@ -376,11 +376,6 @@ test('only file driver cache stores get scoped', function () {
 
     Cache::store('redis')->put('key', 'central');
 
-    // 'redis' and 'nonexistent_store' are skipped by the driver check in scopeCache(), before it reads their path.
-    // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
-    // line in scopeCache() would throw an ErrorException while initializing tenancy
-    // (with 'redis', we'd get an 'Undefined array key "path"' exception, and with 'nonexistent_store',
-    // we'd get 'Trying to access array offset on null').
     tenancy()->initialize($tenant = Tenant::create());
 
     // Only the file store's path gets scoped
@@ -398,7 +393,7 @@ test('only file driver cache stores get scoped', function () {
     File::deleteDirectory($fooPath);
 });
 
-test('cache scoping can be disabled using the scope_cache config', function () {
+test('cache scoping can be toggled using the scope_cache config', function (bool $scopeCache) {
     $fooPath = storage_path('framework/cache/foo_file');
     File::deleteDirectory($fooPath);
 
@@ -411,25 +406,34 @@ test('cache scoping can be disabled using the scope_cache config', function () {
             'driver' => 'file',
             'path' => $fooPath,
         ],
-        'tenancy.filesystem.scope_cache' => false,
+        'tenancy.filesystem.scope_cache' => $scopeCache,
     ]);
 
     Cache::store('foo_file')->put('key', 'central');
 
     tenancy()->initialize(Tenant::create());
 
-    // The store keeps using its central path, so the cache is shared between contexts
-    expect(config('cache.stores.foo_file.path'))->toBe($fooPath);
-    expect(Cache::store('foo_file')->get('key'))->toBe('central');
+    if ($scopeCache) {
+        expect(config('cache.stores.foo_file.path'))->not()->toBe($fooPath);
+        expect(Cache::store('foo_file')->get('key'))->toBe(null);
+    } else {
+        // The store keeps using its central path, so the cache is shared between contexts
+        expect(config('cache.stores.foo_file.path'))->toBe($fooPath);
+        expect(Cache::store('foo_file')->get('key'))->toBe('central');
+    }
 
     Cache::store('foo_file')->put('key', 'written in tenant context');
 
     tenancy()->end();
 
-    expect(Cache::store('foo_file')->get('key'))->toBe('written in tenant context');
+    if ($scopeCache) {
+        expect(Cache::store('foo_file')->get('key'))->toBe('central');
+    } else {
+        expect(Cache::store('foo_file')->get('key'))->toBe('written in tenant context');
+    }
 
     File::deleteDirectory($fooPath);
-});
+})->with([true, false]);
 
 test('scopeCache ignores changes to tenancy.cache.stores made in tenant context', function () {
     $fooPath = storage_path('framework/cache/foo_file');

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -301,13 +301,12 @@ test('scoped disks are scoped per tenant', function () {
 });
 
 test('file cache stores are separated per tenant', function () {
-    // NOTE ABOUT REGRESSION: this is not a regression test,
-    // this just covers what wasn't covered before.
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
         ],
         'tenancy.cache.stores' => ['file'],
+        // Laravel's default 'file' store config (set explicitly here just for clarity).
         'cache.stores.file' => [
             'driver' => 'file',
             'path' => storage_path('framework/cache/data'),
@@ -369,8 +368,7 @@ test('central cache is not lost when tenancy ends', function () {
     tenancy()->end();
 
     // Nothing deleted the 'foo' entry, so its value should stay 'central' even after reverting tenancy.
-    // NOTE ABOUT REGRESSION: revert() sets the store to the hardcoded storage/framework/cache/data instead of
-    // setting it to whatever it was before initializing tenancy. So the central 'foo' entry is null.
+    // FilesystemTenancyBootstrapper::revert() makes the store use its original configured path.
     expect(Cache::store('foo_file')->get('foo'))->toBe('central');
 
     File::deleteDirectory($path);
@@ -405,9 +403,8 @@ test('file cache stores with different configured paths do not share a directory
     Cache::store('foo_file')->put('key', 'foo');
     Cache::store('bar_file')->put('key', 'bar');
 
-    // NOTE ABOUT REGRESSION: both stores are pointed at the same path,
-    // so they overwrite and read each other's entries.
-    // For the same reason, flushing one of them empties the other.
+    // Each store uses its own directory in the tenant's context, so they don't read or overwrite
+    // each other's entries, and flushing one doesn't empty the other.
     expect(Cache::store('foo_file')->get('key'))->toBe('foo');
     expect(Cache::store('bar_file')->get('key'))->toBe('bar');
 
@@ -455,8 +452,8 @@ test('a configured lock_path is scoped separately from path', function () {
     $tenantPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo";
     $tenantLockPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/cache/foo_locks";
 
-    // NOTE ABOUT REGRESSION: path and lock_path both get hardcoded to the same default directory
-    // instead of the ones configured here, so this lock directory never gets created.
+    // Taking the lock creates the tenant's scoped lock_path directory.
+    // Nothing wrote a cache entry, so the tenant's scoped path directory doesn't exist (path and lock_path are scoped separately).
     expect(File::isDirectory($tenantLockPath))->toBeTrue();
     expect(File::isDirectory($tenantPath))->toBeFalse();
 
@@ -464,8 +461,7 @@ test('a configured lock_path is scoped separately from path', function () {
 
     expect(Cache::store('foo_file')->lock('foo')->get())->toBeTrue();
 
-    // NOTE ABOUT REGRESSION: revert() has the same hardcoding bug, so lock_path is never restored
-    // to what it was configured with either.
+    // After reverting, locks go back to the configured central lock_path.
     expect(File::isDirectory($lockPath))->toBeTrue();
 
     File::deleteDirectory($path);
@@ -537,10 +533,9 @@ test('a cache store using a path not based on storage_path() is suffixed in plac
 
     expect(File::isDirectory("{$path}/tenant{$tenant1->id}"))->toBeTrue();
 
-    // NOTE ABOUT REGRESSION: storage_path() is already scoped to tenant1 here (storagePath() runs
-    // before scopeCache() in bootstrap()), so this is the tenant's default cache directory
-    // the code points every store's cache at, regardless of its configured path. It should stay
-    // empty here, since foo_file is configured with its own $path that's not storage_path()-based.
+    // storage_path() is already scoped to tenant1 here (storagePath() runs before scopeCache() in
+    // bootstrap()), so this is the tenant's default cache directory. Nothing should be there, since
+    // foo_file is configured with its own $path that isn't storage_path()-based.
     expect(File::isDirectory(storage_path('framework/cache/data')))->toBeFalse();
 
     tenancy()->end();

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -571,7 +571,7 @@ test('a file cache store without a configured lock_path defaults to using its sc
     expect(File::isDirectory($path))->toBeTrue();
 });
 
-test('a cache store using a path not based on storage_path() has the tenant suffix appended', function () {
+test('a cache store using a path not based on storage_path() is scoped to a tenant subdirectory', function () {
     // tenantScopedPath() has no central storage path prefix to swap for the tenant's here,
     // so it appends the tenant suffix to $path instead.
     $path = '/tmp/tenancy-cache-test';
@@ -600,8 +600,8 @@ test('a cache store using a path not based on storage_path() has the tenant suff
     tenancy()->initialize($tenant1);
     expect(Cache::store('foo_file')->get('key'))->toBe('tenant1');
 
-    // Tenant's 'foo_file' cache directory is created at $path with
-    // the tenant suffix appended, not at the tenant-scoped storage_path().
+    // Tenant's 'foo_file' cache directory is created inside $path,
+    // not at the tenant-scoped storage_path().
     expect(File::isDirectory("{$path}/tenant{$tenant1->id}"))->toBeTrue();
     expect(File::isDirectory(storage_path('framework/cache/data')))->toBeFalse();
 

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -325,10 +325,10 @@ test('file cache stores are separated per tenant', function () {
 
     // 'redis' and 'nonexistent_store' are skipped by the driver check in scopeCache(), before it reads their path.
     // Without the skipping logic, the `$this->originalCachePaths[$name] = $store['path']`
-    // line in scopeCache() would throw an ErrorException (with 'redis', we'd get an
-    // 'Undefined array key "path"' exception, and with 'nonexistent_store',
+    // line in scopeCache() would throw an ErrorException while initializing tenancy
+    // (with 'redis', we'd get an 'Undefined array key "path"' exception, and with 'nonexistent_store',
     // we'd get 'Trying to access array offset on null').
-    expect(fn () => tenancy()->initialize($tenant1))->not()->toThrow(ErrorException::class);
+    tenancy()->initialize($tenant1);
 
     expect(Cache::store('file')->get('key'))->toBeNull();
     Cache::store('file')->put('key', 'tenant1');

--- a/tests/SessionSeparationTest.php
+++ b/tests/SessionSeparationTest.php
@@ -83,6 +83,57 @@ test('file sessions are separated', function (bool $scopeSessions) {
     }
 })->with([true, false]);
 
+test('file sessions are separated when a custom session path is configured', function () {
+    $centralStoragePath = storage_path();
+    $configuredSessionPath = "{$centralStoragePath}/framework/foo_sessions";
+
+    config([
+        'tenancy.bootstrappers' => [FilesystemTenancyBootstrapper::class],
+        'session.driver' => 'file',
+        'session.files' => $configuredSessionPath,
+    ]);
+
+    $sessionPath = fn () => invade(app('session')->driver()->getHandler())->path;
+
+    expect($sessionPath())->toBe($configuredSessionPath);
+
+    File::cleanDirectory($configuredSessionPath); // clean up the configured sessions dir from past test runs
+
+    $tenant = Tenant::create();
+    $tenantSessionPath = "{$centralStoragePath}/tenant{$tenant->id}/framework/foo_sessions";
+
+    $tenant->enter();
+
+    // The configured path gets scoped to the tenant
+    expect($sessionPath())->toBe($tenantSessionPath);
+    // Initializing tenancy creates the tenant session dir
+    expect(is_dir($tenantSessionPath))->toBeTrue();
+
+    $tenant->leave();
+
+    // Session path reverts back to the original configured path
+    expect($sessionPath())->toBe($configuredSessionPath);
+
+    // StartSession saves the session at the end of the request, so each request below creates a session file
+    Route::middleware([StartSession::class, InitializeTenancyByPath::class])->get('/{tenant}/foo', fn () => 'bar');
+    Route::middleware(StartSession::class)->get('/central', fn () => 'bar');
+
+    expect(File::files($tenantSessionPath))->toHaveCount(0);
+
+    // Visiting a tenant route should create the session file at the configured path scoped for the tenant
+    pest()->get("/{$tenant->id}/foo");
+
+    expect(File::files($tenantSessionPath))->toHaveCount(1);
+    expect(File::files($configuredSessionPath))->toHaveCount(0);
+
+    // End tenancy to test the revert behavior (= the central session file gets created to the original configured path)
+    tenancy()->end();
+
+    pest()->get('/central');
+
+    expect(File::files($configuredSessionPath))->toHaveCount(1);
+});
+
 test('redis sessions are separated using the redis bootstrapper', function (bool $bootstrappedEnabled) {
     config([
         'tenancy.bootstrappers' => $bootstrappedEnabled ? [RedisTenancyBootstrapper::class] : [],

--- a/tests/SessionSeparationTest.php
+++ b/tests/SessionSeparationTest.php
@@ -126,7 +126,7 @@ test('file sessions are separated when a custom session path is configured', fun
     expect(File::files($tenantSessionPath))->toHaveCount(1);
     expect(File::files($configuredSessionPath))->toHaveCount(0);
 
-    // End tenancy to test the revert behavior (= the central session file gets created to the original configured path)
+    // End tenancy to test the revert behavior (= the central session file gets created at the original configured path)
     tenancy()->end();
 
     pest()->get('/central');


### PR DESCRIPTION
> The cache part of this is specific to `file`-driver stores that are listed in `tenancy.cache.stores`, while `tenancy.filesystem.scope_cache` is set to `true`. The session part applies to the `file` session driver, while `tenancy.filesystem.scope_sessions` is set to `true`.
>
> Ran into this while checking whether we could drop the separate 'parallel' cache store from our boilerplate's testing setup and instead just give the 'file' store a per-process path (`framework/cache/data_<parallel testing token>`), so each test process gets its own cache directory. Turns out `scopeCache()` discards configured paths entirely, so that has no effect (see below).

Using a different directory for the `file` cache store by setting `cache.stores.file.path` (either using `config([...])`, or directly in `config/cache.php` -- doesn't matter) has no effect -- `FilesystemTenancyBootstrapper::scopeCache()` ignores `path`/`lock_path` entirely and rewrites both to a hardcoded `<storage>/framework/cache/data` path on every `tenancy()->initialize()`/`tenancy()->end()`:
```php
// In `FilesystemTenancyBootstrapper::scopeCache()` (called both in `bootstrap()` and in `revert()`)
foreach ($stores as $name) {
    $path = $storagePath . '/framework/cache/data';
    $this->app['config']["cache.stores.{$name}.path"] = $path;
    $this->app['config']["cache.stores.{$name}.lock_path"] = $path;
    ...
}
```

Specific issues with hardcoding the path like this:
- a store with a configured (non-default) path gets scoped to use the default one (what I described above)
- `lock_path` is always overwritten with `path`, so a store with a separate lock directory loses that separation
- `revert()` runs the same code, so it doesn't restore what the store was configured with before tenancy initialized -- it just re-applies the same hardcoded default. Central cache ends up using the wrong path after ending tenancy.

**`scopeSessions()` has the same bug.** It never reads `session.files`, it hardcodes `<storage>/framework/sessions` on both bootstrap and revert. So a configured session path gets discarded when tenancy initializes, and it doesn't get reverted back to what it was when tenancy ends. For example, with `session.files` set to `/tmp/foo-sessions`:

```
In tenant context:    session.files = .../storage/tenant<key>/framework/sessions
After ending tenancy: session.files = .../storage/framework/sessions
```

So after ending tenancy, sessions don't go back to the configured `/tmp/foo-sessions`. They use the hardcoded `<storage>/framework/sessions` path, which was never configured anywhere.

### The fix

In `bootstrap()`, `scopeCache()` captures the original configured paths and scopes those instead of using a hardcoded default.

- If the configured path is under the central storage path, that central part gets swapped for the tenant's storage path, keeping everything after it the same (e.g. `storage/framework/cache/data` becomes `storage/tenant1/framework/cache/data`).
- If the path isn't `storage_path()`-based, there's nothing to swap, so the tenant's suffix just gets appended to the end of the path instead.

On `revert()`, `scopeCache(false)` puts the captured paths back into `cache.stores.{$name}.path`/`lock_path` and into the resolved store instance, so central cache uses the path it was configured with again.

> The paths are captured just once, during `scopeCache()` at `bootstrap()`. If `bootstrap()` fails after `scopeCache()` (e.g. when `scopeSessions()` can't create its directory), `revert()` never runs and the config is left with the scoped paths, so capturing a second time would lose the central ones. Also, `revert()` iterates the stores whose paths were captured during bootstrap rather than `config('tenancy.cache.stores')`. Removing a store from that config in tenant context would otherwise make `revert()` skip it and leave it stuck with a tenant-scoped path, and adding one would make `tenancy()->end()` throw because its path was never captured (see the 'scopeCache ignores changes to tenancy.cache.stores made in tenant context' test). These are edge cases most users wouldn't notice, but still, worth mentioning.

`lock_path` stays `null` when a store doesn't configure it, rather than us making it default to the scoped path -- `FileStore` already falls back to `path` for locks in that case, so we can just respect the store's original config.

`scopeSessions()` does the same for `session.files`. It captures the configured path during `bootstrap()` (once, for the same reason as above), scopes it, and puts it back on `revert()` (the default `storage/framework/sessions` still ends up as `storage/tenant1/framework/sessions`, so nothing changes for the default config).

Also added tests that cover each of the issues above (+ a test for handling paths that aren't `storage_path()`-based, and one for a custom `session.files` path).

**POSSIBLE MINOR BC:** Someone with `'path' => '/var/cache/foobar'` currently gets tenant cache in `storage/tenant1/framework/cache/data`. After this fix, they get `/var/cache/foobar/tenant1`, so whatever is already cached in the old directory is orphaned. The same applies to a non-default `storage_path()`-based path, e.g. `'path' => storage_path('framework/cache/data_' . env('TEST_TOKEN', 'default'))`. The config is now respected while scoping. The same goes for sessions -- with a non-default `session.files`, tenant sessions move from `storage/tenant1/framework/sessions` to the configured path scoped for the tenant, so the sessions in the old directory are orphaned.

## Note about directory separators

While implementing a method that centralizes scoping a path to the tenant (`tenantScopedPath()`), we looked into which code should use `DIRECTORY_SEPARATOR` instead of plain `/` (for Windows compatibility, overall correctness and consistency).

In short, the separators only matter in code that compares paths -- there, both sides of the check have to use the same separators (it doesn't matter whether that's `DIRECTORY_SEPARATOR` or `/`). Strings that only get passed to the filesystem are fine with plain `/` -- the filesystem handles these just fine (for example, Laravel uses `storage_path('framework/cache/data')` as the default `file` cache store's path, and that works just fine on Windows).

A thing related to this are the `rtrim()` calls. In `diskRoot()`'s "disk present in `tenancy.filesystem.disks`, but not in `tenancy.filesystem.root_override`" code branch, `rtrim()` only trimmed the `/` separator. So if a Windows user used a local disk like that, and configured that disk's path to use a trailing separator, the method would set the disk root to a path like `C:\app\uploads\/tenant1`. In practice, this shouldn't be an issue, but trimming both `/` and `\` prevents that code from setting the root to a weird path like that (so a very low impact change).

The `tenantStoragePath()` method got the same treatment as `diskRoot()` mentioned above: the original storage path _could_ be configured with a trailing slash. Again, this was a non-issue, but only because the method's output didn't get compared to other strings in a way where this _could_  be an issue. The `rtrim` there is a _slight_ improvement, but primarily, this got changed for consistency with the change in `diskRoot()`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

* Improved isolation of file-based caches and sessions across tenant contexts.
* Preserved central cache and session locations when switching contexts.
* Scoped cache and lock directories independently, including custom paths.
* Restored original cache and session settings after leaving a tenant context.
* Avoided scoping unsupported, missing, or newly added cache stores.
* Improved compatibility for custom filesystem paths across operating systems.

## Tests

* Expanded coverage for tenant isolation, custom directories, lock paths, session files, and restoration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->