### PR TITLE
[MINOR BC] [4.x] Make storage features not depend on the suffix_storage_path config

### DIFF
--- a/assets/config.php
+++ b/assets/config.php
@@ -321,7 +321,7 @@ return [
 
     /**
      * Filesystem tenancy config. Used by FilesystemTenancyBootstrapper.
-     * https://tenancyforlaravel.com/docs/v3/tenancy-bootstrappers/#filesystem-tenancy-boostrapper.
+     * https://v4.tenancyforlaravel.com/bootstrappers/filesystem.
      */
     'filesystem' => [
         /**
@@ -337,10 +337,16 @@ return [
         /**
          * Use this for local disks.
          *
-         * See https://tenancyforlaravel.com/docs/v3/tenancy-bootstrappers/#filesystem-tenancy-boostrapper
+         * The override can use these placeholders:
+         * - %storage_path% -- the tenant's storage directory. Note that this is resolved
+         *   by the bootstrapper, so it doesn't depend on the 'suffix_storage_path' config below.
+         * - %original_storage_path% -- the central storage directory.
+         * - %tenant% -- the tenant's key.
+         *
+         * See https://v4.tenancyforlaravel.com/bootstrappers/filesystem
          */
         'root_override' => [
-            // Disks whose roots should be overridden after storage_path() is suffixed.
+            // Disks whose roots should be overridden in tenant context.
             'local' => '%storage_path%/app/',
             'public' => '%storage_path%/app/public/',
         ],
@@ -357,7 +363,8 @@ return [
          * Use `php artisan tenants:link` to create a symbolic link from the tenant's storage to its public directory.
          */
         'url_override' => [
-            // Note that the local disk you add must exist in the tenancy.filesystem.disks config
+            // Note that the local disk you add must exist in the tenancy.filesystem.disks config,
+            // and it must have a non-falsy root (i.e., not null or empty string).
             'public' => 'public-%tenant%',
         ],
 

--- a/assets/config.php
+++ b/assets/config.php
@@ -378,7 +378,8 @@ return [
         /**
          * Should storage_path() be suffixed.
          *
-         * Note: This only affects the storage_path() helper. Disks, cache and sessions are
+         * Note: This only affects the storage_path() helper. Disks listed in the 'disks' config
+         * above, and cache and sessions if 'scope_cache' and 'scope_sessions' are enabled, are
          * scoped to the tenant's storage directory either way. With this disabled, files
          * accessed using storage_path() are shared by all tenants.
          *

--- a/assets/config.php
+++ b/assets/config.php
@@ -321,11 +321,12 @@ return [
 
     /**
      * Filesystem tenancy config. Used by FilesystemTenancyBootstrapper.
-     * https://v4.tenancyforlaravel.com/bootstrappers/filesystem.
+     * https://v4.tenancyforlaravel.com/bootstrappers/filesystem
      */
     'filesystem' => [
         /**
-         * Each disk listed in the 'disks' array will be suffixed by the suffix_base, followed by the tenant_id.
+         * Each disk listed in the 'disks' array will have its root
+         * suffixed by the suffix_base, followed by the tenant_id.
          */
         'suffix_base' => 'tenant',
         'disks' => [
@@ -337,11 +338,13 @@ return [
         /**
          * Use this for local disks.
          *
-         * The override can use these placeholders:
-         * - %storage_path% -- the tenant's storage directory. Note that this is resolved
-         *   by the bootstrapper, so it doesn't depend on the 'suffix_storage_path' config below.
+         * Customizes how the disk's root is scoped, instead of the default behavior
+         * which simply appends the tenant suffix to the original root.
+         *
+         * The overrides can reference the following placeholders:
+         * - %storage_path% -- the tenant's storage directory
          * - %original_storage_path% -- the central storage directory.
-         * - %tenant% -- the tenant's key.
+         * - %tenant% -- the tenant key.
          *
          * See https://v4.tenancyforlaravel.com/bootstrappers/filesystem
          */
@@ -364,7 +367,7 @@ return [
          */
         'url_override' => [
             // Note that the local disk you add must exist in the tenancy.filesystem.disks config,
-            // and it must have a non-falsy root (i.e., not null or empty string).
+            // and it must have a non-falsy root (not null nor an empty string).
             'public' => 'public-%tenant%',
         ],
 
@@ -385,14 +388,7 @@ return [
         /**
          * Should storage_path() be suffixed.
          *
-         * Note: This only affects the storage_path() helper. Disks listed in the 'disks' config
-         * above, and cache and sessions if 'scope_cache' and 'scope_sessions' are enabled, are
-         * scoped to the tenant's storage directory either way. With this disabled, files
-         * accessed using storage_path() are shared by all tenants.
-         *
-         * For the vast majority of applications, this feature should be enabled. But in some
-         * edge cases, it can cause issues (like using Passport with Vapor - see #196), so
-         * you may want to disable this if you are experiencing these edge case issues.
+         * Only affects the storage_path() helper, other features use the tenant storage directory regardless.
          */
         'suffix_storage_path' => true,
 

--- a/assets/config.php
+++ b/assets/config.php
@@ -357,7 +357,7 @@ return [
          * Use `php artisan tenants:link` to create a symbolic link from the tenant's storage to its public directory.
          */
         'url_override' => [
-            // Note that the local disk you add must exist in the tenancy.filesystem.root_override config
+            // Note that the local disk you add must exist in the tenancy.filesystem.disks config
             'public' => 'public-%tenant%',
         ],
 

--- a/assets/config.php
+++ b/assets/config.php
@@ -378,7 +378,9 @@ return [
         /**
          * Should storage_path() be suffixed.
          *
-         * Note: Disabling this will likely break local disk tenancy. Only disable this if you're using an external file storage service like S3.
+         * Note: This only affects the storage_path() helper. Disks, cache and sessions are
+         * scoped to the tenant's storage directory either way. With this disabled, files
+         * accessed using storage_path() are shared by all tenants.
          *
          * For the vast majority of applications, this feature should be enabled. But in some
          * edge cases, it can cause issues (like using Passport with Vapor - see #196), so

--- a/src/Actions/CreateStorageSymlinksAction.php
+++ b/src/Actions/CreateStorageSymlinksAction.php
@@ -47,6 +47,12 @@ class CreateStorageSymlinksAction
             mkdir($storagePath, 0777, true);
         }
 
+        // The public path of a prefixed disk includes the prefix,
+        // and its parent directories may not exist yet.
+        if (! is_dir($publicParent = dirname($publicPath))) {
+            mkdir($publicParent, 0777, true);
+        }
+
         if ($relativeLink) {
             app()->make('files')->relativeLink($storagePath, $publicPath);
         } else {

--- a/src/Actions/RemoveStorageSymlinksAction.php
+++ b/src/Actions/RemoveStorageSymlinksAction.php
@@ -18,7 +18,8 @@ class RemoveStorageSymlinksAction
     /**
      * Should the directories created for nested symlinks be removed along with the symlink.
      *
-     * Before enabling this, make sure you understand the removeLink() method and its implications.
+     * Before enabling this, make sure you understand the removeLink() method
+     * and the high stakes of recursively removing parent directories (even if the logic should be sound).
      *
      * @see CreateStorageSymlinksAction
      */

--- a/src/Actions/RemoveStorageSymlinksAction.php
+++ b/src/Actions/RemoveStorageSymlinksAction.php
@@ -16,6 +16,15 @@ class RemoveStorageSymlinksAction
     use DealsWithTenantSymlinks;
 
     /**
+     * Should the directories created for nested symlinks be removed along with the symlink.
+     *
+     * Before enabling this, make sure you understand the removeLink() method and its implications.
+     *
+     * @see CreateStorageSymlinksAction
+     */
+    public static bool $removeNestedDirectories = false;
+
+    /**
      * @param Tenant|Collection<covariant int|string, Tenant&\Illuminate\Database\Eloquent\Model>|LazyCollection<covariant int|string, Tenant&\Illuminate\Database\Eloquent\Model> $tenants
      */
     public function __invoke(Tenant|Collection|LazyCollection $tenants): void
@@ -32,21 +41,32 @@ class RemoveStorageSymlinksAction
 
     protected function removeLink(string $publicPath, Tenant $tenant): void
     {
+        if (! $this->symlinkExists($publicPath)) {
+            return;
+        }
+
         $files = app()->make('files');
 
-        if ($this->symlinkExists($publicPath)) {
-            event(new RemovingStorageSymlink($tenant));
+        event(new RemovingStorageSymlink($tenant));
 
-            $files->delete($publicPath);
+        $files->delete($publicPath);
 
-            event(new StorageSymlinkRemoved($tenant));
+        event(new StorageSymlinkRemoved($tenant));
+
+        if (! static::$removeNestedDirectories) {
+            return;
+        }
+
+        $publicRoot = realpath(public_path());
+        $directory = realpath(dirname($publicPath));
+
+        if ($publicRoot === false || $directory === false) {
+            return;
         }
 
         // Remove the directories CreateStorageSymlinksAction created for the symlink
         // until a non-empty one is reached.
-        $directory = dirname($publicPath);
-
-        while ($directory !== public_path() && $files->isEmptyDirectory($directory)) {
+        while (str_starts_with($directory, $publicRoot . DIRECTORY_SEPARATOR) && $files->isEmptyDirectory($directory)) {
             $files->deleteDirectory($directory);
 
             $directory = dirname($directory);

--- a/src/Actions/RemoveStorageSymlinksAction.php
+++ b/src/Actions/RemoveStorageSymlinksAction.php
@@ -66,7 +66,7 @@ class RemoveStorageSymlinksAction
 
         // Remove the directories CreateStorageSymlinksAction created for the symlink
         // until a non-empty one is reached.
-        while (str_starts_with($directory, $publicRoot . DIRECTORY_SEPARATOR) && $files->isEmptyDirectory($directory)) {
+        while (str_starts_with(rtrim($directory, '/\\'), rtrim($publicRoot, '/\\') . DIRECTORY_SEPARATOR) && $files->isEmptyDirectory($directory)) {
             $files->deleteDirectory($directory);
 
             $directory = dirname($directory);

--- a/src/Actions/RemoveStorageSymlinksAction.php
+++ b/src/Actions/RemoveStorageSymlinksAction.php
@@ -32,12 +32,24 @@ class RemoveStorageSymlinksAction
 
     protected function removeLink(string $publicPath, Tenant $tenant): void
     {
+        $files = app()->make('files');
+
         if ($this->symlinkExists($publicPath)) {
             event(new RemovingStorageSymlink($tenant));
 
-            app()->make('files')->delete($publicPath);
+            $files->delete($publicPath);
 
             event(new StorageSymlinkRemoved($tenant));
+        }
+
+        // Remove the directories CreateStorageSymlinksAction created for the symlink
+        // until a non-empty one is reached.
+        $directory = dirname($publicPath);
+
+        while ($directory !== public_path() && $files->isEmptyDirectory($directory)) {
+            $files->deleteDirectory($directory);
+
+            $directory = dirname($directory);
         }
     }
 }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -176,7 +176,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     {
         $diskConfig = $this->app['config']["filesystems.disks.{$disk}"];
 
-        if ($diskConfig['driver'] !== 'local' || $this->app['config']["tenancy.filesystem.url_override.{$disk}"] === null) {
+        if ($diskConfig['driver'] !== 'local' || ! $this->app['config']["tenancy.filesystem.url_override.{$disk}"]) {
             return;
         }
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -331,8 +331,8 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     /**
      * Get the storage path of the passed tenant (independent of the current context).
      *
-     * This is the directory the bootstrapper scopes disks, cache and sessions to,
-     * regardless of suffix_storage_path (that config option only affects the storage_path() helper).
+     * The returned path doesn't depend on suffix_storage_path -- that config option
+     * only controls whether storage_path() uses it.
      */
     public static function getBoundTenantStoragePath(Tenant $tenant): string
     {

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -128,9 +128,9 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $scopedDisks = [];
 
         foreach ($this->app['config']['filesystems.disks'] as $name => $disk) {
-            if (isset($disk['driver'], $disk['disk'])
+            if (isset($disk['driver'])
                 && $disk['driver'] === 'scoped'
-                && in_array($disk['disk'], $tenantDisks, true)) {
+                && in_array(static::baseDiskName($name), $tenantDisks, true)) {
                 $scopedDisks[] = $name;
             }
         }
@@ -339,5 +339,35 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $bootstrapper = app(static::class);
 
         return $bootstrapper->tenantStoragePath($bootstrapper->suffix($tenant));
+    }
+
+    /**
+     * Name of the disk whose root the passed disk uses.
+     *
+     * Disks using the 'scoped' driver have no root or url of their own -- they inherit these from their parent disk,
+     * which can be scoped as well, so only the final/base parent has to be tenant-aware.
+     *
+     * Returns null if the chain doesn't end with a named disk, i.e. when a parent disk is
+     * configured inline or when the disks reference each other.
+     */
+    public static function baseDiskName(string $disk): string|null
+    {
+        // Keep track of visited disks to avoid infinite loops in case of disks referencing each other
+        $visited = [];
+
+        while (config("filesystems.disks.$disk.driver") === 'scoped') {
+            if (in_array($disk, $visited, true)) {
+                return null;
+            }
+
+            $visited[] = $disk;
+
+            if (! is_string($disk = config("filesystems.disks.$disk.disk"))) {
+                // Laravel allows configuring the parent disk inline as an array, and such a disk has no name
+                return null;
+            }
+        }
+
+        return $disk;
     }
 }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -331,8 +331,8 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     /**
      * Get the storage path of the passed tenant (independent of the current context).
      *
-     * The returned path doesn't depend on suffix_storage_path -- that config option
-     * only controls whether storage_path() uses it.
+     * Note that the returned path doesn't depend on suffix_storage_path.
+     * That config option only affects the storage_path() helper.
      */
     public static function getBoundTenantStoragePath(Tenant $tenant): string
     {

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -128,10 +128,16 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
         $scopedDisks = [];
 
         foreach ($this->app['config']['filesystems.disks'] as $name => $disk) {
-            if (isset($disk['driver'])
-                && $disk['driver'] === 'scoped'
-                && in_array(static::baseDiskName($name), $tenantDisks, true)) {
+            if (($disk['driver'] ?? null) !== 'scoped') {
+                continue;
+            }
+
+            $baseDisk = static::baseDiskName($name);
+
+            if (in_array($baseDisk, $tenantDisks, true)) {
                 $scopedDisks[] = $name;
+            } elseif (in_array($name, $tenantDisks, true)) {
+                throw new Exception("A disk using the 'scoped' driver cannot be tenant-aware. List its base disk in tenancy.filesystem.disks instead.");
             }
         }
 
@@ -142,6 +148,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     {
         if ($this->app['config']["filesystems.disks.$disk.driver"] === 'scoped') {
             // Skip scoped disks since they have no root to override
+            // (reachable when a scoped disk is listed in tenancy.filesystem.disks alongside its base disk).
             return;
         }
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -140,6 +140,11 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
     protected function diskRoot(string $disk, Tenant|false $tenant): void
     {
+        if ($this->app['config']["filesystems.disks.$disk.driver"] === 'scoped') {
+            // Skip scoped disks since they have no root to override
+            return;
+        }
+
         if ($tenant === false) {
             $this->app['config']["filesystems.disks.$disk.root"] = $this->originalDisks[$disk]['root'];
 

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -327,4 +327,17 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     {
         return app(static::class)->originalStoragePath;
     }
+
+    /**
+     * Get the storage path of the passed tenant (independent of the current context).
+     *
+     * This is the directory the bootstrapper scopes disks, cache and sessions to,
+     * regardless of suffix_storage_path (that config option only affects the storage_path() helper).
+     */
+    public static function getBoundTenantStoragePath(Tenant $tenant): string
+    {
+        $bootstrapper = app(static::class);
+
+        return $bootstrapper->tenantStoragePath($bootstrapper->suffix($tenant));
+    }
 }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -339,7 +339,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      * Note that the returned path doesn't depend on suffix_storage_path.
      * That config option only affects the storage_path() helper.
      */
-    public static function getBoundTenantStoragePath(Tenant $tenant): string
+    public static function getTenantStoragePath(Tenant $tenant): string
     {
         $bootstrapper = app(static::class);
 
@@ -349,7 +349,7 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
     /**
      * Name of the disk whose root the passed disk uses.
      *
-     * Disks using the 'scoped' driver have no root or url of their own -- they inherit these from their parent disk,
+     * Disks using the 'scoped' driver have no root or url of their own -- they inherit those from their parent disk,
      * which can be scoped as well, so only the final/base parent has to be tenant-aware.
      *
      * Returns null if the chain doesn't end with a named disk, i.e. when a parent disk is
@@ -362,12 +362,14 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
 
         while (config("filesystems.disks.$disk.driver") === 'scoped') {
             if (in_array($disk, $visited, true)) {
+                // The disk and its parents reference each other, invalid
                 return null;
             }
 
             $visited[] = $disk;
+            $disk = config("filesystems.disks.$disk.disk");
 
-            if (! is_string($disk = config("filesystems.disks.$disk.disk"))) {
+            if (! is_string($disk)) {
                 // Laravel allows configuring the parent disk inline as an array, and such a disk has no name
                 return null;
             }

--- a/src/Bootstrappers/FilesystemTenancyBootstrapper.php
+++ b/src/Bootstrappers/FilesystemTenancyBootstrapper.php
@@ -132,12 +132,10 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
                 continue;
             }
 
-            $baseDisk = static::baseDiskName($name);
-
-            if (in_array($baseDisk, $tenantDisks, true)) {
+            if (in_array(static::baseDiskName($name), $tenantDisks, true)) {
                 $scopedDisks[] = $name;
             } elseif (in_array($name, $tenantDisks, true)) {
-                throw new Exception("A disk using the 'scoped' driver cannot be tenant-aware. List its base disk in tenancy.filesystem.disks instead.");
+                throw new Exception("Disk [$name] uses the 'scoped' driver, so it has no root to make tenant-aware. List its base disk in tenancy.filesystem.disks instead.");
             }
         }
 
@@ -359,27 +357,17 @@ class FilesystemTenancyBootstrapper implements TenancyBootstrapper
      * Disks using the 'scoped' driver have no root or url of their own -- they inherit those from their parent disk,
      * which can be scoped as well, so only the final/base parent has to be tenant-aware.
      *
-     * Returns null if the chain doesn't end with a named disk, i.e. when a parent disk is
-     * configured inline or when the disks reference each other.
+     * Returns null if the base disk has no name, i.e. when the disk is configured inline as an array.
      */
     public static function baseDiskName(string $disk): string|null
     {
-        // Keep track of visited disks to avoid infinite loops in case of disks referencing each other
-        $visited = [];
-
         while (config("filesystems.disks.$disk.driver") === 'scoped') {
-            if (in_array($disk, $visited, true)) {
-                // The disk and its parents reference each other, invalid
-                return null;
-            }
-
-            $visited[] = $disk;
-            $disk = config("filesystems.disks.$disk.disk");
-
-            if (! is_string($disk)) {
+            if (! is_string($parent = config("filesystems.disks.$disk.disk"))) {
                 // Laravel allows configuring the parent disk inline as an array, and such a disk has no name
                 return null;
             }
+
+            $disk = $parent;
         }
 
         return $disk;

--- a/src/Bootstrappers/LogChannelBootstrapper.php
+++ b/src/Bootstrappers/LogChannelBootstrapper.php
@@ -151,12 +151,12 @@ class LogChannelBootstrapper implements TenancyBootstrapper
                 // The tenant log will be located at e.g. "storage/tenant{$tenantKey}/logs/laravel.log".
                 $originalChannelPath = $this->config->get("logging.channels.{$channel}.path");
                 $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
-                $tenantStoragePath = FilesystemTenancyBootstrapper::getBoundTenantStoragePath($tenant);
+                $tenantStoragePath = FilesystemTenancyBootstrapper::getTenantStoragePath($tenant);
 
                 // The tenant log will inherit the segment that follows the storage path from the central channel path config.
                 // For example, if a channel's path is configured to storage_path('logs/foo.log') (storage/logs/foo.log),
                 // the '/logs/foo.log' segment will be placed within the tenant storage path (so the log will be located at storage/tenant123/logs/foo.log).
-                $this->config->set("logging.channels.{$channel}.path", $tenantStoragePath . Str::after($originalChannelPath, $centralStoragePath));
+                $this->config->set("logging.channels.{$channel}.path", $tenantStoragePath . Str::after($originalChannelPath, rtrim($centralStoragePath, '/\\')));
             }
         }
     }

--- a/src/Bootstrappers/LogChannelBootstrapper.php
+++ b/src/Bootstrappers/LogChannelBootstrapper.php
@@ -21,7 +21,7 @@ use Stancl\Tenancy\Contracts\Tenant;
  * Laravel's 'single' and 'daily' channels by default. To customize it,
  * see the property's docblock.
  *
- * Note that since the tenant's storage path is resolved using FilesystemTenancyBootstrapper::getBoundTenantStoragePath(),
+ * Note that since the tenant's storage path is resolved using FilesystemTenancyBootstrapper::getTenantStoragePath(),
  * which is a public static method, FilesystemTenancyBootstrapper does not have to be enabled.
  *
  * For logging channels that are not filesystem-based, see the $channelOverrides logic.

--- a/src/Bootstrappers/LogChannelBootstrapper.php
+++ b/src/Bootstrappers/LogChannelBootstrapper.php
@@ -21,11 +21,8 @@ use Stancl\Tenancy\Contracts\Tenant;
  * Laravel's 'single' and 'daily' channels by default. To customize it,
  * see the property's docblock.
  *
- * For the storage path channels to be scoped correctly:
- * - this bootstrapper must run *after* FilesystemTenancyBootstrapper,
- *   since FilesystemTenancyBootstrapper adjusts storage_path() for the tenant
- * - storage path suffixing has to be enabled (= config('tenancy.filesystem.suffix_storage_path')
- *   must be true), since the storage path suffix is what separates filesystem-based logs
+ * Note that since the tenant's storage path is resolved using FilesystemTenancyBootstrapper::getBoundTenantStoragePath(),
+ * which is a public static method, FilesystemTenancyBootstrapper does not have to be enabled.
  *
  * For logging channels that are not filesystem-based, see the $channelOverrides logic.
  *
@@ -40,14 +37,10 @@ class LogChannelBootstrapper implements TenancyBootstrapper
     /**
      * Logging channels whose path is built using storage_path() (e.g. Laravel's 'single' and 'daily').
      *
-     * Channels included here will be configured to use tenant-specific storage paths
-     * created using storage_path() in the tenant context. Overrides in the $channelOverrides
-     * property take precedence over $storagePathChannels when a channel is included in both.
+     * Channels included here will be configured to use tenant-specific storage paths.
      *
-     * Requires FilesystemTenancyBootstrapper to run before this bootstrapper,
-     * and storage path suffixing to be enabled.
-     *
-     * @see Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper
+     * Overrides in the $channelOverrides property take precedence over
+     * $storagePathChannels when a channel is included in both.
      */
     public static array $storagePathChannels = ['single', 'daily'];
 
@@ -158,11 +151,12 @@ class LogChannelBootstrapper implements TenancyBootstrapper
                 // The tenant log will be located at e.g. "storage/tenant{$tenantKey}/logs/laravel.log".
                 $originalChannelPath = $this->config->get("logging.channels.{$channel}.path");
                 $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
+                $tenantStoragePath = FilesystemTenancyBootstrapper::getBoundTenantStoragePath($tenant);
 
                 // The tenant log will inherit the segment that follows the storage path from the central channel path config.
                 // For example, if a channel's path is configured to storage_path('logs/foo.log') (storage/logs/foo.log),
-                // the 'logs/foo.log' segment will be passed to storage_path() in the tenant context (storage/tenant123/logs/foo.log).
-                $this->config->set("logging.channels.{$channel}.path", storage_path(Str::after($originalChannelPath, $centralStoragePath)));
+                // the '/logs/foo.log' segment will be appended to the tenant storage path (so the log will be located at storage/tenant123/logs/foo.log).
+                $this->config->set("logging.channels.{$channel}.path", $tenantStoragePath . Str::after($originalChannelPath, $centralStoragePath));
             }
         }
     }

--- a/src/Bootstrappers/LogChannelBootstrapper.php
+++ b/src/Bootstrappers/LogChannelBootstrapper.php
@@ -155,7 +155,7 @@ class LogChannelBootstrapper implements TenancyBootstrapper
 
                 // The tenant log will inherit the segment that follows the storage path from the central channel path config.
                 // For example, if a channel's path is configured to storage_path('logs/foo.log') (storage/logs/foo.log),
-                // the '/logs/foo.log' segment will be appended to the tenant storage path (so the log will be located at storage/tenant123/logs/foo.log).
+                // the '/logs/foo.log' segment will be placed within the tenant storage path (so the log will be located at storage/tenant123/logs/foo.log).
                 $this->config->set("logging.channels.{$channel}.path", $tenantStoragePath . Str::after($originalChannelPath, $centralStoragePath));
             }
         }

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -50,6 +50,12 @@ trait DealsWithTenantSymlinks
                 throw new Exception("Disk $disk is not a local disk. Only local disks can be symlinked.");
             }
 
+            if (! in_array($disk, config('tenancy.filesystem.disks'), true)) {
+                // The bootstrapper only scopes disks listed in tenancy.filesystem.disks. Without that,
+                // the disk root stays central, and the symlink of every tenant would point to it.
+                throw new Exception("Disk $disk is not tenant-aware. Add it to the tenancy.filesystem.disks config to make its root tenant-specific.");
+            }
+
             $publicPath = str_replace('%tenant%', (string) $tenantKey, $publicPath);
 
             $symlinks[public_path($publicPath)] = $tenantDisks[$disk]['root'];

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -58,8 +58,16 @@ trait DealsWithTenantSymlinks
             }
 
             $publicPath = str_replace('%tenant%', (string) $tenantKey, $publicPath);
+            $diskRoot = $tenantDisks[$disk]['root'];
 
-            $symlinks[public_path($publicPath)] = $tenantDisks[$disk]['root'];
+            if ($prefix = trim($disks[$disk]['prefix'] ?? '', '/\\')) {
+                $diskRoot = rtrim($diskRoot, '/\\') . DIRECTORY_SEPARATOR . $prefix;
+
+                // Storage::url() appends the disk's prefix to the url, so the prefix has to be in the public path as well
+                $publicPath .= DIRECTORY_SEPARATOR . $prefix;
+            }
+
+            $symlinks[public_path($publicPath)] = $diskRoot;
         }
 
         return $symlinks;

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -7,15 +7,21 @@ namespace Stancl\Tenancy\Concerns;
 use Exception;
 use Stancl\Tenancy\Contracts\Tenant;
 
+/**
+ * Requires FilesystemTenancyBootstrapper to be enabled, since the tenant symlinks
+ * point to the disk roots scoped by the bootstrapper.
+ *
+ * @see \Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper
+ */
 trait DealsWithTenantSymlinks
 {
     /**
-     * Get all possible tenant symlinks, existing or not (array of ['public path' => 'storage path']).
+     * Get all possible tenant symlinks, existing or not (array of ['public path' => 'disk root']).
      *
      * Tenants can have a symlink for each disk registered in the tenancy.filesystem.url_override config.
      * This is used for creating all possible tenant symlinks and removing all existing tenant symlinks.
-     * The same storage path can be symlinked to multiple public paths, which is why the public path
-     * is the Collection key.
+     * The same disk root can be symlinked to multiple public paths, which is why the public path
+     * is the array key.
      *
      * @return array<string, string>
      */
@@ -26,7 +32,7 @@ trait DealsWithTenantSymlinks
         $rootOverrides = config('tenancy.filesystem.root_override');
 
         $tenantKey = $tenant->getTenantKey();
-        $tenantStoragePath = tenancy()->run($tenant, fn () => storage_path());
+        $tenantDisks = tenancy()->run($tenant, fn () => config('filesystems.disks'));
 
         /** @var array<string, string> $symlinks */
         $symlinks = [];
@@ -45,9 +51,8 @@ trait DealsWithTenantSymlinks
             }
 
             $publicPath = str_replace('%tenant%', (string) $tenantKey, $publicPath);
-            $storagePath = str_replace('%storage_path%', $tenantStoragePath, $rootOverrides[$disk]);
 
-            $symlinks[public_path($publicPath)] = $storagePath;
+            $symlinks[public_path($publicPath)] = $tenantDisks[$disk]['root'];
         }
 
         return $symlinks;

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -40,7 +40,6 @@ trait DealsWithTenantSymlinks
 
         foreach ($urlOverrides as $disk => $publicPath) {
             if (! $publicPath) {
-                // The disk's URL is not overridden, same as in FilesystemTenancyBootstrapper::diskUrl()
                 continue;
             }
 

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -18,7 +18,9 @@ trait DealsWithTenantSymlinks
     /**
      * Get all possible tenant symlinks, existing or not (array of ['public path' => 'disk root']).
      *
-     * Tenants can have a symlink for each disk registered in the tenancy.filesystem.url_override config.
+     * Tenants can have a symlink for each local disk that is listed
+     * in both tenancy.filesystem.disks and tenancy.filesystem.url_override.
+     *
      * This is used for creating all possible tenant symlinks and removing all existing tenant symlinks.
      * The same disk root can be symlinked to multiple public paths, which is why the public path
      * is the array key.
@@ -29,7 +31,6 @@ trait DealsWithTenantSymlinks
     {
         $disks = config('filesystems.disks');
         $urlOverrides = config('tenancy.filesystem.url_override');
-        $rootOverrides = config('tenancy.filesystem.root_override');
 
         $tenantKey = $tenant->getTenantKey();
         $tenantDisks = tenancy()->run($tenant, fn () => config('filesystems.disks'));
@@ -38,11 +39,12 @@ trait DealsWithTenantSymlinks
         $symlinks = [];
 
         foreach ($urlOverrides as $disk => $publicPath) {
-            if (! isset($disks[$disk])) {
+            if (! $publicPath) {
+                // The disk's URL is not overridden, same as in FilesystemTenancyBootstrapper::diskUrl()
                 continue;
             }
 
-            if (! isset($rootOverrides[$disk])) {
+            if (! isset($disks[$disk])) {
                 continue;
             }
 
@@ -51,8 +53,8 @@ trait DealsWithTenantSymlinks
             }
 
             if (! in_array($disk, config('tenancy.filesystem.disks'), true)) {
-                // The bootstrapper only scopes disks listed in tenancy.filesystem.disks. Without that,
-                // the disk root stays central, and the symlink of every tenant would point to it.
+                // The bootstrapper only scopes disks listed in tenancy.filesystem.disks.
+                // Without that, the root stays central and the symlink of every tenant would point to it.
                 throw new Exception("Disk $disk is not tenant-aware. Add it to the tenancy.filesystem.disks config to make its root tenant-specific.");
             }
 

--- a/src/Concerns/DealsWithTenantSymlinks.php
+++ b/src/Concerns/DealsWithTenantSymlinks.php
@@ -16,7 +16,7 @@ use Stancl\Tenancy\Contracts\Tenant;
 trait DealsWithTenantSymlinks
 {
     /**
-     * Get all possible tenant symlinks, existing or not (array of ['public path' => 'disk root']).
+     * Get all possible tenant symlinks, existing or not (array of ['public path' => 'disk root with the disk's prefix appended']).
      *
      * Tenants can have a symlink for each local disk that is listed
      * in both tenancy.filesystem.disks and tenancy.filesystem.url_override.
@@ -61,9 +61,11 @@ trait DealsWithTenantSymlinks
             $diskRoot = $tenantDisks[$disk]['root'];
 
             if ($prefix = trim($disks[$disk]['prefix'] ?? '', '/\\')) {
+                // Append the disk's prefix to the disk root
                 $diskRoot = rtrim($diskRoot, '/\\') . DIRECTORY_SEPARATOR . $prefix;
 
-                // Storage::url() appends the disk's prefix to the url, so the prefix has to be in the public path as well
+                // Append the same prefix to the public path.
+                // Storage::url() appends the disk's prefix to the url, so the prefix has to be in the public path as well.
                 $publicPath .= DIRECTORY_SEPARATOR . $prefix;
             }
 

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -121,7 +121,7 @@ class TenantAssetController implements HasMiddleware
         }
 
         if ($tenant = tenant()) {
-            return FilesystemTenancyBootstrapper::getBoundTenantStoragePath($tenant) . '/app/public';
+            return FilesystemTenancyBootstrapper::getTenantStoragePath($tenant) . '/app/public';
         }
 
         return storage_path('app/public');

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -29,6 +29,13 @@ class TenantAssetController implements HasMiddleware
      */
     public static array $middleware = [];
 
+    /**
+     * Disk the assets are served from.
+     *
+     * When null, the assets are served from app/public inside the tenant's storage directory.
+     */
+    public static string|null $publicDisk = null;
+
     public static function middleware()
     {
         return array_map(
@@ -59,13 +66,25 @@ class TenantAssetController implements HasMiddleware
     }
 
     /**
-     * Assets are served from app/public inside the tenant's storage directory.
+     * Directory the assets are served from -- the root of the $publicDisk,
+     * or app/public inside the tenant's storage directory when no disk is configured.
      *
-     * The directory is resolved using the FilesystemTenancyBootstrapper (rather than storage_path(),
-     * so that it's tenant-scoped regardless of the suffix_storage_path config).
+     * The storage directory is resolved using the FilesystemTenancyBootstrapper (rather than
+     * storage_path(), so that it's tenant-scoped regardless of the suffix_storage_path config).
      */
     protected function assetRoot(): string
     {
+        if (static::$publicDisk) {
+            $diskRoot = config('filesystems.disks.' . static::$publicDisk . '.root');
+
+            if (! is_string($diskRoot)) {
+                // A disk with no root path would let the controller serve any file in the app
+                throw new Exception('Disk [' . static::$publicDisk . '] has no root path configured.');
+            }
+
+            return rtrim($diskRoot, '/');
+        }
+
         if ($tenant = tenant()) {
             return FilesystemTenancyBootstrapper::getBoundTenantStoragePath($tenant) . '/app/public';
         }

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -17,15 +17,11 @@ use Throwable;
 
 /**
  * Serves files from app/public inside the tenant's storage directory, or from the root
- * of the $publicDisk when one is configured.
+ * of the $publicDisk when the property is set.
  *
- * Requires FilesystemTenancyBootstrapper to be enabled since it points the public disk's
- * root at the tenant's storage directory. Without it, the disk keeps writing to the central
- * storage/app/public, so the tenant's directory is never populated and requests 404
- * (the path itself is tenant-specific either way, via getBoundTenantStoragePath()).
- *
- * With a $publicDisk configured, the assets come from that disk's root instead. The
- * bootstrapper is needed to make that root tenant-specific (see $publicDisk).
+ * Requires FilesystemTenancyBootstrapper to be enabled, so that writes to the default
+ * public disk end up in the app/public within the *tenant's* storage, or so that the
+ * public disk set in the static property is similarly scoped.
  *
  * @see FilesystemTenancyBootstrapper
  */
@@ -55,8 +51,8 @@ class TenantAssetController implements HasMiddleware
      *
      * It should also be listed in tenancy.filesystem.disks -- for scoped disks, it's the parent
      * disk that has to be listed there (since a scoped disk inherits the parent's root).
-     * FilesystemTenancyBootstrapper only scopes the roots of disks listed there, so otherwise
-     * every tenant is served the same (central) directory.
+     * FilesystemTenancyBootstrapper only scopes the roots of disks listed there, so
+     * without that every tenant would be served the same (central) directory.
      */
     public static string|null $publicDisk = null;
 
@@ -142,7 +138,7 @@ class TenantAssetController implements HasMiddleware
 
         // User is attempting to access a file outside the $allowedRoot folder.
         // The trailing separator is needed so that sibling directories that
-        // start with the same name (e.g. app/public-private) don't pass.
+        // start with the same name (e.g. app/public-private) aren't accepted.
         $this->abortIf(! str($attemptedPath)->startsWith(rtrim($allowedRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR), 'Accessing a file outside the storage root');
     }
 

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -102,7 +102,11 @@ class TenantAssetController implements HasMiddleware
                 throw new Exception('Disk [' . static::$publicDisk . '] is not a local disk. Only local disks can be used for serving assets.');
             }
 
-            $baseDiskName = $this->baseDiskName(static::$publicDisk);
+            $baseDiskName = FilesystemTenancyBootstrapper::baseDiskName(static::$publicDisk);
+
+            if ($baseDiskName === null) {
+                throw new Exception('Disk [' . static::$publicDisk . '] has an unnamed parent disk. Use a named parent disk listed in tenancy.filesystem.disks.');
+            }
 
             if (! in_array($baseDiskName, config('tenancy.filesystem.disks'), true)) {
                 // FilesystemTenancyBootstrapper only scopes the roots of disks listed in tenancy.filesystem.disks.
@@ -121,26 +125,6 @@ class TenantAssetController implements HasMiddleware
         }
 
         return storage_path('app/public');
-    }
-
-    /**
-     * Name of the disk whose root the passed disk uses.
-     *
-     * Disks using the 'scoped' driver have no root of their own -- they inherit the root of their parent disk,
-     * which can be scoped as well, so the final/base parent is what has to be tenant-aware.
-     */
-    protected function baseDiskName(string $disk): string
-    {
-        while (config("filesystems.disks.$disk.driver") === 'scoped') {
-            if (! is_string($parent = config("filesystems.disks.$disk.disk"))) {
-                // Laravel allows configuring the parent inline as an array, in which case it has no name
-                throw new Exception("Disk [$disk] has its parent disk configured inline. Use a named parent disk listed in tenancy.filesystem.disks.");
-            }
-
-            $disk = $parent;
-        }
-
-        return $disk;
     }
 
     /**

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -6,10 +6,10 @@ namespace Stancl\Tenancy\Controllers;
 
 use Closure;
 use Exception;
+use Illuminate\Filesystem\LocalFilesystemAdapter;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
-use Illuminate\Filesystem\LocalFilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -9,6 +9,8 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
+use Illuminate\Filesystem\LocalFilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
@@ -43,9 +45,13 @@ class TenantAssetController implements HasMiddleware
      *
      * When null, the assets are served from app/public inside the tenant's storage directory.
      *
-     * The disk has to be local and have a root configured, since the assets are read from the filesystem.
-     * It should also be listed in tenancy.filesystem.disks. FilesystemTenancyBootstrapper only scopes
-     * the roots of disks listed there, so otherwise every tenant is served the same central directory.
+     * The disk has to be local, since the assets are read from the filesystem. Disks using the
+     * 'scoped' driver are supported as long as their parent disk uses the 'local' driver.
+     *
+     * It should also be listed in tenancy.filesystem.disks -- for scoped disks, it's the parent
+     * disk that has to be listed there (since a scoped disk inherits the parent's root).
+     * FilesystemTenancyBootstrapper only scopes the roots of disks listed there, so otherwise
+     * every tenant is served the same (central) directory.
      */
     public static string|null $publicDisk = null;
 
@@ -89,14 +95,17 @@ class TenantAssetController implements HasMiddleware
     protected function assetRoot(): string
     {
         if (static::$publicDisk) {
-            $diskRoot = config('filesystems.disks.' . static::$publicDisk . '.root');
+            $disk = Storage::disk(static::$publicDisk);
 
-            if (! is_string($diskRoot)) {
-                // A disk with no root path would let the controller serve any file in the app
-                throw new Exception('Disk [' . static::$publicDisk . '] has no root path configured.');
+            if (! $disk instanceof LocalFilesystemAdapter) {
+                // The root has to be read from the resolved disk rather than from the disk's config,
+                // since the config root isn't the full root path of every local disk. Disks using the
+                // 'scoped' driver have no root in their config -- they inherit their parent disk's root --
+                // and a 'prefix' is part of the root path as well.
+                throw new Exception('Disk [' . static::$publicDisk . '] is not a local disk. Only local disks can be used for serving assets.');
             }
 
-            return rtrim($diskRoot, '/');
+            return rtrim($disk->path(''), DIRECTORY_SEPARATOR);
         }
 
         if ($tenant = tenant()) {

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -9,6 +9,7 @@ use Exception;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Routing\Controllers\Middleware;
+use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
@@ -51,10 +52,25 @@ class TenantAssetController implements HasMiddleware
                 ? (static::$headers)($request)
                 : static::$headers;
 
-            return response()->file(storage_path("app/public/$path"), $headers);
+            return response()->file($this->assetRoot() . "/$path", $headers);
         } catch (Throwable) {
             abort(404);
         }
+    }
+
+    /**
+     * Assets are served from app/public inside the tenant's storage directory.
+     *
+     * The directory is resolved using the FilesystemTenancyBootstrapper (rather than storage_path(),
+     * so that it's tenant-scoped regardless of the suffix_storage_path config).
+     */
+    protected function assetRoot(): string
+    {
+        if ($tenant = tenant()) {
+            return FilesystemTenancyBootstrapper::getBoundTenantStoragePath($tenant) . '/app/public';
+        }
+
+        return storage_path('app/public');
     }
 
     /**
@@ -67,9 +83,9 @@ class TenantAssetController implements HasMiddleware
     {
         $this->abortIf($path === null, 'Empty path');
 
-        $allowedRoot = realpath(storage_path('app/public'));
+        $allowedRoot = realpath($this->assetRoot());
 
-        // `storage_path('app/public')` doesn't exist, so it cannot contain files
+        // The asset root doesn't exist, so it cannot contain files
         $this->abortIf($allowedRoot === false, "Storage root doesn't exist");
 
         $attemptedPath = realpath("{$allowedRoot}/{$path}");

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -112,8 +112,10 @@ class TenantAssetController implements HasMiddleware
         // User is attempting to access a nonexistent file
         $this->abortIf($attemptedPath === false, 'Accessing a nonexistent file');
 
-        // User is attempting to access a file outside the $allowedRoot folder
-        $this->abortIf(! str($attemptedPath)->startsWith($allowedRoot), 'Accessing a file outside the storage root');
+        // User is attempting to access a file outside the $allowedRoot folder.
+        // The trailing separator is needed so that sibling directories that
+        // start with the same name (e.g. app/public-private) don't pass.
+        $this->abortIf(! str($attemptedPath)->startsWith(rtrim($allowedRoot, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR), 'Accessing a file outside the storage root');
     }
 
     /** @return void|never */

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -47,10 +47,10 @@ class TenantAssetController implements HasMiddleware
      * When null, the assets are served from app/public inside the tenant's storage directory.
      *
      * The disk has to be local, since the assets are read from the filesystem. Disks using the
-     * 'scoped' driver are supported as long as their parent disk uses the 'local' driver.
+     * 'scoped' driver are supported as long as the disk they're based on uses the 'local' driver.
      *
-     * It should also be listed in tenancy.filesystem.disks -- for scoped disks, it's the parent
-     * disk that has to be listed there (since a scoped disk inherits the parent's root).
+     * The disk also has to be listed in tenancy.filesystem.disks -- for scoped disks, it's the
+     * disk they're based on that has to be listed there (since a scoped disk inherits its root).
      * FilesystemTenancyBootstrapper only scopes the roots of disks listed there, so
      * without that every tenant would be served the same (central) directory.
      */
@@ -87,8 +87,8 @@ class TenantAssetController implements HasMiddleware
 
     /**
      * Directory the assets are served from -- the root of the $publicDisk, or app/public
-     * inside the tenant's storage directory when no disk is configured. With no current
-     * tenant (e.g. on a universal route), the central storage directory is used.
+     * inside the tenant's storage directory when no disk is configured. With no disk and
+     * no current tenant (e.g. on a universal route), the central app/public is used.
      *
      * The tenant's storage directory is resolved using the FilesystemTenancyBootstrapper (rather
      * than storage_path(), so that it's tenant-scoped regardless of the suffix_storage_path config).
@@ -99,13 +99,20 @@ class TenantAssetController implements HasMiddleware
             $disk = Storage::disk(static::$publicDisk);
 
             if (! $disk instanceof LocalFilesystemAdapter) {
-                // The root has to be read from the resolved disk rather than from the disk's config,
-                // since the config root isn't the full root path of every local disk. Disks using the
-                // 'scoped' driver have no root in their config -- they inherit their parent disk's root --
-                // and a 'prefix' is part of the root path as well.
                 throw new Exception('Disk [' . static::$publicDisk . '] is not a local disk. Only local disks can be used for serving assets.');
             }
 
+            $baseDiskName = $this->baseDiskName(static::$publicDisk);
+
+            if (! in_array($baseDiskName, config('tenancy.filesystem.disks'), true)) {
+                // FilesystemTenancyBootstrapper only scopes the roots of disks listed in tenancy.filesystem.disks.
+                // Without that, the root stays central and every tenant would be served the same directory.
+                throw new Exception("Disk [$baseDiskName] is not tenant-aware. Add it to the tenancy.filesystem.disks config to make its root tenant-specific.");
+            }
+
+            // The root is read from the resolved disk rather than from the disk's config, since the
+            // config root isn't the full root path of every local disk. Disks using the 'scoped' driver
+            // have no root in their config, and a 'prefix' is part of the root path as well.
             return rtrim($disk->path(''), DIRECTORY_SEPARATOR);
         }
 
@@ -114,6 +121,26 @@ class TenantAssetController implements HasMiddleware
         }
 
         return storage_path('app/public');
+    }
+
+    /**
+     * Name of the disk whose root the passed disk uses.
+     *
+     * Disks using the 'scoped' driver have no root of their own -- they inherit the root of their parent disk,
+     * which can be scoped as well, so the final/base parent is what has to be tenant-aware.
+     */
+    protected function baseDiskName(string $disk): string
+    {
+        while (config("filesystems.disks.$disk.driver") === 'scoped') {
+            if (! is_string($parent = config("filesystems.disks.$disk.disk"))) {
+                // Laravel allows configuring the parent inline as an array, in which case it has no name
+                throw new Exception("Disk [$disk] has its parent disk configured inline. Use a named parent disk listed in tenancy.filesystem.disks.");
+            }
+
+            $disk = $parent;
+        }
+
+        return $disk;
     }
 
     /**

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -16,11 +16,16 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
 /**
- * Requires FilesystemTenancyBootstrapper to be enabled, since the assets are served from the
- * tenant's storage directory, which isn't tenant-specific unless the bootstrapper scopes it.
+ * Serves files from app/public inside the tenant's storage directory, or from the root
+ * of the $publicDisk when one is configured.
  *
- * With a $publicDisk configured, the assets are served from the disk's root instead, so the
- * bootstrapper is only needed if that root should be tenant-specific.
+ * Requires FilesystemTenancyBootstrapper to be enabled since it points the public disk's
+ * root at the tenant's storage directory. Without it, the disk keeps writing to the central
+ * storage/app/public, so the tenant's directory is never populated and requests 404
+ * (the path itself is tenant-specific either way, via getBoundTenantStoragePath()).
+ *
+ * With a $publicDisk configured, the assets come from that disk's root instead. The
+ * bootstrapper is needed to make that root tenant-specific (see $publicDisk).
  *
  * @see FilesystemTenancyBootstrapper
  */

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -13,6 +13,13 @@ use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
+/**
+ * Requires FilesystemTenancyBootstrapper to be enabled, since the assets are served from
+ * the tenant's storage directory (or from the root of $publicDisk), and neither is
+ * tenant-specific unless the bootstrapper scopes it.
+ *
+ * @see FilesystemTenancyBootstrapper
+ */
 class TenantAssetController implements HasMiddleware
 {
     /**
@@ -33,6 +40,10 @@ class TenantAssetController implements HasMiddleware
      * Disk the assets are served from.
      *
      * When null, the assets are served from app/public inside the tenant's storage directory.
+     *
+     * The disk has to be local and have a root configured, since the assets are read from the filesystem.
+     * It should also be listed in tenancy.filesystem.disks. FilesystemTenancyBootstrapper only scopes
+     * the roots of disks listed there, so otherwise every tenant is served the same central directory.
      */
     public static string|null $publicDisk = null;
 
@@ -66,11 +77,12 @@ class TenantAssetController implements HasMiddleware
     }
 
     /**
-     * Directory the assets are served from -- the root of the $publicDisk,
-     * or app/public inside the tenant's storage directory when no disk is configured.
+     * Directory the assets are served from -- the root of the $publicDisk, or app/public
+     * inside the tenant's storage directory when no disk is configured. With no current
+     * tenant (e.g. on a universal route), the central storage directory is used.
      *
-     * The storage directory is resolved using the FilesystemTenancyBootstrapper (rather than
-     * storage_path(), so that it's tenant-scoped regardless of the suffix_storage_path config).
+     * The tenant's storage directory is resolved using the FilesystemTenancyBootstrapper (rather
+     * than storage_path(), so that it's tenant-scoped regardless of the suffix_storage_path config).
      */
     protected function assetRoot(): string
     {

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -14,9 +14,11 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
 
 /**
- * Requires FilesystemTenancyBootstrapper to be enabled, since the assets are served from
- * the tenant's storage directory (or from the root of $publicDisk), and neither is
- * tenant-specific unless the bootstrapper scopes it.
+ * Requires FilesystemTenancyBootstrapper to be enabled, since the assets are served from the
+ * tenant's storage directory, which isn't tenant-specific unless the bootstrapper scopes it.
+ *
+ * With a $publicDisk configured, the assets are served from the disk's root instead, so the
+ * bootstrapper is only needed if that root should be tenant-specific.
  *
  * @see FilesystemTenancyBootstrapper
  */

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -142,6 +142,7 @@ class TenantAssetController implements HasMiddleware
         // The asset root doesn't exist, so it cannot contain files
         $this->abortIf($allowedRoot === false, "Storage root doesn't exist");
 
+        // realpath() ensures the directory exists and converts / to \ on Windows
         $attemptedPath = realpath("{$allowedRoot}/{$path}");
 
         // User is attempting to access a nonexistent file

--- a/src/Controllers/TenantAssetController.php
+++ b/src/Controllers/TenantAssetController.php
@@ -20,7 +20,7 @@ use Throwable;
  * of the $publicDisk when the property is set.
  *
  * Requires FilesystemTenancyBootstrapper to be enabled, so that writes to the default
- * public disk end up in the app/public within the *tenant's* storage, or so that the
+ * public disk end up in the app/public directory within the *tenant's* storage, or so that the
  * public disk set in the static property is similarly scoped.
  *
  * @see FilesystemTenancyBootstrapper
@@ -51,8 +51,6 @@ class TenantAssetController implements HasMiddleware
      *
      * The disk also has to be listed in tenancy.filesystem.disks -- for scoped disks, it's the
      * disk they're based on that has to be listed there (since a scoped disk inherits its root).
-     * FilesystemTenancyBootstrapper only scopes the roots of disks listed there, so
-     * without that every tenant would be served the same (central) directory.
      */
     public static string|null $publicDisk = null;
 
@@ -87,11 +85,10 @@ class TenantAssetController implements HasMiddleware
 
     /**
      * Directory the assets are served from -- the root of the $publicDisk, or app/public
-     * inside the tenant's storage directory when no disk is configured. With no disk and
-     * no current tenant (e.g. on a universal route), the central app/public is used.
+     * inside the tenant's storage directory when no disk is configured. When no disk is
+     * configured and there's no current tenant, the central app/public is used.
      *
-     * The tenant's storage directory is resolved using the FilesystemTenancyBootstrapper (rather
-     * than storage_path(), so that it's tenant-scoped regardless of the suffix_storage_path config).
+     * The tenant's storage directory is resolved using the FilesystemTenancyBootstrapper::getTenantStoragePath().
      */
     protected function assetRoot(): string
     {
@@ -114,9 +111,10 @@ class TenantAssetController implements HasMiddleware
                 throw new Exception("Disk [$baseDiskName] is not tenant-aware. Add it to the tenancy.filesystem.disks config to make its root tenant-specific.");
             }
 
-            // The root is read from the resolved disk rather than from the disk's config, since the
-            // config root isn't the full root path of every local disk. Disks using the 'scoped' driver
-            // have no root in their config, and a 'prefix' is part of the root path as well.
+            // The full path is read from the resolved disk rather than from the disk's configured 'root',
+            // since the 'root' doesn't have to be the full path of every local disk:
+            // - disks using the 'scoped' driver have no 'root' in their config -- they inherit it from the parent disk
+            // - a disk's configured 'prefix' is a part of the full path as well.
             return rtrim($disk->path(''), DIRECTORY_SEPARATOR);
         }
 

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -16,16 +16,11 @@ use Stancl\Tenancy\Contracts\Tenant;
 /**
  * Delete the tenant's storage directory.
  *
- * The directory is the one FilesystemTenancyBootstrapper scopes the tenant's disks, cache
- * and sessions to. The path is derived the same way the bootstrapper derives it, so the
- * bootstrapper doesn't *have* to be enabled (though if it isn't, nothing was written there and
- * there's nothing to delete).
- *
- * Files outside that directory (e.g. disks with an %original_storage_path%-based
- * root_override) are not deleted.
- *
- * Note that this job is not affected by the tenancy.filesystem.suffix_storage_path config
- * since it doesn't use the storage_path() helper.
+ * The directory is used by the FilesystemTenancyBootstrapper for:
+ * - scoped storage_path() when suffix_storage_path is enabled
+ * - scoped cache when enabled
+ * - scoped sessions when enabled
+ * - scoped disks when enabled
  *
  * @see FilesystemTenancyBootstrapper
  */

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -34,7 +34,7 @@ class DeleteTenantStorage implements ShouldQueue
 
     public function handle(): void
     {
-        $tenantStoragePath = FilesystemTenancyBootstrapper::getBoundTenantStoragePath($this->tenant);
+        $tenantStoragePath = FilesystemTenancyBootstrapper::getTenantStoragePath($this->tenant);
         $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
 
         if (realpath($tenantStoragePath) === realpath($centralStoragePath)) {

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -16,13 +16,16 @@ use Stancl\Tenancy\Contracts\Tenant;
 /**
  * Delete the tenant's storage directory.
  *
- * Requires FilesystemTenancyBootstrapper to be enabled, since the deleted directory
- * is the one the bootstrapper scopes disks, cache and sessions to.
+ * Requires FilesystemTenancyBootstrapper to be enabled, since the tenant storage path
+ * is resolved from it.
  *
- * The job does not depend on the tenancy.filesystem.suffix_storage_path config,
+ * Files outside that directory (e.g. disks with an %original_storage_path%-based
+ * root_override) are not deleted.
+ *
+ * Note that this job is not affected by the tenancy.filesystem.suffix_storage_path config
  * since it doesn't use the storage_path() helper.
  *
- * @see Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper
+ * @see FilesystemTenancyBootstrapper
  */
 class DeleteTenantStorage implements ShouldQueue
 {

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -16,8 +16,10 @@ use Stancl\Tenancy\Contracts\Tenant;
 /**
  * Delete the tenant's storage directory.
  *
- * Requires FilesystemTenancyBootstrapper to be enabled, since the tenant storage path
- * is resolved from it.
+ * The directory is the one FilesystemTenancyBootstrapper scopes the tenant's disks, cache
+ * and sessions to. The path is derived the same way the bootstrapper derives it, so the
+ * bootstrapper doesn't *have* to be enabled (though if it isn't, nothing was written there and
+ * there's nothing to delete).
  *
  * Files outside that directory (e.g. disks with an %original_storage_path%-based
  * root_override) are not deleted.

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -35,6 +35,12 @@ class DeleteTenantStorage implements ShouldQueue
     public function handle(): void
     {
         $tenantStoragePath = FilesystemTenancyBootstrapper::getBoundTenantStoragePath($this->tenant);
+        $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
+
+        if (realpath($tenantStoragePath) === realpath($centralStoragePath)) {
+            // Never delete the central storage directory -- that would delete the files of all tenants
+            return;
+        }
 
         if (is_dir($tenantStoragePath)) {
             File::deleteDirectory($tenantStoragePath);

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -10,8 +10,20 @@ use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\File;
+use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Stancl\Tenancy\Contracts\Tenant;
 
+/**
+ * Delete the tenant's storage directory.
+ *
+ * Requires FilesystemTenancyBootstrapper to be enabled, since the deleted directory
+ * is the one the bootstrapper scopes disks, cache and sessions to.
+ *
+ * The job does not depend on the tenancy.filesystem.suffix_storage_path config,
+ * since it doesn't use the storage_path() helper.
+ *
+ * @see Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper
+ */
 class DeleteTenantStorage implements ShouldQueue
 {
     use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
@@ -22,19 +34,7 @@ class DeleteTenantStorage implements ShouldQueue
 
     public function handle(): void
     {
-        if (config('tenancy.filesystem.suffix_storage_path') === false) {
-            // Skip storage deletion if path suffixing is disabled
-            return;
-        }
-
-        $centralStoragePath = tenancy()->central(fn () => storage_path());
-        $tenantStoragePath = tenancy()->run($this->tenant, fn () => storage_path());
-
-        if ($tenantStoragePath === $centralStoragePath) {
-            // Check again to ensure the tenant storage path is distinct from the central storage path
-            // to avoid any accidental central storage path deletion
-            return;
-        }
+        $tenantStoragePath = FilesystemTenancyBootstrapper::getBoundTenantStoragePath($this->tenant);
 
         if (is_dir($tenantStoragePath)) {
             File::deleteDirectory($tenantStoragePath);

--- a/src/Jobs/DeleteTenantStorage.php
+++ b/src/Jobs/DeleteTenantStorage.php
@@ -43,7 +43,7 @@ class DeleteTenantStorage implements ShouldQueue
         $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
 
         if (realpath($tenantStoragePath) === realpath($centralStoragePath)) {
-            // Never delete the central storage directory -- that would delete the files of all tenants
+            // Never delete the central storage directory
             return;
         }
 

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -79,7 +79,7 @@ test('create storage symlinks action fails for disks that are not tenant-aware',
     expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeFalse();
 });
 
-test('create storage symlinks action skips disks with a null url_override', function () {
+test('create storage symlinks action skips disks with no url_override', function (string|null $localUrlOverride) {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -87,8 +87,7 @@ test('create storage symlinks action skips disks with a null url_override', func
         'tenancy.filesystem.suffix_base' => 'tenant-',
         'tenancy.filesystem.url_override' => [
             'public' => 'public-%tenant%',
-            // A null override means the disk's URL is not overridden, same as in the FS bootstrapper
-            'local' => null,
+            'local' => $localUrlOverride,
         ],
     ]);
 
@@ -99,7 +98,16 @@ test('create storage symlinks action skips disks with a null url_override', func
 
     // The local disk is skipped, so the public disk still gets its symlink
     expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeTrue();
-});
+
+    // The bootstrapper skips the same disk, so its URL is not overridden either
+    $centralUrl = config('filesystems.disks.local.url');
+    tenancy()->initialize($tenant);
+
+    expect(config('filesystems.disks.local.url'))->toBe($centralUrl);
+})->with([
+    'null url_override' => [null],
+    'empty url_override' => [''],
+]);
 
 test('remove storage symlinks action works', function() {
     config([

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -17,6 +17,12 @@ use Illuminate\Support\Facades\Storage;
 beforeEach(function () {
     Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
     Event::listen(TenancyEnded::class, RevertToCentralContext::class);
+
+    RemoveStorageSymlinksAction::$removeNestedDirectories = false;
+});
+
+afterEach(function () {
+    RemoveStorageSymlinksAction::$removeNestedDirectories = false;
 });
 
 test('create storage symlinks action works', function (string|null $rootOverride, bool $suffixStoragePath) {
@@ -207,6 +213,8 @@ test('symlinks of prefixed disks only expose the prefixed directory', function (
 });
 
 test('removing a prefixed disk symlink removes the directories created for it', function () {
+    RemoveStorageSymlinksAction::$removeNestedDirectories = true;
+
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -241,6 +249,8 @@ test('removing a prefixed disk symlink removes the directories created for it', 
 });
 
 test('non-empty directories are not removed with the symlink', function () {
+    RemoveStorageSymlinksAction::$removeNestedDirectories = true;
+
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -28,7 +28,11 @@ test('create storage symlinks action works', function (string|null $rootOverride
         // The disk root is suffixed regardless of the suffix_storage_path config
         'tenancy.filesystem.suffix_storage_path' => $suffixStoragePath,
         'tenancy.filesystem.root_override.public' => $rootOverride,
-        'tenancy.filesystem.url_override.public' => 'public-%tenant%'
+        'tenancy.filesystem.url_override' => [
+            'public' => 'public-%tenant%',
+            // Disks with a falsy url_override are skipped
+            'local' => '',
+        ],
     ]);
 
     /** @var Tenant $tenant */
@@ -49,6 +53,9 @@ test('create storage symlinks action works', function (string|null $rootOverride
     expect(is_link($publicPath))->toBeTrue();
     expect(readlink($publicPath))->toBe(config('filesystems.disks.public.root'));
     expect(file_get_contents($publicPath . '/foo.txt'))->toBe('tenant file');
+
+    // The local disk is skipped because its url_override is '' -- no symlink is created at public_path('')
+    expect(is_link(public_path('')))->toBeFalse();
 })->with([
     'default root_override' => ['%storage_path%/app/public/', true],
     'suffix_storage_path disabled' => ['%storage_path%/app/public/', false],
@@ -78,36 +85,6 @@ test('create storage symlinks action fails for disks that are not tenant-aware',
 
     expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeFalse();
 });
-
-test('create storage symlinks action skips disks with no url_override', function (string|null $localUrlOverride) {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'tenancy.filesystem.suffix_base' => 'tenant-',
-        'tenancy.filesystem.url_override' => [
-            'public' => 'public-%tenant%',
-            'local' => $localUrlOverride,
-        ],
-    ]);
-
-    /** @var Tenant $tenant */
-    $tenant = Tenant::create();
-
-    (new CreateStorageSymlinksAction)($tenant);
-
-    // The local disk is skipped, so the public disk still gets its symlink
-    expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeTrue();
-
-    // The bootstrapper skips the same disk, so its URL is not overridden either
-    $centralUrl = config('filesystems.disks.local.url');
-    tenancy()->initialize($tenant);
-
-    expect(config('filesystems.disks.local.url'))->toBe($centralUrl);
-})->with([
-    'null url_override' => [null],
-    'empty url_override' => [''],
-]);
 
 test('remove storage symlinks action works', function() {
     config([

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -12,19 +12,22 @@ use Stancl\Tenancy\Actions\CreateStorageSymlinksAction;
 use Stancl\Tenancy\Actions\RemoveStorageSymlinksAction;
 use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 beforeEach(function () {
     Event::listen(TenancyInitialized::class, BootstrapTenancy::class);
     Event::listen(TenancyEnded::class, RevertToCentralContext::class);
 });
 
-test('create storage symlinks action works', function() {
+test('create storage symlinks action works', function (string $rootOverride, bool $suffixStoragePath) {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
         ],
         'tenancy.filesystem.suffix_base' => 'tenant-',
-        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        // The disk root is suffixed regardless of the suffix_storage_path config
+        'tenancy.filesystem.suffix_storage_path' => $suffixStoragePath,
+        'tenancy.filesystem.root_override.public' => $rootOverride,
         'tenancy.filesystem.url_override.public' => 'public-%tenant%'
     ]);
 
@@ -38,13 +41,19 @@ test('create storage symlinks action works', function() {
     expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeFalse();
     expect(file_exists($publicPath))->toBeFalse();
 
+    Storage::disk('public')->put('foo.txt', 'tenant file');
+
     (new CreateStorageSymlinksAction)($tenant);
 
-    // The symlink exists and is valid
-    expect(is_link($publicPath = public_path("public-$tenantKey")))->toBeTrue();
-    expect(file_exists($publicPath))->toBeTrue();
-    $this->assertEquals(storage_path("app/public/"), readlink($publicPath));
-});
+    // The symlink exists and points to the directory the tenant's disk writes to
+    expect(is_link($publicPath))->toBeTrue();
+    expect(readlink($publicPath))->toBe(config('filesystems.disks.public.root'));
+    expect(file_get_contents($publicPath . '/foo.txt'))->toBe('tenant file');
+})->with([
+    'default root_override' => ['%storage_path%/app/public/', true],
+    'suffix_storage_path disabled' => ['%storage_path%/app/public/', false],
+    'custom root_override' => ['%original_storage_path%/app/public/%tenant%/', true],
+]);
 
 test('remove storage symlinks action works', function() {
     config([

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -149,3 +149,119 @@ test('removing tenant symlinks works even if the symlinks are invalid', function
 
     expect(is_link($publicPath))->toBeFalse();
 });
+
+test('disks with a prefix are symlinked correctly', function (string $prefix) {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.suffix_base' => 'tenant-',
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%',
+        'filesystems.disks.public.prefix' => $prefix,
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+    $tenantKey = $tenant->getTenantKey();
+
+    // possibleTenantSymlinks() trims the prefix, do the same here for the assertions to be accurate
+    $prefix = trim($prefix, '/');
+
+    tenancy()->initialize($tenant);
+
+    Storage::disk('public')->put('foo.txt', 'tenant file');
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    expect(Storage::disk('public')->url('foo.txt'))->toBe("http://localhost/public-{$tenantKey}/{$prefix}/foo.txt");
+    expect(readlink(public_path("public-{$tenantKey}/{$prefix}")))->toBe(storage_path("app/public/{$prefix}"));
+    expect(file_get_contents(public_path("public-{$tenantKey}/{$prefix}/foo.txt")))->toBe('tenant file');
+})->with(['abc', 'abc/def', '/abc/def/']);
+
+test('symlinks of prefixed disks only expose the prefixed directory', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%',
+        'filesystems.disks.public.prefix' => 'abc',
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+    $tenantKey = $tenant->getTenantKey();
+
+    tenancy()->initialize($tenant);
+
+    Storage::disk('public')->put('foo.txt', 'tenant file');
+
+    // The disk cannot reach this file, neither should the symlink
+    File::put(storage_path('app/public/sibling.txt'), 'file next to the prefixed directory');
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    expect(file_exists(public_path("public-{$tenantKey}/sibling.txt")))->toBeFalse();
+    expect(file_get_contents(public_path("public-{$tenantKey}/abc/foo.txt")))->toBe('tenant file');
+});
+
+test('removing a prefixed disk symlink removes the directories created for it', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%',
+        'filesystems.disks.public.prefix' => 'abc/def',
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+    $tenantKey = $tenant->getTenantKey();
+
+    tenancy()->initialize($tenant);
+
+    Storage::disk('public')->put('foo.txt', 'tenant file');
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    $symlink = public_path("public-{$tenantKey}/abc/def");
+    $diskRoot = readlink($symlink);
+
+    (new RemoveStorageSymlinksAction)($tenant);
+
+    // The symlink and every directory created for it are deleted
+    expect(is_link($symlink))->toBeFalse();
+    expect(file_exists(public_path("public-{$tenantKey}")))->toBeFalse();
+    // public_path() itself is not deleted
+    expect(is_dir(public_path()))->toBeTrue();
+    // The directory that the symlink points to is untouched
+    expect(file_get_contents($diskRoot . '/foo.txt'))->toBe('tenant file');
+});
+
+test('non-empty directories are not removed with the symlink', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%',
+        'filesystems.disks.public.prefix' => 'abc/def',
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+    $tenantKey = $tenant->getTenantKey();
+
+    tenancy()->initialize($tenant);
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    File::put(public_path("public-{$tenantKey}/abc/actual-file.txt"), 'foo');
+
+    (new RemoveStorageSymlinksAction)($tenant);
+
+    expect(is_link(public_path("public-{$tenantKey}/abc/def")))->toBeFalse();
+    expect(file_get_contents(public_path("public-{$tenantKey}/abc/actual-file.txt")))->toBe('foo');
+});

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -71,8 +71,6 @@ test('create storage symlinks action fails for disks that are not tenant-aware',
     /** @var Tenant $tenant */
     $tenant = Tenant::create();
 
-    (new CreateStorageSymlinksAction)($tenant);
-
     expect(fn () => (new CreateStorageSymlinksAction)($tenant))
         ->toThrow(Exception::class, 'Disk public is not tenant-aware.');
 

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -19,7 +19,7 @@ beforeEach(function () {
     Event::listen(TenancyEnded::class, RevertToCentralContext::class);
 });
 
-test('create storage symlinks action works', function (string $rootOverride, bool $suffixStoragePath) {
+test('create storage symlinks action works', function (string|null $rootOverride, bool $suffixStoragePath) {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -53,6 +53,8 @@ test('create storage symlinks action works', function (string $rootOverride, boo
     'default root_override' => ['%storage_path%/app/public/', true],
     'suffix_storage_path disabled' => ['%storage_path%/app/public/', false],
     'custom root_override' => ['%original_storage_path%/app/public/%tenant%/', true],
+    // Without a root_override, the bootstrapper suffixes the disk's central root
+    'no root_override' => [null, true],
 ]);
 
 test('create storage symlinks action fails for disks that are not tenant-aware', function () {
@@ -75,6 +77,28 @@ test('create storage symlinks action fails for disks that are not tenant-aware',
         ->toThrow(Exception::class, 'Disk public is not tenant-aware.');
 
     expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeFalse();
+});
+
+test('create storage symlinks action skips disks with a null url_override', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.suffix_base' => 'tenant-',
+        'tenancy.filesystem.url_override' => [
+            'public' => 'public-%tenant%',
+            // A null override means the disk's URL is not overridden, same as in the FS bootstrapper
+            'local' => null,
+        ],
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    // The local disk is skipped, so the public disk still gets its symlink
+    expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeTrue();
 });
 
 test('remove storage symlinks action works', function() {

--- a/tests/ActionTest.php
+++ b/tests/ActionTest.php
@@ -55,6 +55,30 @@ test('create storage symlinks action works', function (string $rootOverride, boo
     'custom root_override' => ['%original_storage_path%/app/public/%tenant%/', true],
 ]);
 
+test('create storage symlinks action fails for disks that are not tenant-aware', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        // The public disk has both overrides configured, but it is not in
+        // tenancy.filesystem.disks, so the bootstrapper never scopes its root.
+        // Symlinking it would point every tenant's public path to the central disk root.
+        'tenancy.filesystem.disks' => ['local'],
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.filesystem.url_override.public' => 'public-%tenant%',
+    ]);
+
+    /** @var Tenant $tenant */
+    $tenant = Tenant::create();
+
+    (new CreateStorageSymlinksAction)($tenant);
+
+    expect(fn () => (new CreateStorageSymlinksAction)($tenant))
+        ->toThrow(Exception::class, 'Disk public is not tenant-aware.');
+
+    expect(is_link(public_path('public-' . $tenant->getTenantKey())))->toBeFalse();
+});
+
 test('remove storage symlinks action works', function() {
     config([
         'tenancy.bootstrappers' => [

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -356,6 +356,31 @@ test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk
     ]);
 });
 
+test('scoped disks referencing each other do not make bootstrapper hang', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'filesystems.disks.foo' => [
+            'driver' => 'scoped',
+            'disk' => 'bar',
+            'prefix' => 'foo',
+        ],
+        'filesystems.disks.bar' => [
+            'driver' => 'scoped',
+            'disk' => 'foo',
+            'prefix' => 'bar',
+        ],
+    ]);
+
+    expect(FilesystemTenancyBootstrapper::baseDiskName('foo'))->toBeNull();
+    expect(FilesystemTenancyBootstrapper::baseDiskName('bar'))->toBeNull();
+
+    tenancy()->initialize(Tenant::create());
+
+    expect(tenant())->not()->toBeNull();
+});
+
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');
     $barPath = storage_path('framework/cache/bar_file');

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -299,6 +299,33 @@ test('scoped disks are scoped per tenant', function (bool $nested) {
     'nested scoped disk' => true,
 ]);
 
+test('scoped disks based on a non-local disk are scoped per tenant', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'filesystems.disks.scoped_s3' => [
+            'driver' => 'scoped',
+            'disk' => 's3',
+            'prefix' => 'scoped_s3_prefix',
+        ],
+        'tenancy.filesystem.disks' => ['s3'], // As long as the base disk (s3) is listed here, the scoped disk will be scoped
+    ]);
+
+    expect(Storage::disk('s3')->path('foo.txt'))->toBe('foo.txt');
+    expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe('scoped_s3_prefix/foo.txt');
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    expect(Storage::disk('s3')->path('foo.txt'))->toBe("tenant{$tenant->id}/foo.txt");
+    expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe("tenant{$tenant->id}/scoped_s3_prefix/foo.txt");
+
+    tenancy()->end();
+
+    expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe('scoped_s3_prefix/foo.txt');
+});
+
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');
     $barPath = storage_path('framework/cache/bar_file');

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -218,6 +218,17 @@ test('tenant storage gets deleted during tenant deletion when the DeletingTenant
     expect(File::isDirectory($centralStoragePath))->toBeTrue();
 })->with([true, false]);
 
+test('DeleteTenantStorage does not delete the central storage directory when the filesystem bootstrapper is disabled', function () {
+    config(['tenancy.bootstrappers' => []]);
+
+    $centralStoragePath = storage_path();
+    $tenant = Tenant::create();
+
+    (new DeleteTenantStorage($tenant))->handle();
+
+    expect(File::isDirectory($centralStoragePath))->toBeTrue();
+});
+
 test('the framework/cache directory is created when storage_path is scoped', function (bool $suffixStoragePath) {
     config([
         'tenancy.bootstrappers' => [

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -250,7 +250,7 @@ test('the framework/cache directory is created when storage_path is scoped', fun
     }
 })->with([true, false]);
 
-test('scoped disks are scoped per tenant', function () {
+test('scoped disks are scoped per tenant', function (bool $nested) {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -260,30 +260,44 @@ test('scoped disks are scoped per tenant', function () {
             'disk' => 'public',
             'prefix' => 'scoped_disk_prefix',
         ],
+        'filesystems.disks.nested_disk' => [
+            'driver' => 'scoped',
+            'disk' => 'scoped_disk',
+            'prefix' => 'nested_disk_prefix',
+        ],
     ]);
+
+    $disk = $nested ? 'nested_disk' : 'scoped_disk';
+    $prefix = $nested ? 'scoped_disk_prefix/nested_disk_prefix' : 'scoped_disk_prefix';
 
     $tenant = Tenant::create();
 
-    Storage::disk('scoped_disk')->put('foo.txt', 'central');
-    expect(Storage::disk('scoped_disk')->get('foo.txt'))->toBe('central');
-    expect(file_get_contents(storage_path() . "/app/public/scoped_disk_prefix/foo.txt"))->toBe('central');
+    Storage::disk($disk)->put('foo.txt', 'central');
+
+    config(['filesystem.disks.public.prefix' => 'scoped_disk_prefix']);
+
+    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
+    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('central');
 
     tenancy()->initialize($tenant);
 
-    expect(Storage::disk('scoped_disk')->get('foo.txt'))->toBe(null);
-    Storage::disk('scoped_disk')->put('foo.txt', 'tenant');
-    expect(file_get_contents(storage_path() . "/app/public/scoped_disk_prefix/foo.txt"))->toBe('tenant');
-    expect(Storage::disk('scoped_disk')->get('foo.txt'))->toBe('tenant');
+    expect(Storage::disk($disk)->get('foo.txt'))->toBe(null);
+    Storage::disk($disk)->put('foo.txt', 'tenant');
+    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('tenant');
+    expect(Storage::disk($disk)->get('foo.txt'))->toBe('tenant');
 
     tenancy()->end();
 
-    expect(Storage::disk('scoped_disk')->get('foo.txt'))->toBe('central');
-    Storage::disk('scoped_disk')->put('foo.txt', 'central2');
-    expect(Storage::disk('scoped_disk')->get('foo.txt'))->toBe('central2');
+    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
+    Storage::disk($disk)->put('foo.txt', 'central2');
+    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central2');
 
-    expect(file_get_contents(storage_path() . "/app/public/scoped_disk_prefix/foo.txt"))->toBe('central2');
-    expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/scoped_disk_prefix/foo.txt"))->toBe('tenant');
-});
+    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('central2');
+    expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/{$prefix}/foo.txt"))->toBe('tenant');
+})->with([
+    'scoped disk' => false,
+    'nested scoped disk' => true,
+]);
 
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -328,7 +328,7 @@ test('scoped disks based on a non-local disk are scoped per tenant', function ()
     expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe('scoped_s3_prefix/foo.txt');
 });
 
-test('adding a scoped disk to tenancy.filesystem.disks throws an exception if its base disk is not listed', function (string $disk) {
+test('adding a scoped disk to tenancy.filesystem.disks throws an exception if its base disk is not listed', function () {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -343,62 +343,41 @@ test('adding a scoped disk to tenancy.filesystem.disks throws an exception if it
             'disk' => 'foo',
             'prefix' => 'bar',
         ],
-        // Scoped disk with an inline parent
-        'filesystems.disks.inline_parent' => [
+    ]);
+
+    $initializeTenancy = fn () => tenancy()->initialize(Tenant::create());
+
+    config(['tenancy.filesystem.disks' => ['foo']]);
+    expect($initializeTenancy)->toThrow(Exception::class, "Disk [foo] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+
+    config(['tenancy.filesystem.disks' => ['bar']]);
+    expect($initializeTenancy)->toThrow(Exception::class, "Disk [bar] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+
+    config(['tenancy.filesystem.disks' => ['public', 'foo', 'bar']]);
+    expect($initializeTenancy)->not()->toThrow(Throwable::class);
+});
+
+test('adding a scoped disk with an inline base disk to tenancy.filesystem.disks throws an exception', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'filesystems.disks.inline_base' => [
             'driver' => 'scoped',
             'disk' => [
                 'driver' => 'local',
                 'root' => storage_path('app/inline'),
             ],
-            'prefix' => 'inline_parent',
+            'prefix' => 'inline_base',
         ],
-        'tenancy.filesystem.disks' => [$disk],
     ]);
 
-    expect(fn () => tenancy()->initialize(Tenant::create()))
-        ->toThrow(Exception::class, "Disk [$disk] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+    $initializeTenancy = fn () => tenancy()->initialize(Tenant::create());
 
-    // 'inline_parent' has no base disk name to list, so there's no way to make it tenant-aware
-    // and the exception is thrown regardless of what's listed.
-    if ($disk !== 'inline_parent') {
-        config(['tenancy.filesystem.disks' => ['public', $disk]]);
-
-        expect(fn () => tenancy()->initialize(Tenant::create()))
-            ->not()->toThrow(Exception::class, "Disk [$disk] uses the 'scoped' driver, so it has no root to make tenant-aware.");
-    }
-})->with([
-    'scoped disk' => 'foo',
-    'nested scoped disk' => 'bar',
-    'scoped disk with an inline base disk' => 'inline_parent',
-]);
-
-test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk when its base disk is listed too', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'filesystems.disks.foo' => [
-            'driver' => 'scoped',
-            'disk' => 'public',
-            'prefix' => 'foo',
-        ],
-        // Only the scoped disk's parent/base disk ('public') has to be listed here.
-        // Listing 'foo' too is redundant, and it shouldn't change anything.
-        'tenancy.filesystem.disks' => ['local', 'public', 'foo'],
-    ]);
-
-    $tenant = Tenant::create();
-    tenancy()->initialize($tenant);
-
-    // The 'foo' disk's parent disk ('public') is tenant-aware, so its root is scoped the same way.
-    expect(Storage::disk('foo')->path('testing.txt'))->toBe(storage_path('app/public/foo/testing.txt'));
-
-    // Scoped disks have no root or url of their own, so the bootstrapper leaves their config alone
-    expect(config('filesystems.disks.foo'))->toBe([
-        'driver' => 'scoped',
-        'disk' => 'public',
-        'prefix' => 'foo',
-    ]);
+    // The base disk is inline, so it has no name.
+    // There's no way to make the scoped disk tenant-aware.
+    config(['tenancy.filesystem.disks' => ['inline_base']]);
+    expect($initializeTenancy)->toThrow(Exception::class, "Disk [inline_base] uses the 'scoped' driver, so it has no root to make tenant-aware.");
 });
 
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -185,64 +185,38 @@ test('create and delete storage symlinks jobs work', function() {
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantKey"));
 });
 
-test('tenant storage gets deleted during tenant deletion when the DeletingTenant pipeline contains DeleteTenantStorage', function() {
+test('tenant storage gets deleted during tenant deletion when the DeletingTenant pipeline contains DeleteTenantStorage', function(bool $suffixStoragePath) {
     Event::listen(DeletingTenant::class,
         JobPipeline::make([DeleteTenantStorage::class])->send(function (DeletingTenant $event) {
             return $event->tenant;
         })->shouldBeQueued(false)->toListener()
     );
 
+    config([
+        'tenancy.bootstrappers' => [FilesystemTenancyBootstrapper::class],
+        // suffix_storage_path only affects the storage_path() helper.
+        // The disks are scoped to the tenant's storage directory either way,
+        // so the tenant files end up there.
+        'tenancy.filesystem.suffix_storage_path' => $suffixStoragePath,
+        // This is the default tenancy config -- set it here explicitly for clarity
+        'tenancy.filesystem.suffix_base' => 'tenant',
+        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+    ]);
+
     $centralStoragePath = storage_path();
-    tenancy()->initialize(Tenant::create());
+    $tenant = Tenant::create();
+    $tenantStoragePath = $centralStoragePath . "/tenant{$tenant->getTenantKey()}";
 
-    // FilesystemTenancyBootstrapper not enabled,
-    // tenant and central storage path is the same,
-    // the storage deletion will be skipped.
-    $tenantStoragePath = storage_path();
-    expect($tenantStoragePath)->toBe($centralStoragePath);
-    expect(File::isDirectory($centralStoragePath))->toBeTrue();
-    tenant()->delete();
+    tenancy()->initialize($tenant);
 
-    expect(File::isDirectory($centralStoragePath))->toBeTrue();
+    Storage::disk('public')->put('foo.txt', 'tenant file');
+    expect(file_get_contents($tenantStoragePath . '/app/public/foo.txt'))->toBe('tenant file');
 
-    config([
-        'tenancy.bootstrappers' => [FilesystemTenancyBootstrapper::class],
-        'tenancy.filesystem.suffix_storage_path' => false,
-    ]);
-
-    tenancy()->initialize(Tenant::create());
-
-    $tenantStoragePath = storage_path();
-
-    // FilesystemTenancyBootstrapper enabled,
-    // but tenant and central storage path is still the same
-    // because suffix_storage_path is false.
-    // The storage deletion will be skipped.
-    expect($tenantStoragePath)->toBe($centralStoragePath);
-    expect(File::isDirectory($centralStoragePath))->toBeTrue();
-    tenant()->delete();
-
-    expect(File::isDirectory($centralStoragePath))->toBeTrue();
-
-    config([
-        'tenancy.bootstrappers' => [FilesystemTenancyBootstrapper::class],
-        'tenancy.filesystem.suffix_storage_path' => true,
-    ]);
-
-    tenancy()->initialize(Tenant::create());
-    $tenantStoragePath = storage_path();
-
-    // FilesystemTenancyBootstrapper enabled,
-    // suffix_storage_path enabled, so the two paths are distinct.
-    // Tenant storage will be deleted.
-    expect($tenantStoragePath)->not()->toBe($centralStoragePath);
-    expect(File::isDirectory($tenantStoragePath))->toBeTrue();
-
-    tenant()->delete();
+    $tenant->delete();
 
     expect(File::isDirectory($tenantStoragePath))->toBeFalse();
     expect(File::isDirectory($centralStoragePath))->toBeTrue();
-});
+})->with([true, false]);
 
 test('the framework/cache directory is created when storage_path is scoped', function (bool $suffixStoragePath) {
     config([

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -185,7 +185,7 @@ test('create and delete storage symlinks jobs work', function() {
     $this->assertDirectoryDoesNotExist(public_path("public-$tenantKey"));
 });
 
-test('tenant storage gets deleted during tenant deletion when the DeletingTenant pipeline contains DeleteTenantStorage', function(bool $suffixStoragePath) {
+test('tenant storage gets deleted during tenant deletion when the DeletingTenant pipeline contains DeleteTenantStorage', function (bool $bootstrapperEnabled) {
     Event::listen(DeletingTenant::class,
         JobPipeline::make([DeleteTenantStorage::class])->send(function (DeletingTenant $event) {
             return $event->tenant;
@@ -193,40 +193,47 @@ test('tenant storage gets deleted during tenant deletion when the DeletingTenant
     );
 
     config([
-        'tenancy.bootstrappers' => [FilesystemTenancyBootstrapper::class],
-        // suffix_storage_path only affects the storage_path() helper.
-        // The disks are scoped to the tenant's storage directory either way,
-        // so the tenant files end up there.
-        'tenancy.filesystem.suffix_storage_path' => $suffixStoragePath,
-        // This is the default tenancy config -- set it here explicitly for clarity
-        'tenancy.filesystem.suffix_base' => 'tenant',
-        'tenancy.filesystem.root_override.public' => '%storage_path%/app/public/',
+        'tenancy.bootstrappers' => $bootstrapperEnabled ? [FilesystemTenancyBootstrapper::class] : [],
     ]);
 
     $centralStoragePath = storage_path();
+    $tenantStoragePath = fn (Tenant $tenant) => $centralStoragePath . "/tenant{$tenant->getTenantKey()}";
+
     $tenant = Tenant::create();
-    $tenantStoragePath = $centralStoragePath . "/tenant{$tenant->getTenantKey()}";
 
-    tenancy()->initialize($tenant);
+    File::ensureDirectoryExists($tenantStoragePath($tenant));
 
-    Storage::disk('public')->put('foo.txt', 'tenant file');
-    expect(file_get_contents($tenantStoragePath . '/app/public/foo.txt'))->toBe('tenant file');
+    expect(File::isDirectory($centralStoragePath))->toBeTrue();
+    expect(File::isDirectory($tenantStoragePath($tenant)))->toBeTrue();
 
     $tenant->delete();
 
-    expect(File::isDirectory($tenantStoragePath))->toBeFalse();
     expect(File::isDirectory($centralStoragePath))->toBeTrue();
-})->with([true, false]);
+    expect(File::isDirectory($tenantStoragePath($tenant)))->toBeFalse();
+})->with([
+    'filesystem bootstrapper enabled' => true,
+    'filesystem bootstrapper disabled' => false,
+]);
 
-test('DeleteTenantStorage does not delete the central storage directory when the filesystem bootstrapper is disabled', function () {
-    config(['tenancy.bootstrappers' => []]);
-
-    $centralStoragePath = storage_path();
+test('DeleteTenantStorage never deletes the central storage directory', function () {
     $tenant = Tenant::create();
+
+    $centralStoragePath = FilesystemTenancyBootstrapper::getBoundCentralStoragePath();
+    $tenantStoragePath = FilesystemTenancyBootstrapper::getTenantStoragePath($tenant);
+
+    File::ensureDirectoryExists($centralStoragePath . '/app');
+
+    // Make the tenant storage path a symlink to the central storage directory
+    File::deleteDirectory($tenantStoragePath);
+    symlink($centralStoragePath, $tenantStoragePath);
+
+    expect(realpath($tenantStoragePath))->toBe(realpath($centralStoragePath));
 
     (new DeleteTenantStorage($tenant))->handle();
 
     expect(File::isDirectory($centralStoragePath))->toBeTrue();
+    expect(File::isDirectory($centralStoragePath . '/app'))->toBeTrue();
+    expect(is_link($tenantStoragePath))->toBeTrue();
 });
 
 test('the framework/cache directory is created when storage_path is scoped', function (bool $suffixStoragePath) {

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -326,7 +326,53 @@ test('scoped disks based on a non-local disk are scoped per tenant', function ()
     expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe('scoped_s3_prefix/foo.txt');
 });
 
-test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk', function () {
+test('adding a scoped disk to tenancy.filesystem.disks throws an exception if its base disk is not listed', function (string $disk) {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'filesystems.disks.foo' => [
+            'driver' => 'scoped',
+            'disk' => 'public',
+            'prefix' => 'foo',
+        ],
+        'filesystems.disks.bar' => [
+            'driver' => 'scoped',
+            'disk' => 'foo',
+            'prefix' => 'bar',
+        ],
+        // Disks referencing each other (neither has a base disk)
+        'filesystems.disks.abc' => [
+            'driver' => 'scoped',
+            'disk' => 'def',
+            'prefix' => 'abc',
+        ],
+        'filesystems.disks.def' => [
+            'driver' => 'scoped',
+            'disk' => 'abc',
+            'prefix' => 'def',
+        ],
+        'tenancy.filesystem.disks' => [$disk],
+    ]);
+
+    expect(fn () => tenancy()->initialize(Tenant::create()))
+        ->toThrow(Exception::class, "List its base disk in tenancy.filesystem.disks instead");
+
+    // Parent of 'abc' is 'def', whose parent is 'abc' -- there's no base disk for these, so these are
+    // still invalid and the exception will still be thrown.
+    if ($disk !== 'abc') {
+        config(['tenancy.filesystem.disks' => ['public', $disk]]);
+
+        expect(fn () => tenancy()->initialize(Tenant::create()))
+            ->not()->toThrow(Exception::class, "List its base disk in tenancy.filesystem.disks instead");
+    }
+})->with([
+    'scoped disk' => 'foo',
+    'nested scoped disk' => 'bar',
+    'scoped disk with no base disk' => 'abc',
+]);
+
+test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk when its base disk is listed too', function () {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -345,7 +391,6 @@ test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk
     tenancy()->initialize($tenant);
 
     // The 'foo' disk's parent disk ('public') is tenant-aware, so its root is scoped the same way.
-    // It doesn't matter that 'foo' itself is tenant-aware.
     expect(Storage::disk('foo')->path('testing.txt'))->toBe(storage_path('app/public/foo/testing.txt'));
 
     // Scoped disks have no root or url of their own, so the bootstrapper leaves their config alone

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -341,35 +341,33 @@ test('adding a scoped disk to tenancy.filesystem.disks throws an exception if it
             'disk' => 'foo',
             'prefix' => 'bar',
         ],
-        // Disks referencing each other (neither has a base disk)
-        'filesystems.disks.abc' => [
+        // Scoped disk with an inline parent
+        'filesystems.disks.inline_parent' => [
             'driver' => 'scoped',
-            'disk' => 'def',
-            'prefix' => 'abc',
-        ],
-        'filesystems.disks.def' => [
-            'driver' => 'scoped',
-            'disk' => 'abc',
-            'prefix' => 'def',
+            'disk' => [
+                'driver' => 'local',
+                'root' => storage_path('app/inline'),
+            ],
+            'prefix' => 'inline_parent',
         ],
         'tenancy.filesystem.disks' => [$disk],
     ]);
 
     expect(fn () => tenancy()->initialize(Tenant::create()))
-        ->toThrow(Exception::class, "List its base disk in tenancy.filesystem.disks instead");
+        ->toThrow(Exception::class, "Disk [$disk] uses the 'scoped' driver, so it has no root to make tenant-aware.");
 
-    // Parent of 'abc' is 'def', whose parent is 'abc' -- there's no base disk for these, so these are
-    // still invalid and the exception will still be thrown.
-    if ($disk !== 'abc') {
+    // 'inline_parent' has no base disk name to list, so there's no way to make it tenant-aware
+    // and the exception is thrown regardless of what's listed.
+    if ($disk !== 'inline_parent') {
         config(['tenancy.filesystem.disks' => ['public', $disk]]);
 
         expect(fn () => tenancy()->initialize(Tenant::create()))
-            ->not()->toThrow(Exception::class, "List its base disk in tenancy.filesystem.disks instead");
+            ->not()->toThrow(Exception::class, "Disk [$disk] uses the 'scoped' driver, so it has no root to make tenant-aware.");
     }
 })->with([
     'scoped disk' => 'foo',
     'nested scoped disk' => 'bar',
-    'scoped disk with no base disk' => 'abc',
+    'scoped disk with an inline base disk' => 'inline_parent',
 ]);
 
 test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk when its base disk is listed too', function () {
@@ -399,31 +397,6 @@ test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk
         'disk' => 'public',
         'prefix' => 'foo',
     ]);
-});
-
-test('scoped disks referencing each other do not make bootstrapper hang', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
-        'filesystems.disks.foo' => [
-            'driver' => 'scoped',
-            'disk' => 'bar',
-            'prefix' => 'foo',
-        ],
-        'filesystems.disks.bar' => [
-            'driver' => 'scoped',
-            'disk' => 'foo',
-            'prefix' => 'bar',
-        ],
-    ]);
-
-    expect(FilesystemTenancyBootstrapper::baseDiskName('foo'))->toBeNull();
-    expect(FilesystemTenancyBootstrapper::baseDiskName('bar'))->toBeNull();
-
-    tenancy()->initialize(Tenant::create());
-
-    expect(tenant())->not()->toBeNull();
 });
 
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -277,7 +277,7 @@ test('the framework/cache directory is created when storage_path is scoped', fun
     }
 })->with([true, false]);
 
-test('scoped disks are scoped per tenant', function (bool $nested) {
+test('scoped disks are scoped per tenant', function () {
     config([
         'tenancy.bootstrappers' => [
             FilesystemTenancyBootstrapper::class,
@@ -294,32 +294,30 @@ test('scoped disks are scoped per tenant', function (bool $nested) {
         ],
     ]);
 
-    $disk = $nested ? 'nested_disk' : 'scoped_disk';
-    $path = 'app/public/scoped_disk_prefix/' . ($nested ? 'nested_disk_prefix/' : '') . 'foo.txt';
+    foreach (['scoped_disk' => '', 'nested_disk' => '/nested_disk_prefix'] as $disk => $nested_prefix) {
+        $path = "app/public/scoped_disk_prefix{$nested_prefix}/foo.txt";
 
-    $tenant = Tenant::create();
-    $centralFile = storage_path($path);
-    $tenantFile = storage_path("tenant{$tenant->id}/$path");
+        $tenant = Tenant::create();
+        $centralFile = storage_path($path);
+        $tenantFile = storage_path("tenant{$tenant->id}/$path");
 
-    Storage::disk($disk)->put('foo.txt', 'central');
-    expect(file_get_contents($centralFile))->toBe('central');
+        Storage::disk($disk)->put('foo.txt', 'central');
+        expect(file_get_contents($centralFile))->toBe('central');
 
-    tenancy()->initialize($tenant);
+        tenancy()->initialize($tenant);
 
-    expect(Storage::disk($disk)->get('foo.txt'))->toBeNull();
+        expect(Storage::disk($disk)->get('foo.txt'))->toBeNull();
 
-    Storage::disk($disk)->put('foo.txt', 'tenant');
-    expect(file_get_contents($tenantFile))->toBe('tenant');
+        Storage::disk($disk)->put('foo.txt', 'tenant');
+        expect(file_get_contents($tenantFile))->toBe('tenant');
 
-    tenancy()->end();
+        tenancy()->end();
 
-    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
-    expect(file_get_contents($centralFile))->toBe('central');
-    expect(file_get_contents($tenantFile))->toBe('tenant');
-})->with([
-    'scoped disk' => false,
-    'nested scoped disk' => true,
-]);
+        expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
+        expect(file_get_contents($centralFile))->toBe('central');
+        expect(file_get_contents($tenantFile))->toBe('tenant');
+    }
+});
 
 test('scoped disks based on a non-local disk are scoped per tenant', function () {
     config([
@@ -363,25 +361,7 @@ test('adding a scoped disk to tenancy.filesystem.disks throws an exception if it
             'disk' => 'foo',
             'prefix' => 'bar',
         ],
-    ]);
-
-    $initializeTenancy = fn () => tenancy()->initialize(Tenant::create());
-
-    config(['tenancy.filesystem.disks' => ['foo']]);
-    expect($initializeTenancy)->toThrow(Exception::class, "Disk [foo] uses the 'scoped' driver, so it has no root to make tenant-aware.");
-
-    config(['tenancy.filesystem.disks' => ['bar']]);
-    expect($initializeTenancy)->toThrow(Exception::class, "Disk [bar] uses the 'scoped' driver, so it has no root to make tenant-aware.");
-
-    config(['tenancy.filesystem.disks' => ['public', 'foo', 'bar']]);
-    expect($initializeTenancy)->not()->toThrow(Throwable::class);
-});
-
-test('adding a scoped disk with an inline base disk to tenancy.filesystem.disks throws an exception', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-        ],
+        // There's no way for a scoped disk with an array parent to have the parent listed in tenancy.filesystem.disks
         'filesystems.disks.inline_base' => [
             'driver' => 'scoped',
             'disk' => [
@@ -394,10 +374,19 @@ test('adding a scoped disk with an inline base disk to tenancy.filesystem.disks 
 
     $initializeTenancy = fn () => tenancy()->initialize(Tenant::create());
 
-    // The base disk is inline, so it has no name.
-    // There's no way to make the scoped disk tenant-aware.
+    config(['tenancy.filesystem.disks' => ['foo']]);
+    expect($initializeTenancy)->toThrow(Exception::class, "Disk [foo] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+
+    config(['tenancy.filesystem.disks' => ['bar']]);
+    expect($initializeTenancy)->toThrow(Exception::class, "Disk [bar] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+
     config(['tenancy.filesystem.disks' => ['inline_base']]);
     expect($initializeTenancy)->toThrow(Exception::class, "Disk [inline_base] uses the 'scoped' driver, so it has no root to make tenant-aware.");
+
+    config(['tenancy.filesystem.disks' => ['public', 'foo', 'bar']]);
+    expect($initializeTenancy)->not()->toThrow(Throwable::class);
+
+    // No way to make the 'inline_base' disk work
 });
 
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -268,32 +268,27 @@ test('scoped disks are scoped per tenant', function (bool $nested) {
     ]);
 
     $disk = $nested ? 'nested_disk' : 'scoped_disk';
-    $prefix = $nested ? 'scoped_disk_prefix/nested_disk_prefix' : 'scoped_disk_prefix';
+    $path = 'app/public/scoped_disk_prefix/' . ($nested ? 'nested_disk_prefix/' : '') . 'foo.txt';
 
     $tenant = Tenant::create();
+    $centralFile = storage_path($path);
+    $tenantFile = storage_path("tenant{$tenant->id}/$path");
 
     Storage::disk($disk)->put('foo.txt', 'central');
-
-    config(['filesystem.disks.public.prefix' => 'scoped_disk_prefix']);
-
-    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
-    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('central');
+    expect(file_get_contents($centralFile))->toBe('central');
 
     tenancy()->initialize($tenant);
 
-    expect(Storage::disk($disk)->get('foo.txt'))->toBe(null);
+    expect(Storage::disk($disk)->get('foo.txt'))->toBeNull();
+
     Storage::disk($disk)->put('foo.txt', 'tenant');
-    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('tenant');
-    expect(Storage::disk($disk)->get('foo.txt'))->toBe('tenant');
+    expect(file_get_contents($tenantFile))->toBe('tenant');
 
     tenancy()->end();
 
     expect(Storage::disk($disk)->get('foo.txt'))->toBe('central');
-    Storage::disk($disk)->put('foo.txt', 'central2');
-    expect(Storage::disk($disk)->get('foo.txt'))->toBe('central2');
-
-    expect(file_get_contents(storage_path() . "/app/public/{$prefix}/foo.txt"))->toBe('central2');
-    expect(file_get_contents(storage_path() . "/tenant{$tenant->id}/app/public/{$prefix}/foo.txt"))->toBe('tenant');
+    expect(file_get_contents($centralFile))->toBe('central');
+    expect(file_get_contents($tenantFile))->toBe('tenant');
 })->with([
     'scoped disk' => false,
     'nested scoped disk' => true,

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -326,6 +326,36 @@ test('scoped disks based on a non-local disk are scoped per tenant', function ()
     expect(Storage::disk('scoped_s3')->path('foo.txt'))->toBe('scoped_s3_prefix/foo.txt');
 });
 
+test('adding a scoped disk to tenancy.filesystem.disks has no effect on the disk', function () {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'filesystems.disks.foo' => [
+            'driver' => 'scoped',
+            'disk' => 'public',
+            'prefix' => 'foo',
+        ],
+        // Only the scoped disk's parent/base disk ('public') has to be listed here.
+        // Listing 'foo' too is redundant, and it shouldn't change anything.
+        'tenancy.filesystem.disks' => ['local', 'public', 'foo'],
+    ]);
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    // The 'foo' disk's parent disk ('public') is tenant-aware, so its root is scoped the same way.
+    // It doesn't matter that 'foo' itself is tenant-aware.
+    expect(Storage::disk('foo')->path('testing.txt'))->toBe(storage_path('app/public/foo/testing.txt'));
+
+    // Scoped disks have no root or url of their own, so the bootstrapper leaves their config alone
+    expect(config('filesystems.disks.foo'))->toBe([
+        'driver' => 'scoped',
+        'disk' => 'public',
+        'prefix' => 'foo',
+    ]);
+});
+
 test('file cache stores get their paths scoped on bootstrap and restored back on revert', function () {
     $fooPath = storage_path('framework/cache/foo_file');
     $barPath = storage_path('framework/cache/bar_file');

--- a/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
+++ b/tests/Bootstrappers/FilesystemTenancyBootstrapperTest.php
@@ -146,6 +146,26 @@ test('links to storage disks with a configured root are suffixed if not overridd
     expect(storage_path())->toEqual($expectedStoragePath);
 });
 
+test('disks with a falsy url_override do not get their url overridden', function ($urlOverride) {
+    config([
+        'tenancy.bootstrappers' => [
+            FilesystemTenancyBootstrapper::class,
+        ],
+        'tenancy.filesystem.url_override.public' => $urlOverride,
+    ]);
+
+    $tenant = Tenant::create();
+
+    $centralUrl = config('filesystems.disks.public.url');
+
+    tenancy()->initialize($tenant);
+
+    expect(config('filesystems.disks.public.url'))->toBe($centralUrl);
+})->with([
+    'empty string' => [''],
+    'null' => [null],
+]);
+
 test('create and delete storage symlinks jobs work', function() {
     Event::listen(
         TenantCreated::class,

--- a/tests/Bootstrappers/LogChannelBootstrapperTest.php
+++ b/tests/Bootstrappers/LogChannelBootstrapperTest.php
@@ -9,7 +9,6 @@ use Stancl\Tenancy\Events\TenancyInitialized;
 use Stancl\Tenancy\Listeners\BootstrapTenancy;
 use Stancl\Tenancy\Listeners\RevertToCentralContext;
 use Stancl\Tenancy\Bootstrappers\LogChannelBootstrapper;
-use Stancl\Tenancy\Bootstrappers\FilesystemTenancyBootstrapper;
 use Illuminate\Support\Facades\Log;
 
 afterEach($cleanup = function () {
@@ -42,15 +41,6 @@ beforeEach(function () use ($cleanup) {
 });
 
 test('storage path channels get tenant-specific paths by default', function () {
-    // Note that for LogChannelBootstrapper to change the paths correctly by default,
-    // the bootstrapper MUST run after FilesystemTenancyBootstrapper.
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
-    ]);
-
     $centralStoragePath = storage_path();
     $tenant = Tenant::create();
 
@@ -76,10 +66,6 @@ test('storage path channels get tenant-specific paths by default', function () {
 
 test('all channels included in a stack get processed correctly', function () {
     config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
         'logging.channels.stack' => [
             'driver' => 'stack',
             'channels' => ['single', 'daily'],
@@ -176,30 +162,24 @@ test('channel config keys remain unchanged if the specified tenant override attr
 });
 
 test('channel overrides take precedence over the default storage path channel updating logic', function () {
+    $centralStoragePath = storage_path();
     $tenant = Tenant::create(['id' => 'tenant1']);
 
     LogChannelBootstrapper::$storagePathChannels = ['single'];
 
     LogChannelBootstrapper::$channelOverrides = [
-        'single' => function (Tenant $tenant, array $channel) {
-            return array_merge($channel, ['path' => storage_path("logs/override-{$tenant->id}.log")]);
+        'single' => function (Tenant $tenant, array $channel) use ($centralStoragePath) {
+            return array_merge($channel, ['path' => "{$centralStoragePath}/logs/override-{$tenant->id}.log"]);
         },
     ];
 
     tenancy()->initialize($tenant);
 
     // Should use channel override, not the storage path updating behavior
-    expect(config('logging.channels.single.path'))->toEndWith('storage/logs/override-tenant1.log');
+    expect(config('logging.channels.single.path'))->toBe("{$centralStoragePath}/logs/override-tenant1.log");
 });
 
 test('channels are forgotten and re-resolved during bootstrap and revert', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
-    ]);
-
     $logManager = app('log');
     $originalChannel = $logManager->channel('single');
     $originalSinglePath = config('logging.channels.single.path');
@@ -229,14 +209,8 @@ test('channels are forgotten and re-resolved during bootstrap and revert', funct
 
 // Test real usage
 test('logs are written to tenant-specific files and do not leak between contexts', function () {
-    config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
-    ]);
-
-    $centralLogPath = storage_path('logs/laravel.log');
+    $centralStoragePath = storage_path();
+    $centralLogPath = "{$centralStoragePath}/logs/laravel.log";
 
     Log::channel('single')->info('central');
 
@@ -244,15 +218,11 @@ test('logs are written to tenant-specific files and do not leak between contexts
 
     [$tenant1, $tenant2] = [Tenant::create(['id' => 'tenant1']), Tenant::create(['id' => 'tenant2'])];
 
-    tenancy()->runForMultiple([$tenant1, $tenant2], function (Tenant $tenant) use ($centralLogPath) {
+    tenancy()->runForMultiple([$tenant1, $tenant2], function (Tenant $tenant) use ($centralStoragePath) {
         Log::channel('single')->info($tenant->id);
 
-        $tenantLogPath = storage_path('logs/laravel.log');
-
         // The log gets saved to the tenant's storage directory (default behavior)
-        expect($tenantLogPath)
-            ->not()->toBe($centralLogPath)
-            ->toEndWith("storage/tenant{$tenant->id}/logs/laravel.log");
+        $tenantLogPath = "{$centralStoragePath}/tenant{$tenant->id}/logs/laravel.log";
 
         expect(file_get_contents($tenantLogPath))
             ->toContain($tenant->id)
@@ -268,14 +238,14 @@ test('logs are written to tenant-specific files and do not leak between contexts
     // Tenant log messages didn't leak to logs of other tenants
     tenancy()->initialize($tenant1);
 
-    expect(file_get_contents(storage_path('logs/laravel.log')))
+    expect(file_get_contents("{$centralStoragePath}/tenant{$tenant1->id}/logs/laravel.log"))
         ->toContain('tenant1')
         ->not()->toContain('central')
         ->not()->toContain('tenant2');
 
     tenancy()->initialize($tenant2);
 
-    expect(file_get_contents(storage_path('logs/laravel.log')))
+    expect(file_get_contents("{$centralStoragePath}/tenant{$tenant2->id}/logs/laravel.log"))
         ->toContain('tenant2')
         ->not()->toContain('central')
         ->not()->toContain('tenant1');
@@ -285,9 +255,8 @@ test('logs are written to tenant-specific files and do not leak between contexts
     $tenant = Tenant::create(['id' => 'override-tenant']);
 
     LogChannelBootstrapper::$channelOverrides = [
-        'single' => function (Tenant $tenant, array $channel) {
-            // The tenant log path will be set to storage/tenantoverride-tenant/logs/custom-override-tenant.log
-            return array_merge($channel, ['path' => storage_path("logs/custom-{$tenant->id}.log")]);
+        'single' => function (Tenant $tenant, array $channel) use ($centralStoragePath) {
+            return array_merge($channel, ['path' => "{$centralStoragePath}/tenant{$tenant->id}/logs/custom-{$tenant->id}.log"]);
         },
     ];
 
@@ -296,21 +265,18 @@ test('logs are written to tenant-specific files and do not leak between contexts
 
     Log::channel('single')->info('tenant-override');
 
-    expect(file_get_contents(storage_path('logs/custom-override-tenant.log')))->toContain('tenant-override');
+    expect(file_get_contents("{$centralStoragePath}/tenantoverride-tenant/logs/custom-override-tenant.log"))->toContain('tenant-override');
 });
 
 test('stack logs are written to all configured channels with tenant-specific paths', function () {
     config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
         'logging.channels.stack' => [
             'driver' => 'stack',
             'channels' => ['single', 'daily'],
         ],
     ]);
 
+    $centralStoragePath = storage_path();
     $tenant = Tenant::create(['id' => 'stack-tenant']);
     $today = now()->format('Y-m-d');
 
@@ -327,8 +293,8 @@ test('stack logs are written to all configured channels with tenant-specific pat
     // Tenant context stack log
     tenancy()->initialize($tenant);
     Log::channel('stack')->info('tenant');
-    $tenantSingleLogPath = storage_path('logs/laravel.log');
-    $tenantDailyLogPath = storage_path("logs/laravel-{$today}.log");
+    $tenantSingleLogPath = "{$centralStoragePath}/tenant{$tenant->id}/logs/laravel.log";
+    $tenantDailyLogPath = "{$centralStoragePath}/tenant{$tenant->id}/logs/laravel-{$today}.log";
 
     expect(file_get_contents($tenantSingleLogPath))->toContain('tenant');
     expect(file_get_contents($tenantDailyLogPath))->toContain('tenant');
@@ -351,18 +317,15 @@ test('stack logs are written to all configured channels with tenant-specific pat
 
 test('stack channels that include any configured channel are re-resolved', function () {
     config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
         'logging.channels.custom_stack' => [
             'driver' => 'stack',
             'channels' => ['single'],
         ],
     ]);
 
+    $centralStoragePath = storage_path();
     $tenant = Tenant::create(['id' => 'stack-tenant']);
-    $centralLogPath = storage_path('logs/laravel.log');
+    $centralLogPath = "{$centralStoragePath}/logs/laravel.log";
 
     $logManager = app('log');
 
@@ -387,7 +350,7 @@ test('stack channels that include any configured channel are re-resolved', funct
         ->toContain('central log message')
         ->not()->toContain('tenant log message');
 
-    $tenantLogPath = storage_path('logs/laravel.log');
+    $tenantLogPath = "{$centralStoragePath}/tenant{$tenant->id}/logs/laravel.log";
     expect(file_exists($tenantLogPath))->toBeTrue();
     expect(file_get_contents($tenantLogPath))
         ->toContain('tenant log message');
@@ -454,10 +417,6 @@ test('slack channel uses correct webhook urls', function () {
 
 test('tenant logs inherit the path from the central log path config', function () {
     config([
-        'tenancy.bootstrappers' => [
-            FilesystemTenancyBootstrapper::class,
-            LogChannelBootstrapper::class,
-        ],
         'logging.channels.stack' => [
             'driver' => 'stack',
             'channels' => ['single', 'daily'],
@@ -466,6 +425,7 @@ test('tenant logs inherit the path from the central log path config', function (
         'logging.channels.daily.path' => storage_path('logs/daily/custom-name.log'),
     ]);
 
+    $centralStoragePath = storage_path();
     $tenant = Tenant::create();
     $today = now()->format('Y-m-d');
 
@@ -476,18 +436,17 @@ test('tenant logs inherit the path from the central log path config', function (
 
     tenancy()->initialize($tenant);
 
-    // Tenant log is located at storage/tenantX/logs/custom-name.log
     Log::channel('stack')->info($tenant->id);
 
     // The filename from the central config is preserved in tenant context
     expect(config('logging.channels.single.path'))->toEndWith('logs/single/custom-name.log');
     expect(config('logging.channels.daily.path'))->toEndWith('logs/daily/custom-name.log');
 
-    expect(file_get_contents(storage_path('logs/single/custom-name.log')))
+    expect(file_get_contents("{$centralStoragePath}/tenant{$tenant->id}/logs/single/custom-name.log"))
         ->toContain($tenant->id)
         ->not()->toContain('central');
 
-    expect(file_get_contents(storage_path("logs/daily/custom-name-{$today}.log")))
+    expect(file_get_contents("{$centralStoragePath}/tenant{$tenant->id}/logs/daily/custom-name-{$today}.log"))
         ->toContain($tenant->id)
         ->not()->toContain('central');
 });

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -31,6 +31,7 @@ beforeEach(function () {
     TenancyUrlGenerator::$passTenantParameterToRoutes = true;
     TenantAssetController::$headers = [];
     TenantAssetController::$publicDisk = null;
+    InitializeTenancyByRequestData::$onFail = null;
 
     /** @var CloneRoutesAsTenant $cloneAction */
     $cloneAction = app(CloneRoutesAsTenant::class);
@@ -128,6 +129,21 @@ test('tenant asset controller throws when the configured disk has no root', func
     pest()->expectExceptionMessage('Disk [rootless] has no root path configured.');
 
     pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
+});
+
+test('tenant assets are served from the central storage path in central context', function () {
+    config(['tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class]);
+
+    // Mimic the universal route setup (let the request through even though no tenant is identified)
+    InitializeTenancyByRequestData::$onFail = fn ($e, $request, $next) => $next($request);
+
+    $filename = 'testfile' . Str::random(8);
+    Storage::disk('public')->put($filename, 'bar');
+
+    $response = pest()->get(tenant_asset($filename));
+
+    $response->assertSuccessful();
+    expect($response->getFile()->getPathname())->toBe(storage_path("app/public/$filename"));
 });
 
 test('asset helper returns a link to tenant asset controller when asset url is null', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -404,6 +404,10 @@ test('tenant asset controller throws an exception when accessing a file in a dir
 
     Storage::disk('media')->put('photo.jpg', 'public file');
 
+    pest()->get(tenant_asset('photo.jpg'), [
+        'X-Tenant' => $tenant->id,
+    ])->assertSuccessful();
+
     // A directory next to the asset root, e.g. one holding files that shouldn't be served
     mkdir($privateDirectory = storage_path('app/media-originals'), recursive: true);
     file_put_contents($privateDirectory . '/photo.jpg', 'private file');

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -398,9 +398,10 @@ test('tenant asset controller only serves files inside the asset root', function
 
     pest()->get(tenant_asset('photo.jpg'), ['X-Tenant' => $tenant->id])->assertSuccessful();
 
-    // Files outside the asset root, e.g. ones that shouldn't be served.
-    // The directory with the second file starts with the name of the asset root.
+    // Files outside the asset root
     file_put_contents(storage_path('app/photo.jpg'), 'private file');
+
+    // This path starts with the asset root but is a sibling dir, not a child. Regression assertion
     mkdir($siblingDirectory = storage_path('app/public-originals'), recursive: true);
     file_put_contents($siblingDirectory . '/photo.jpg', 'private file');
 

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -120,7 +120,7 @@ test('the disk used for serving tenant assets is configurable', function () {
     expect($response->getFile()->getPathname())->toBe($path);
 });
 
-test('tenant asset controller throws when the configured disk is not local', function () {
+test('tenant asset controller throws when the configured disk is not local', function (string $publicDisk) {
     config([
         'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
         // Add a disk that uses the s3 driver (= non-local disk).
@@ -132,18 +132,26 @@ test('tenant asset controller throws when the configured disk is not local', fun
             'secret' => 'secret',
             'bucket' => 'bucket',
         ],
+        'filesystems.disks.scoped_remote' => [
+            'driver' => 'scoped',
+            'disk' => 'remote',
+            'prefix' => 'assets',
+        ],
     ]);
 
-    TenantAssetController::$publicDisk = 'remote';
+    TenantAssetController::$publicDisk = $publicDisk;
 
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
     $this->withoutExceptionHandling();
-    pest()->expectExceptionMessage('Disk [remote] is not a local disk.');
+    pest()->expectExceptionMessage("Disk [$publicDisk] is not a local disk.");
 
     pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
-});
+})->with([
+    'disk' => 'remote',
+    'scoped disk' => 'scoped_remote',
+]);
 
 test('tenant asset controller throws when the disk used for serving assets is not tenant-aware', function (string $publicDisk, string $expectedMessage) {
     $centralStoragePath = storage_path();

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -30,6 +30,7 @@ beforeEach(function () {
     TenancyUrlGenerator::$prefixRouteNames = false;
     TenancyUrlGenerator::$passTenantParameterToRoutes = true;
     TenantAssetController::$headers = [];
+    TenantAssetController::$publicDisk = null;
 
     /** @var CloneRoutesAsTenant $cloneAction */
     $cloneAction = app(CloneRoutesAsTenant::class);
@@ -86,6 +87,47 @@ test('tenant assets are served even when the suffix_storage_path config is set t
     $response->assertSuccessful();
     expect($response->getFile()->getPathname())
         ->toBe("$centralStoragePath/tenant{$tenant->id}/app/public/$filename");
+});
+
+test('the disk used for serving tenant assets is configurable', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        // This is tenancy's default override for the local disk's root, set it here for clarity
+        'tenancy.filesystem.root_override.local' => '%storage_path%/app/',
+    ]);
+
+    // The local disk's root is overridden to '%storage_path%/app/' (so it does not use 'app/public')
+    TenantAssetController::$publicDisk = 'local';
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    $filename = 'testfile' . Str::random(8);
+    Storage::disk('local')->put($filename, 'bar');
+    $path = Storage::disk('local')->path($filename);
+
+    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+
+    // The asset is served from the disk's root instead of 'app/public'
+    $response->assertSuccessful();
+    expect($response->getFile()->getPathname())->toBe($path);
+});
+
+test('tenant asset controller throws when the configured disk has no root', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        'filesystems.disks.rootless' => ['driver' => 's3'],
+    ]);
+
+    TenantAssetController::$publicDisk = 'rootless';
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    $this->withoutExceptionHandling();
+    pest()->expectExceptionMessage('Disk [rootless] has no root path configured.');
+
+    pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
 });
 
 test('asset helper returns a link to tenant asset controller when asset url is null', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -145,6 +145,55 @@ test('tenant asset controller throws when the configured disk is not local', fun
     pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
 });
 
+test('tenant asset controller throws when the disk used for serving assets is not tenant-aware', function (string $publicDisk, string $expectedMessage) {
+    $centralStoragePath = storage_path();
+
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        'filesystems.disks.media' => [
+            'driver' => 'local',
+            'root' => storage_path('app/media'),
+        ],
+        'filesystems.disks.scoped_media' => [
+            'driver' => 'scoped',
+            'disk' => 'media',
+            'prefix' => 'assets',
+        ],
+        'filesystems.disks.inline_scoped_media' => [
+            'driver' => 'scoped',
+            // Laravel allows configuring the parent disk inline, but such a disk
+            // has no name, so it cannot be listed in tenancy.filesystem.disks (i.e. made tenant-aware)
+            'disk' => [
+                'driver' => 'local',
+                'root' => storage_path('app/media'),
+            ],
+            'prefix' => 'assets',
+        ],
+        // 'media' isn't tenant-aware (i.e. not included in tenancy.filesystem.disks)
+        'tenancy.filesystem.root_override.media' => '%storage_path%/app/media/',
+    ]);
+
+    TenantAssetController::$publicDisk = $publicDisk;
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    Storage::disk($publicDisk)->put($filename = 'testfile' . Str::random(8), 'bar');
+
+    // The disk's root stays central
+    expect(Storage::disk($publicDisk)->path($filename))->toStartWith("$centralStoragePath/app/media/");
+
+    $this->withoutExceptionHandling();
+
+    pest()->expectExceptionMessage($expectedMessage);
+
+    pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+})->with([
+    'disk' => ['media', 'Disk [media] is not tenant-aware.'],
+    'scoped disk' => ['scoped_media', 'Disk [media] is not tenant-aware.'],
+    'scoped disk with an inline parent disk' => ['inline_scoped_media', 'Disk [inline_scoped_media] has its parent disk configured inline.'],
+]);
+
 test('tenant assets are served from the resolved root of a scoped disk', function () {
     config([
         'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -180,7 +180,7 @@ test('tenant asset controller throws when the configured disk is not local or no
     }
 });
 
-test('tenant assets are served from the resolved root of a scoped disk', function () {
+test('tenant assets are served from the resolved root of the configured disk', function () {
     config([
         'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
         // A scoped disk has no configured root -- it inherits the root of its parent disk
@@ -190,56 +190,36 @@ test('tenant assets are served from the resolved root of a scoped disk', functio
             'disk' => 'public',
             'prefix' => 'scoped_disk_prefix',
         ],
-        // Default tenancy config, set it here for clarity
-        'tenancy.filesystem.disks' => ['local', 'public'],
-    ]);
-
-    TenantAssetController::$publicDisk = 'scoped_disk';
-
-    $tenant = Tenant::create();
-    tenancy()->initialize($tenant);
-
-    $filename = 'testfile' . Str::random(8);
-    Storage::disk('scoped_disk')->put($filename, 'bar');
-    $path = Storage::disk('scoped_disk')->path($filename);
-
-    // The parent disk is tenant-aware, so the scoped disk's root is inside the tenant's storage directory
-    expect($path)->toBe(storage_path("app/public/scoped_disk_prefix/$filename"));
-
-    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
-
-    $response->assertSuccessful();
-    expect($response->getFile()->getPathname())->toBe($path);
-});
-
-test('tenant assets are served from the resolved root of a disk with a configured prefix', function () {
-    config([
-        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
-        // A prefix is part of the disk's root path, so it has to be included in the asset root
+        // A prefix is part of the disk's full path, so it has to be included in the asset root
         'filesystems.disks.prefixed' => [
             'driver' => 'local',
             'root' => storage_path('app/media'),
-            'prefix' => 'foo-prefix',
+            'prefix' => 'foo_prefix',
         ],
-        'tenancy.filesystem.disks' => ['prefixed'],
+        'tenancy.filesystem.disks' => ['local', 'public', 'prefixed'],
         'tenancy.filesystem.root_override.prefixed' => '%storage_path%/app/media/',
     ]);
-
-    TenantAssetController::$publicDisk = 'prefixed';
 
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
-    $filename = 'testfile' . Str::random(8);
-    Storage::disk('prefixed')->put($filename, 'bar');
-    $path = Storage::disk('prefixed')->path($filename);
+    foreach ([
+        'scoped_disk' => 'app/public/scoped_disk_prefix',
+        'prefixed' => 'app/media/foo_prefix',
+    ] as $publicDisk => $expectedRoot) {
+        TenantAssetController::$publicDisk = $publicDisk;
 
-    expect($path)->toBe(storage_path("app/media/foo-prefix/$filename"));
+        $filename = 'testfile' . Str::random(8);
+        Storage::disk($publicDisk)->put($filename, 'bar');
+        $path = Storage::disk($publicDisk)->path($filename);
 
-    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+        expect($path)->toBe(storage_path("{$expectedRoot}/$filename"));
 
-    $response->assertSuccessful();
-    expect($response->getFile()->getPathname())->toBe($path);
+        $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+
+        $response->assertSuccessful();
+        expect($response->getFile()->getPathname())->toBe($path);
+    }
 });
 
 test('tenant assets are served from the central storage path in central context', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -31,7 +31,6 @@ beforeEach(function () {
     TenancyUrlGenerator::$passTenantParameterToRoutes = true;
     TenantAssetController::$headers = [];
     TenantAssetController::$publicDisk = null;
-    InitializeTenancyByRequestData::$onFail = null;
 
     /** @var CloneRoutesAsTenant $cloneAction */
     $cloneAction = app(CloneRoutesAsTenant::class);
@@ -44,7 +43,6 @@ beforeEach(function () {
 afterEach(function () {
     TenantAssetController::$headers = [];
     TenantAssetController::$publicDisk = null;
-    InitializeTenancyByRequestData::$onFail = null;
 });
 
 test('asset can be accessed using the url returned by the tenant asset helper', function () {
@@ -220,21 +218,6 @@ test('tenant assets are served from the resolved root of the configured disk', f
         $response->assertSuccessful();
         expect($response->getFile()->getPathname())->toBe($path);
     }
-});
-
-test('tenant assets are served from the central storage path in central context', function () {
-    config(['tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class]);
-
-    // Mimic the universal route setup (let the request through even though no tenant is identified)
-    InitializeTenancyByRequestData::$onFail = fn ($e, $request, $next) => $next($request);
-
-    $filename = 'testfile' . Str::random(8);
-    Storage::disk('public')->put($filename, 'bar');
-
-    $response = pest()->get(tenant_asset($filename));
-
-    $response->assertSuccessful();
-    expect($response->getFile()->getPathname())->toBe(storage_path("app/public/$filename"));
 });
 
 test('asset helper returns a link to tenant asset controller when asset url is null', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -120,21 +120,91 @@ test('the disk used for serving tenant assets is configurable', function () {
     expect($response->getFile()->getPathname())->toBe($path);
 });
 
-test('tenant asset controller throws when the configured disk has no root', function () {
+test('tenant asset controller throws when the configured disk is not local', function () {
     config([
         'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
-        'filesystems.disks.rootless' => ['driver' => 's3'],
+        // Add a disk that uses the s3 driver (= non-local disk).
+        // Use dummy credentials so that the s3 disk can be resolved without throwing an AWS exception.
+        'filesystems.disks.remote' => [
+            'driver' => 's3',
+            'region' => 'us-east-1',
+            'key' => 'key',
+            'secret' => 'secret',
+            'bucket' => 'bucket',
+        ],
     ]);
 
-    TenantAssetController::$publicDisk = 'rootless';
+    TenantAssetController::$publicDisk = 'remote';
 
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
     $this->withoutExceptionHandling();
-    pest()->expectExceptionMessage('Disk [rootless] has no root path configured.');
+    pest()->expectExceptionMessage('Disk [remote] is not a local disk.');
 
     pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
+});
+
+test('tenant assets are served from the resolved root of a scoped disk', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        // A scoped disk has no configured root -- it inherits the root of its parent disk
+        // and appends its prefix to it, both of which happens when the disk is resolved.
+        'filesystems.disks.scoped_disk' => [
+            'driver' => 'scoped',
+            'disk' => 'public',
+            'prefix' => 'scoped_disk_prefix',
+        ],
+        // Default tenancy config, set it here for clarity
+        'tenancy.filesystem.disks' => ['local', 'public'],
+    ]);
+
+    TenantAssetController::$publicDisk = 'scoped_disk';
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    $filename = 'testfile' . Str::random(8);
+    Storage::disk('scoped_disk')->put($filename, 'bar');
+    $path = Storage::disk('scoped_disk')->path($filename);
+
+    // The parent disk is tenant-aware, so the scoped disk's root is inside the tenant's storage directory
+    expect($path)->toBe(storage_path("app/public/scoped_disk_prefix/$filename"));
+
+    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+
+    $response->assertSuccessful();
+    expect($response->getFile()->getPathname())->toBe($path);
+});
+
+test('tenant assets are served from the resolved root of a disk with a configured prefix', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        // A prefix is part of the disk's root path, so it has to be included in the asset root
+        'filesystems.disks.prefixed' => [
+            'driver' => 'local',
+            'root' => storage_path('app/media'),
+            'prefix' => 'foo-prefix',
+        ],
+        'tenancy.filesystem.disks' => ['prefixed'],
+        'tenancy.filesystem.root_override.prefixed' => '%storage_path%/app/media/',
+    ]);
+
+    TenantAssetController::$publicDisk = 'prefixed';
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    $filename = 'testfile' . Str::random(8);
+    Storage::disk('prefixed')->put($filename, 'bar');
+    $path = Storage::disk('prefixed')->path($filename);
+
+    expect($path)->toBe(storage_path("app/media/foo-prefix/$filename"));
+
+    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+
+    $response->assertSuccessful();
+    expect($response->getFile()->getPathname())->toBe($path);
 });
 
 test('tenant assets are served from the central storage path in central context', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -65,6 +65,29 @@ test('asset can be accessed using the url returned by the tenant asset helper', 
     expect($content)->toBe('bar');
 });
 
+test('tenant assets are served even when the suffix_storage_path config is set to false', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        'tenancy.filesystem.suffix_storage_path' => false,
+    ]);
+
+    // With suffix_storage_path disabled, storage_path() stays central in tenant context
+    $centralStoragePath = storage_path();
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    $filename = 'testfile' . Str::random(8);
+    Storage::disk('public')->put($filename, 'bar');
+
+    $response = pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
+
+    // The asset is served from the tenant's storage directory, not from the central storage path
+    $response->assertSuccessful();
+    expect($response->getFile()->getPathname())
+        ->toBe("$centralStoragePath/tenant{$tenant->id}/app/public/$filename");
+});
+
 test('asset helper returns a link to tenant asset controller when asset url is null', function () {
     config(['app.asset_url' => null]);
     config(['tenancy.filesystem.asset_helper_override' => true]);

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -199,7 +199,7 @@ test('tenant asset controller throws when the disk used for serving assets is no
 })->with([
     'disk' => ['media', 'Disk [media] is not tenant-aware.'],
     'scoped disk' => ['scoped_media', 'Disk [media] is not tenant-aware.'],
-    'scoped disk with an inline parent disk' => ['inline_scoped_media', 'Disk [inline_scoped_media] has its parent disk configured inline.'],
+    'scoped disk with an inline parent disk' => ['inline_scoped_media', 'Disk [inline_scoped_media] has an unnamed parent disk.'],
 ]);
 
 test('tenant assets are served from the resolved root of a scoped disk', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -120,7 +120,7 @@ test('the disk used for serving tenant assets is configurable', function () {
     expect($response->getFile()->getPathname())->toBe($path);
 });
 
-test('tenant asset controller throws when the configured disk is not local', function (string $publicDisk) {
+test('tenant asset controller throws when the configured disk is not local or not tenant-aware', function () {
     config([
         'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
         // Add a disk that uses the s3 driver (= non-local disk).
@@ -137,27 +137,7 @@ test('tenant asset controller throws when the configured disk is not local', fun
             'disk' => 'remote',
             'prefix' => 'assets',
         ],
-    ]);
-
-    TenantAssetController::$publicDisk = $publicDisk;
-
-    $tenant = Tenant::create();
-    tenancy()->initialize($tenant);
-
-    $this->withoutExceptionHandling();
-    pest()->expectExceptionMessage("Disk [$publicDisk] is not a local disk.");
-
-    pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]);
-})->with([
-    'disk' => 'remote',
-    'scoped disk' => 'scoped_remote',
-]);
-
-test('tenant asset controller throws when the disk used for serving assets is not tenant-aware', function (string $publicDisk, string $expectedMessage) {
-    $centralStoragePath = storage_path();
-
-    config([
-        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        // 'media' isn't tenant-aware (i.e. not included in tenancy.filesystem.disks)
         'filesystems.disks.media' => [
             'driver' => 'local',
             'root' => storage_path('app/media'),
@@ -177,30 +157,28 @@ test('tenant asset controller throws when the disk used for serving assets is no
             ],
             'prefix' => 'assets',
         ],
-        // 'media' isn't tenant-aware (i.e. not included in tenancy.filesystem.disks)
-        'tenancy.filesystem.root_override.media' => '%storage_path%/app/media/',
     ]);
-
-    TenantAssetController::$publicDisk = $publicDisk;
 
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
-    Storage::disk($publicDisk)->put($filename = 'testfile' . Str::random(8), 'bar');
-
-    // The disk's root stays central
-    expect(Storage::disk($publicDisk)->path($filename))->toStartWith("$centralStoragePath/app/media/");
-
     $this->withoutExceptionHandling();
 
-    pest()->expectExceptionMessage($expectedMessage);
+    $expectedExceptions = [
+        'remote' => 'Disk [remote] is not a local disk.',
+        'scoped_remote' => 'Disk [scoped_remote] is not a local disk.',
+        'media' => 'Disk [media] is not tenant-aware.',
+        'scoped_media' => 'Disk [media] is not tenant-aware.',
+        'inline_scoped_media' => 'Disk [inline_scoped_media] has an unnamed parent disk.',
+    ];
 
-    pest()->get(tenant_asset($filename), ['X-Tenant' => $tenant->id]);
-})->with([
-    'disk' => ['media', 'Disk [media] is not tenant-aware.'],
-    'scoped disk' => ['scoped_media', 'Disk [media] is not tenant-aware.'],
-    'scoped disk with an inline parent disk' => ['inline_scoped_media', 'Disk [inline_scoped_media] has an unnamed parent disk.'],
-]);
+    foreach ($expectedExceptions as $publicDisk => $exceptionMessage) {
+        TenantAssetController::$publicDisk = $publicDisk;
+
+        expect(fn () => pest()->get(tenant_asset('foo.txt'), ['X-Tenant' => $tenant->id]))
+            ->toThrow(Exception::class, $exceptionMessage);
+    }
+});
 
 test('tenant assets are served from the resolved root of a scoped disk', function () {
     config([

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -445,56 +445,26 @@ test('tenant asset controller returns a 404 when accessing a nonexistent file', 
     ]);
 });
 
-test('tenant asset controller throws an exception when accessing a file in a directory whose name starts with the name of the asset root', function () {
-    config([
-        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
-        // Disk used for serving the assets -- its root is 'app/media' in the tenant's storage directory
-        'filesystems.disks.media' => ['driver' => 'local', 'root' => storage_path('app/media')],
-        'tenancy.filesystem.disks' => array_merge(config('tenancy.filesystem.disks'), ['media']),
-        'tenancy.filesystem.root_override.media' => '%storage_path%/app/media/',
-    ]);
-
-    TenantAssetController::$publicDisk = 'media';
-
-    $tenant = Tenant::create();
-    tenancy()->initialize($tenant);
-
-    Storage::disk('media')->put('photo.jpg', 'public file');
-
-    pest()->get(tenant_asset('photo.jpg'), [
-        'X-Tenant' => $tenant->id,
-    ])->assertSuccessful();
-
-    // A directory next to the asset root, e.g. one holding files that shouldn't be served
-    mkdir($privateDirectory = storage_path('app/media-originals'), recursive: true);
-    file_put_contents($privateDirectory . '/photo.jpg', 'private file');
-
-    $this->withoutExceptionHandling();
-    pest()->expectExceptionMessage('Accessing a file outside the storage root'); // outside tests this is a 404
-
-    pest()->get(tenant_asset('../media-originals/photo.jpg'), [
-        'X-Tenant' => $tenant->id,
-    ]);
-});
-
-test('test asset controller returns a 404 when accessing a file outside the storage root', function () {
+test('tenant asset controller only serves files inside the asset root', function () {
     config(['tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class]);
 
     $tenant = Tenant::create();
-
     tenancy()->initialize($tenant);
 
-    $storageRoot = storage_path("app/public");
+    Storage::disk('public')->put('photo.jpg', 'public file');
 
-    if (! is_dir($storageRoot)) {
-        mkdir(storage_path("app/public"), recursive: true);
-        file_put_contents(storage_path('app/foo.txt'), 'bar');
-    }
+    pest()->get(tenant_asset('photo.jpg'), ['X-Tenant' => $tenant->id])->assertSuccessful();
+
+    // Files outside the asset root, e.g. ones that shouldn't be served.
+    // The directory with the second file starts with the name of the asset root.
+    file_put_contents(storage_path('app/photo.jpg'), 'private file');
+    mkdir($siblingDirectory = storage_path('app/public-originals'), recursive: true);
+    file_put_contents($siblingDirectory . '/photo.jpg', 'private file');
 
     $this->withoutExceptionHandling();
-    pest()->expectExceptionMessage('Accessing a file outside the storage root'); // outside tests this is a 404
 
-    pest()->get(tenant_asset('../foo.txt'), [
-        'X-Tenant' => $tenant->id,
-    ]);
+    foreach (['../photo.jpg', '../public-originals/photo.jpg'] as $path) {
+        expect(fn () => pest()->get(tenant_asset($path), ['X-Tenant' => $tenant->id]))
+            ->toThrow(Exception::class, 'Accessing a file outside the storage root'); // outside tests this is a 404
+    }
 });

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -41,6 +41,12 @@ beforeEach(function () {
     Event::listen(TenancyEnded::class, RevertToCentralContext::class);
 });
 
+afterEach(function () {
+    TenantAssetController::$headers = [];
+    TenantAssetController::$publicDisk = null;
+    InitializeTenancyByRequestData::$onFail = null;
+});
+
 test('asset can be accessed using the url returned by the tenant asset helper', function () {
     config(['tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class]);
 
@@ -229,8 +235,6 @@ test('TenantAssetController headers are configurable', function () {
 
     $response->assertSuccessful();
     $response->assertHeader('X-Foo', 'Bar');
-
-    TenantAssetController::$headers = []; // reset static property
 });
 
 test('global asset helper returns the same url regardless of tenancy initialization', function () {

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -83,6 +83,8 @@ test('tenant assets are served even when the suffix_storage_path config is set t
     $tenant = Tenant::create();
     tenancy()->initialize($tenant);
 
+    expect(storage_path())->toBe($centralStoragePath);
+
     $filename = 'testfile' . Str::random(8);
     Storage::disk('public')->put($filename, 'bar');
 

--- a/tests/TenantAssetTest.php
+++ b/tests/TenantAssetTest.php
@@ -298,6 +298,34 @@ test('tenant asset controller returns a 404 when accessing a nonexistent file', 
     ]);
 });
 
+test('tenant asset controller throws an exception when accessing a file in a directory whose name starts with the name of the asset root', function () {
+    config([
+        'tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class,
+        // Disk used for serving the assets -- its root is 'app/media' in the tenant's storage directory
+        'filesystems.disks.media' => ['driver' => 'local', 'root' => storage_path('app/media')],
+        'tenancy.filesystem.disks' => array_merge(config('tenancy.filesystem.disks'), ['media']),
+        'tenancy.filesystem.root_override.media' => '%storage_path%/app/media/',
+    ]);
+
+    TenantAssetController::$publicDisk = 'media';
+
+    $tenant = Tenant::create();
+    tenancy()->initialize($tenant);
+
+    Storage::disk('media')->put('photo.jpg', 'public file');
+
+    // A directory next to the asset root, e.g. one holding files that shouldn't be served
+    mkdir($privateDirectory = storage_path('app/media-originals'), recursive: true);
+    file_put_contents($privateDirectory . '/photo.jpg', 'private file');
+
+    $this->withoutExceptionHandling();
+    pest()->expectExceptionMessage('Accessing a file outside the storage root'); // outside tests this is a 404
+
+    pest()->get(tenant_asset('../media-originals/photo.jpg'), [
+        'X-Tenant' => $tenant->id,
+    ]);
+});
+
 test('test asset controller returns a 404 when accessing a file outside the storage root', function () {
     config(['tenancy.identification.default_middleware' => InitializeTenancyByRequestData::class]);
 


### PR DESCRIPTION
> Based on #1473 (scope-cache-fix).

Some of Tenancy's code depended on the `storage_path()` helper being suffixed in tenant context, i.e. `FilesystemTenancyBootstrapper` enabled *and* `tenancy.filesystem.suffix_storage_path` set to `true`.

In the case where `tenancy.filesystem.suffix_storage_path` was set to `false`, things like `DeleteTenantStorage` didn't do anything. That wasn't wrong -- it was the documented behavior -- but `DeleteTenantStorage` didn't have to depend on `storage_path()` at all. It could work just fine even with the storage path suffixing disabled if we had an option to grab the same tenant storage path that `FilesystemTenancyBootstrapper` builds using its protected `tenantStoragePath()` method -- the same method it uses for scoping cache or session paths **regardless of the configured `suffix_storage_path`**.

This PR adds a public static method to the bootstrapper (`FilesystemTenancyBootstrapper::getTenantStoragePath()`) which does exactly that: it returns the tenant storage path built using the bootstrapper's `tenantStoragePath()` method.

This method allows us to remove the `tenancy.filesystem.suffix_storage_path === true`/suffixed `storage_path()` requirements and make the bootstrapper the single source of truth for the tenant storage path. Where `storage_path()` was used for getting the tenant storage path in Tenancy code (like in the `DeleteTenantStorage` job), `getTenantStoragePath()` is used now. **As a result, the `tenancy.filesystem.suffix_storage_path` config now *only* controls whether the helper itself is suffixed.**

In practice, this means the following now works even with `suffix_storage_path` set to `false`:
- The `DeleteTenantStorage` job now deletes the tenant storage. Previously, it wouldn't do anything, and since `FilesystemTenancyBootstrapper` makes your app write to a tenant-scoped path regardless of `suffix_storage_path`, you would be left with the tenant's files.
- The `TenantAssetController` now serves the tenant assets using the tenant storage path (see the "TenantAssetController changes" section below). Previously, the controller served the *central* path, even for tenants.
- The `LogChannelBootstrapper` now makes your app log inside the tenant directory, and it no longer requires `FilesystemTenancyBootstrapper` to be enabled. Previously, the logs went to the central log file.

### TenantAssetController changes

In `TenantAssetController`, there's a new `public static string|null $publicDisk = null` property.

When it's `null` (the default), the controller serves `app/public` inside the tenant storage directory (note that `app/public` is hardcoded), resolved via `FilesystemTenancyBootstrapper::getTenantStoragePath()` instead of `storage_path()` (so it's the tenant's directory regardless of the `suffix_storage_path` config).

When it's set to the name of a **tenant-aware** *local* disk (e.g. `TenantAssetController::$publicDisk = 'public'`), the controller resolves that disk and serves the assets from its root (using `$disk->path('')`) as `FilesystemTenancyBootstrapper` configured it. This is particularly useful if your assets aren't under `app/public` -- the root comes from your `root_override` and includes the disk's `prefix`, so it's customizable. If `$publicDisk` isn't local or tenant-aware, an exception is thrown.

> Note that `$publicDisk` can be a scoped disk, nested as deep as you want. The only requirements are that the scoped disk's final "parent"/base disk is tenant-aware and local (so the same as with non-scoped disks), and that the base disk is named: Laravel allows configuring a scoped disk's parent inline as an array, and such a disk has no name, so it can't be listed in `tenancy.filesystem.disks` -- the controller throws an exception in that case.

There was also a separate, very subtle issue in `validatePath()`. If you had an `app/media-originals` directory next to `app/media`, attempts to reach `app/media-originals` would succeed even though the allowed root ended with `app/media`. Fixed by enforcing that the attempted path has to be *under* the allowed root (i.e. the path has to be `app/media/*`, not just `app/media*`).

Also, the controller now throws an exception when used in central context -- tenant assets should only be served in tenant context.

### Symlinks

Symlinks had the same suffixed `storage_path()` dependency, though the fix there didn't need the new `getTenantStoragePath()` method.

The tenant symlink paths returned by `DealsWithTenantSymlinks::possibleTenantSymlinks()` were built using `storage_path()`, which the method used solely for replacing the `%storage_path%` placeholder in the `root_override` templates. So unless your `suffix_storage_path` config was set to `true`, the symlinks pointed to the central storage.

Now, `possibleTenantSymlinks()` doesn't depend on a suffixed `storage_path()` -- the disk roots are simply read from the config.

`possibleTenantSymlinks()` also had its own code for resolving the `root_override` templates -- very similar to the code `FilesystemTenancyBootstrapper` uses for the same purpose, but weaker. It only supported `%storage_path%` substitution, so if some of your `root_override`s had `%original_storage_path%` or `%tenant%`, these placeholders ended up in the symlink path verbatim (unlike in `FilesystemTenancyBootstrapper`, which replaces all three).

Now that the method doesn't check the `root_override` config at all, disks with a `url_override` set but no `root_override` (which until now, was invalid config due to the `root_override` dependency in `possibleTenantSymlinks()`) now _can_ get a tenant symlink (before, `tenants:link` used to skip them while the bootstrapper still overrode their URL, so `Storage::disk()->url()` returned a tenant URL pointing at a `public/` path that was never created, and every request for those files would throw a 404).

> `FilesystemTenancyBootstrapper::diskRoot()` is now *the only* place that resolves the `root_override` templates. Because the bootstrapper (which has to be enabled for the symlinks to work anyway) configures the tenant-aware disks (i.e. disks listed in `tenancy.filesystem.disks`) with the tenant-scoped root (placeholders already replaced), there's no need for `possibleTenantSymlinks()` to resolve the `root_override` templates itself -- it can just read the `filesystems.disks.*.root` config the bootstrapper modified.
>
> Note that though we got rid of the `root_override` template resolution in `possibleTenantSymlinks()`, we cannot do the same for `url_override`s. The bootstrapper resolves that template and then sets the disk's configured URL to `url($override)`, and `possibleTenantSymlinks()` cannot re-use that -- instead of `url($override)`, the symlinks need `public_path($override)`.

**Symlinks now also work with prefixed disks**. For example, if a disk has a prefix like 'abc/def' (i.e. `config('filesystems.disks.foo.prefix')` set to 'abc/def') and it has a 'foo-%tenant%'  `url_override`, `Storage::disk('foo')->url('some-file.txt')` returns a URL like app.test/foo-$tenantId/**abc/def**/some-file.txt. The URL includes the prefix, so the symlink path has to include it too: running `php artisan tenants:link` creates a symlink at `public/foo-$tenantId/abc/def`, pointing to the prefixed directory inside the tenant's disk root -- e.g. `storage/tenant<$tenantId>/foo/abc/def` (before, the prefix got ignored -- the symlink got created at 'public/**foo-$tenantId**', and pointed to the disk's root, so the symlink exposed everything under the disk root, including files outside the prefix, which the disk itself cannot read). The 'abc' subdirectory gets created automatically before the symlink. On `tenants:link --remove`, the symlink gets removed, and if `RemoveStorageSymlinksAction::$removeNestedDirectories` is set to `true` (it's set to `false` by default), the subdirectories in which the symlink is nested are deleted as well. The subdirectories are deleted upward from the symlink -- the deletion stops when a non-empty directory or the directory-to-be-deleted is not under `public_path()` anymore.

> Note that in `possibleTenantSymlinks()`, we trim the prefix (from both sides), so an 'abc/def/' prefix behaves the same as 'abc/def'.  Still, using a leading separator in a prefix is buggy in Laravel -- see https://github.com/thephpleague/flysystem/issues/1656.

### Misc changes

The check that stops `DeleteTenantStorage` from deleting the central storage directory now compares the two paths using `realpath()`. Without it, a trailing separator on one of the paths and not the other would make the comparison evaluate to `false` and the job would delete the central directory. Nearly impossible in practice, but cheap to prevent.

Scoped disks are now handled more consistently by the bootstrapper:
- `forgetDisks()` now forgets each nested `scoped` disk (along with its base disk).
- the same method now also throws an exception if a `scoped` disk is listed in `tenancy.filesystem.disks` without its parent (non-scoped) disk, or if the `scoped` disk has an inline parent
- `diskRoot()` now has an explicit `driver === 'scoped'` check -- if it passes, the method returns early, since there's no reason to configure the root of scoped disks (these will use the root of their base disk anyway). This means that including a `scoped` disk in `tenancy.filesystem.disks` is functionally a no-op as long as its parent is included there too (if the parent's not included there, an exception will be thrown by `forgetDisks()` as mentioned above).

This PR also updates the comments in the filesystem section of the config. For example, the comment above `root_override` now lists all three placeholders it supports, and the outdated v3 docs links now point to v4 docs.

### Minor breaking changes

- With `FilesystemTenancyBootstrapper` disabled, `TenantAssetController` now returns a `404` instead of serving central assets for every tenant.
- In setups where `suffix_storage_path` is disabled, or where `root_override` uses placeholders other than `%storage_path%`, the symlinks now point elsewhere. These symlinks will need to be recreated (`php artisan tenants:link --force`).
- `php artisan tenants:link` now throws for disks in `url_override` that aren't listed in `tenancy.filesystem.disks`. That includes `tenants:link --remove`, so such disks need to be added to the config before their existing symlinks can be removed.
- `tenants:link` now takes a disk's `prefix` into account. `tenants:link --remove` won't find and remove symlinks created for a disk with a prefix before this PR's changes -- the symlinks have to be deleted manually.
- `FilesystemTenancyBootstrapper` now throws when a `scoped` disk is listed in `tenancy.filesystem.disks` without its parent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Serve tenant assets from configurable local filesystem disks.
- Support prefixed and scoped disks for tenant assets and storage symlinks.
- Clean up empty directories created for removed symlinks.
- Resolve tenant storage and log paths consistently across tenancy contexts.

## Bug Fixes
- Improve tenant storage cleanup while protecting central storage.
- Strengthen asset path security and disk validation.
- Handle empty URL overrides safely.
- Prevent circular scoped-disk configurations from causing hangs.

## Documentation
- Clarify disk root overrides and storage suffix behavior.

## Tests
- Expand coverage for custom disks, symlinks, asset security, scoped disks, and tenant cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->